### PR TITLE
patch missing calls

### DIFF
--- a/freqtrade/exchange.py
+++ b/freqtrade/exchange.py
@@ -39,11 +39,20 @@ def init(config: dict) -> None:
         raise RuntimeError('No exchange specified. Aborting!')
 
     # Check if all pairs are available
+    validate_pairs(config[EXCHANGE.name.lower()]['pair_whitelist'])
+
+
+def validate_pairs(pairs: List[str]) -> None:
+    """
+    Checks if all given pairs are tradable on the current exchange.
+    Raises RuntimeError if one pair is not available.
+    :param pairs: list of pairs
+    :return: None
+    """
     markets = get_markets()
-    exchange_name = EXCHANGE.name.lower()
-    for pair in config[exchange_name]['pair_whitelist']:
+    for pair in pairs:
         if pair not in markets:
-            raise RuntimeError('Pair {} is not available at {}'.format(pair, exchange_name))
+            raise RuntimeError('Pair {} is not available at {}'.format(pair, EXCHANGE.name.lower()))
 
 
 def buy(pair: str, rate: float, amount: float) -> str:

--- a/freqtrade/tests/test_main.py
+++ b/freqtrade/tests/test_main.py
@@ -6,6 +6,7 @@ import pytest
 from jsonschema import validate
 
 from freqtrade import exchange
+from freqtrade.exchange import validate_pairs
 from freqtrade.main import create_trade, handle_trade, close_trade_if_fulfilled, init, \
     get_target_bid
 from freqtrade.misc import CONF_SCHEMA
@@ -52,6 +53,7 @@ def test_create_trade(conf, mocker):
     buy_signal = mocker.patch('freqtrade.main.get_buy_signal', side_effect=lambda _: True)
     mocker.patch.multiple('freqtrade.main.telegram', init=MagicMock(), send_msg=MagicMock())
     mocker.patch.multiple('freqtrade.main.exchange',
+                          validate_pairs=MagicMock(),
                           get_ticker=MagicMock(return_value={
                               'bid': 0.07256061,
                               'ask': 0.072661,
@@ -84,6 +86,7 @@ def test_handle_trade(conf, mocker):
     mocker.patch.dict('freqtrade.main._CONF', conf)
     mocker.patch.multiple('freqtrade.main.telegram', init=MagicMock(), send_msg=MagicMock())
     mocker.patch.multiple('freqtrade.main.exchange',
+                          validate_pairs=MagicMock(),
                           get_ticker=MagicMock(return_value={
                               'bid': 0.17256061,
                               'ask': 0.172661,

--- a/freqtrade/tests/test_telegram.py
+++ b/freqtrade/tests/test_telegram.py
@@ -63,6 +63,7 @@ def test_status_handle(conf, update, mocker):
     msg_mock = MagicMock()
     mocker.patch.multiple('freqtrade.main.telegram', _CONF=conf, init=MagicMock(), send_msg=msg_mock)
     mocker.patch.multiple('freqtrade.main.exchange',
+                          validate_pairs=MagicMock(),
                           get_ticker=MagicMock(return_value={
                               'bid': 0.07256061,
                               'ask': 0.072661,
@@ -87,6 +88,7 @@ def test_profit_handle(conf, update, mocker):
     msg_mock = MagicMock()
     mocker.patch.multiple('freqtrade.main.telegram', _CONF=conf, init=MagicMock(), send_msg=msg_mock)
     mocker.patch.multiple('freqtrade.main.exchange',
+                          validate_pairs=MagicMock(),
                           get_ticker=MagicMock(return_value={
                               'bid': 0.07256061,
                               'ask': 0.072661,
@@ -116,6 +118,7 @@ def test_forcesell_handle(conf, update, mocker):
     msg_mock = MagicMock()
     mocker.patch.multiple('freqtrade.main.telegram', _CONF=conf, init=MagicMock(), send_msg=msg_mock)
     mocker.patch.multiple('freqtrade.main.exchange',
+                          validate_pairs=MagicMock(),
                           get_ticker=MagicMock(return_value={
                               'bid': 0.07256061,
                               'ask': 0.072661,
@@ -143,6 +146,7 @@ def test_performance_handle(conf, update, mocker):
     msg_mock = MagicMock()
     mocker.patch.multiple('freqtrade.main.telegram', _CONF=conf, init=MagicMock(), send_msg=msg_mock)
     mocker.patch.multiple('freqtrade.main.exchange',
+                          validate_pairs=MagicMock(),
                           get_ticker=MagicMock(return_value={
                               'bid': 0.07256061,
                               'ask': 0.072661,
@@ -171,6 +175,7 @@ def test_start_handle(conf, update, mocker):
     mocker.patch.dict('freqtrade.main._CONF', conf)
     msg_mock = MagicMock()
     mocker.patch.multiple('freqtrade.main.telegram', _CONF=conf, init=MagicMock(), send_msg=msg_mock)
+    mocker.patch.multiple('freqtrade.main.exchange', _CONF=conf, init=MagicMock())
     init(conf, 'sqlite://')
 
     update_state(State.STOPPED)
@@ -183,6 +188,7 @@ def test_stop_handle(conf, update, mocker):
     mocker.patch.dict('freqtrade.main._CONF', conf)
     msg_mock = MagicMock()
     mocker.patch.multiple('freqtrade.main.telegram', _CONF=conf, init=MagicMock(), send_msg=msg_mock)
+    mocker.patch.multiple('freqtrade.main.exchange', _CONF=conf, init=MagicMock())
     init(conf, 'sqlite://')
 
     update_state(State.RUNNING)


### PR DESCRIPTION
`get_markets()` was still unpatched in some tests, with this PR tests should no longer depend on successful api calls