### PR TITLE
Restore EMA plots

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -43,6 +43,9 @@ def get_ticker_dataframe(pair: str) -> DataFrame:
     } for t in sorted(data['result'], key=lambda k: k['T']) if arrow.get(t['T']) > minimum_date]
     dataframe = DataFrame(json_normalize(data))
 
+    dataframe['close_30_ema'] = ta.EMA(dataframe, timeperiod=30)
+    dataframe['close_90_ema'] = ta.EMA(dataframe, timeperiod=90)
+
     # calculate StochRSI
     stochrsi = ta.STOCHRSI(dataframe)
     dataframe['stochrsi'] = stochrsi['fastd'] # values between 0-100, not 0-1
@@ -114,8 +117,8 @@ def plot_dataframe(dataframe: DataFrame, pair: str) -> None:
     fig, (ax1, ax2, ax3) = plt.subplots(3, sharex=True)
     fig.suptitle(pair, fontsize=14, fontweight='bold')
     ax1.plot(dataframe.index.values, dataframe['close'], label='close')
-    # ax1.plot(dataframe.index.values, dataframe['close_30_ema'], label='EMA(60)')
-    # ax1.plot(dataframe.index.values, dataframe['close_90_ema'], label='EMA(120)')
+    ax1.plot(dataframe.index.values, dataframe['close_30_ema'], label='EMA(30)')
+    ax1.plot(dataframe.index.values, dataframe['close_90_ema'], label='EMA(90)')
     # ax1.plot(dataframe.index.values, dataframe['sell'], 'ro', label='sell')
     ax1.plot(dataframe.index.values, dataframe['buy'], 'bo', label='buy')
     ax1.legend()


### PR DESCRIPTION
When moving to TA-lib, I disabled the EMA plots that were calculated automatically by `stockstats`. This PR restores those plots using TA-libs EMA indicators.