### PR TITLE
Set balance for bid price between ask and last

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ profit dips below -10% for a given trade. This parameter is optional.
 Possible values are `running` or `stopped`. (default=`running`)
 If the value is `stopped` the bot has to be started with `/start` first.
 
+`ask_last_balance` sets the bidding price. Value `0.0` will use `ask` price, `1.0` will
+use the `last` price and values between those interpolate between ask and last price.
+
 The other values should be self-explanatory,
 if not feel free to raise a github issue.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Possible values are `running` or `stopped`. (default=`running`)
 If the value is `stopped` the bot has to be started with `/start` first.
 
 `ask_last_balance` sets the bidding price. Value `0.0` will use `ask` price, `1.0` will
-use the `last` price and values between those interpolate between ask and last price.
+use the `last` price and values between those interpolate between ask and last price. Using `ask` price will guarantee quick success in bid, but bot will also end up paying more then would probably have been necessary.
 
 The other values should be self-explanatory,
 if not feel free to raise a github issue.

--- a/config.json.example
+++ b/config.json.example
@@ -9,6 +9,9 @@
         "0":  0.02
     },
     "stoploss": -0.10,
+    "bid_strategy": {
+        "ask_last_balance": 0.0
+    },
     "bittrex": {
         "enabled": true,
         "key": "key",

--- a/main.py
+++ b/main.py
@@ -138,6 +138,13 @@ def handle_trade(trade: Trade) -> None:
     except ValueError:
         logger.exception('Unable to handle open order')
 
+def get_target_bid(ticker) -> float:
+    """ Calculates bid target between current ask price and last price """
+    if ticker['ask'] < ticker['last']:
+        return ticker['ask']
+    balance = _CONF['bid_strategy']['ask_last_balance']
+    return ticker['ask'] + balance * (ticker['last'] - ticker['ask'])
+
 
 def create_trade(stake_amount: float, _exchange: exchange.Exchange) -> Optional[Trade]:
     """
@@ -174,7 +181,7 @@ def create_trade(stake_amount: float, _exchange: exchange.Exchange) -> Optional[
     else:
         return None
 
-    open_rate = exchange.get_ticker(pair)['ask']
+    open_rate = get_target_bid(exchange.get_ticker(pair))
     amount = stake_amount / open_rate
     order_id = exchange.buy(pair, open_rate, amount)
 

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import logging
 import time
 import traceback
 from datetime import datetime
-from typing import Optional
+from typing import Dict, Optional
 
 from jsonschema import validate
 
@@ -138,7 +138,7 @@ def handle_trade(trade: Trade) -> None:
     except ValueError:
         logger.exception('Unable to handle open order')
 
-def get_target_bid(ticker) -> float:
+def get_target_bid(ticker: Dict[str, float]) -> float:
     """ Calculates bid target between current ask price and last price """
     if ticker['ask'] < ticker['last']:
         return ticker['ask']

--- a/misc.py
+++ b/misc.py
@@ -48,6 +48,18 @@ CONF_SCHEMA = {
             'minProperties': 1
         },
         'stoploss': {'type': 'number', 'maximum': 0, 'exclusiveMaximum': True},
+        'bid_strategy': {
+            'type': 'object',
+            'properties': {
+                'ask_last_balance': {
+                    'type': 'number',
+                    'minimum': 0,
+                    'maximum': 1,
+                    'exclusiveMaximum': False
+                },
+            },
+            'required': ['ask_last_balance']
+        },
         'bittrex': {'$ref': '#/definitions/exchange'},
         'telegram': {
             'type': 'object',
@@ -85,6 +97,7 @@ CONF_SCHEMA = {
         'stake_amount',
         'dry_run',
         'minimal_roi',
+        'bid_strategy',
         'telegram'
     ]
 }

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -28,6 +28,9 @@ class TestTelegram(unittest.TestCase):
             "720": 0.01,
             "0": 0.02
         },
+        "bid_strategy": {
+            "ask_last_balance": 0.0
+        },
         "bittrex": {
             "enabled": True,
             "key": "key",


### PR DESCRIPTION
`ask_last_balance` sets the bidding price. Value `0.0` will use `ask` price, `1.0` will
use the `last` price and values between those interpolate between ask and last price. Using `ask` price will guarantee quick success in bid, but bot will also end up paying more then would probably have been necessary.
