### PR TITLE
Better buy strategy and sell criteria

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -3,13 +3,14 @@
     "stake_currency": "BTC",
     "stake_amount": 0.05,
     "dry_run": false,
-    "minimal_roi": {
-        "2880": 0.005,
-        "720":  0.01,
-        "0":  0.02
-    },
-    "stoploss": -0.10,
-    "bid_strategy": {
+        "minimal_roi": {
+            "60":  0.0,
+            "40":  0.01,
+            "20":  0.02,
+            "0":  0.03
+        },
+        "stoploss": -0.40,
+        "bid_strategy": {
         "ask_last_balance": 0.0
     },
     "bittrex": {

--- a/test/test_backtesting.py
+++ b/test/test_backtesting.py
@@ -22,11 +22,12 @@ class TestMain(unittest.TestCase):
     pairs = ['btc-neo', 'btc-eth', 'btc-omg', 'btc-edg', 'btc-pay', 'btc-pivx', 'btc-qtum', 'btc-mtl', 'btc-etc', 'btc-ltc']
     conf = {
         "minimal_roi": {
-            "2880": 0.005,
-            "720":  0.01,
-            "0":  0.02
+            "60":  0.0,
+            "40":  0.01,
+            "20":  0.02,
+            "0":  0.03
         },
-        "stoploss": -0.10
+        "stoploss": -0.40
     }
 
     @classmethod


### PR DESCRIPTION
This PR introduces both a new buy algorithm, and adjusts the ROI settings.

Running a months worth of data for 10 coins in backtesting, the old algo with old ROI settings gave:

`Made 454 buys. Average profit -0.76%. Total profit was -3.428. Average duration 1349.6 mins.`

With the new buy algorithm we get:

`Made 839 buys. Average profit 0.51%. Total profit was 4.300. Average duration 599.0 mins.`

When we adjust the ROI settings with the old algorithm, we got:

`Made 468 buys. Average profit 0.78%. Total profit was 3.633. Average duration 361.6 mins.`

and with both the new algorithm and new ROI settings, we get:

`Made 847 buys. Average profit 1.41%. Total profit was 11.946. Average duration 161.7 mins.`

So in purely simulated environment, this PR changes our revenue from `-3x` losses to `11x` profits while dropping the average trade time to 1/8th.


