### PR TITLE
Use TA-lib for MACD and StochRSI

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ if not feel free to raise a github issue.
 ##### Prerequisites
 * python3.6
 * sqlite
+* [TA-lib](https://github.com/mrjbq7/ta-lib#dependencies) binaries
 
 ##### Install
 ```

--- a/analyze.py
+++ b/analyze.py
@@ -4,7 +4,8 @@ import logging
 import arrow
 import requests
 from pandas.io.json import json_normalize
-from stockstats import StockDataFrame
+from pandas import DataFrame
+# from stockstats import StockDataFrame
 import talib.abstract as ta
 
 logging.basicConfig(level=logging.DEBUG,
@@ -12,11 +13,11 @@ logging.basicConfig(level=logging.DEBUG,
 logger = logging.getLogger(__name__)
 
 
-def get_ticker_dataframe(pair: str) -> StockDataFrame:
+def get_ticker_dataframe(pair: str) -> DataFrame:
     """
     Analyses the trend for the given pair
     :param pair: pair as str in format BTC_ETH or BTC-ETH
-    :return: StockDataFrame
+    :return: DataFrame
     """
     minimum_date = arrow.now() - timedelta(hours=6)
     url = 'https://bittrex.com/Api/v2.0/pub/market/GetTicks'
@@ -40,20 +41,25 @@ def get_ticker_dataframe(pair: str) -> StockDataFrame:
         'low': t['L'],
         'date': t['T'],
     } for t in sorted(data['result'], key=lambda k: k['T']) if arrow.get(t['T']) > minimum_date]
-    dataframe = StockDataFrame(json_normalize(data))
+    dataframe = DataFrame(json_normalize(data))
 
     # calculate StochRSI
     stochrsi = ta.STOCHRSI(dataframe)
     dataframe['stochrsi'] = stochrsi['fastd'] # values between 0-100, not 0-1
 
+    macd = ta.MACD(dataframe)
+    dataframe['macd'] = macd['macd']
+    dataframe['macds'] = macd['macdsignal']
+    dataframe['macdh'] = macd['macdhist']
+
     return dataframe
 
 
-def populate_trends(dataframe: StockDataFrame) -> StockDataFrame:
+def populate_trends(dataframe: DataFrame) -> DataFrame:
     """
     Populates the trends for the given dataframe
-    :param dataframe: StockDataFrame
-    :return: StockDataFrame with populated trends
+    :param dataframe: DataFrame
+    :return: DataFrame with populated trends
     """
     """
     dataframe.loc[
@@ -91,10 +97,10 @@ def get_buy_signal(pair: str) -> bool:
     return signal
 
 
-def plot_dataframe(dataframe: StockDataFrame, pair: str) -> None:
+def plot_dataframe(dataframe: DataFrame, pair: str) -> None:
     """
     Plots the given dataframe
-    :param dataframe: StockDataFrame
+    :param dataframe: DataFrame
     :param pair: pair as str
     :return: None
     """
@@ -108,8 +114,8 @@ def plot_dataframe(dataframe: StockDataFrame, pair: str) -> None:
     fig, (ax1, ax2, ax3) = plt.subplots(3, sharex=True)
     fig.suptitle(pair, fontsize=14, fontweight='bold')
     ax1.plot(dataframe.index.values, dataframe['close'], label='close')
-    ax1.plot(dataframe.index.values, dataframe['close_30_ema'], label='EMA(60)')
-    ax1.plot(dataframe.index.values, dataframe['close_90_ema'], label='EMA(120)')
+    # ax1.plot(dataframe.index.values, dataframe['close_30_ema'], label='EMA(60)')
+    # ax1.plot(dataframe.index.values, dataframe['close_90_ema'], label='EMA(120)')
     # ax1.plot(dataframe.index.values, dataframe['sell'], 'ro', label='sell')
     ax1.plot(dataframe.index.values, dataframe['buy'], 'bo', label='buy')
     ax1.legend()

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,5 @@ matplotlib==2.0.2
 PYQT5==5.9
 scikit-learn==0.19.0
 scipy==0.19.1
-stockstats==0.2.0
 jsonschema==2.6.0
 TA-Lib==0.4.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ scikit-learn==0.19.0
 scipy==0.19.1
 stockstats==0.2.0
 jsonschema==2.6.0
+TA-Lib==0.4.10


### PR DESCRIPTION
Now we use TA-lib for calculating MACD and StochRSI. This PR removes the manual calculation of StochRSI and the whole `stockstats` library.

Commit c2d7854 (that adds the TA-lib to requirements.txt) is the same that is also in PR #7 .



