### PR TITLE
set is_open on sell order

### DIFF
--- a/persistence.py
+++ b/persistence.py
@@ -83,6 +83,7 @@ class Trade(Base):
         self.close_profit = profit
         self.close_date = datetime.utcnow()
         self.open_order_id = order_id
+        self.is_open = False
 
         # Flush changes
         Trade.session.flush()

--- a/test/test_persistence.py
+++ b/test/test_persistence.py
@@ -22,6 +22,7 @@ class TestTrade(unittest.TestCase):
             self.assertEqual(trade.close_rate, 1.0)
             self.assertEqual(trade.close_profit, profit)
             self.assertIsNotNone(trade.close_date)
+            self.assertFalse(trade.is_open)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`is_open` flag was not being set to false on sale. Running `/status` after a sale was returning previously sold trades which gives the impression they are still active 