### PR TITLE
More efficient and flexible Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.gitignore
+Dockerfile
+.dockerignore
+config.json*
+*.sqlite

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,23 @@
-FROM    python:3.6.2
-
-RUN apt-get update
-RUN apt-get -y install build-essential
+FROM python:3.6.2
 
 # Install TA-lib
-RUN  wget http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz
-RUN tar zxvf ta-lib-0.4.0-src.tar.gz
-RUN cd ta-lib && ./configure && make && make install
+RUN apt-get update && apt-get -y install build-essential && apt-get clean
+RUN curl -L http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz | \
+  tar xzvf - && \
+  cd ta-lib && \
+  ./configure && make && make install && \
+  cd .. && rm -rf ta-lib
 ENV LD_LIBRARY_PATH /usr/local/lib
 
 # Prepare environment
 RUN mkdir /freqtrade
-COPY . /freqtrade/
 WORKDIR /freqtrade
 
-# Install dependencies and execute
+# Install dependencies
+COPY requirements.txt /freqtrade/
 RUN pip install -r requirements.txt
+
+# Install and execute
+COPY . /freqtrade/
 RUN pip install -e .
 CMD ["freqtrade"]

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ $ docker run -d \
   -v ~/.freq/tradesv2.sqlite:/freqtrade/tradesv2.sqlite \
   freqtrade
 ```
+If you are using `dry_run=True` you need to bind `tradesv2.dry_run.sqlite` instead of `tradesv2.sqlite`.
 
 You can then use the following commands to monitor and manage your container:
 
@@ -133,7 +134,7 @@ $ docker stop freqtrade
 $ docker start freqtrade
 ```
 
-With the above setup you do not need to rebuild the image for configuration
+You do not need to rebuild the image for configuration
 changes, it will suffice to edit `config.json` and restart the container.
 
 #### Contributing

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See the example below:
 },
 ```
 
-`stoploss` is loss in percentage that should trigger a sale. 
+`stoploss` is loss in percentage that should trigger a sale.
 For example value `-0.10` will cause immediate sell if the
 profit dips below -10% for a given trade. This parameter is optional.
 
@@ -47,7 +47,9 @@ Possible values are `running` or `stopped`. (default=`running`)
 If the value is `stopped` the bot has to be started with `/start` first.
 
 `ask_last_balance` sets the bidding price. Value `0.0` will use `ask` price, `1.0` will
-use the `last` price and values between those interpolate between ask and last price. Using `ask` price will guarantee quick success in bid, but bot will also end up paying more then would probably have been necessary.
+use the `last` price and values between those interpolate between ask and last
+price. Using `ask` price will guarantee quick success in bid, but bot will also
+end up paying more then would probably have been necessary.
 
 The other values should be self-explanatory,
 if not feel free to raise a github issue.
@@ -88,11 +90,51 @@ $ BACKTEST=true pytest -s freqtrade/tests/test_backtesting.py
 ```
 
 #### Docker
+
+Building the image:
+
 ```
 $ cd freqtrade
 $ docker build -t freqtrade .
-$ docker run --rm -it freqtrade
 ```
+
+For security reasons, your configuration file will not be included in the
+image, you will need to bind mount it. It is also advised to bind mount
+a SQLite database file (see second example) to keep it between updates.
+
+You can run a one-off container that is immediately deleted upon exiting with
+the following command (config.json must be in the current working directory):
+
+```
+$ docker run --rm -v `pwd`/config.json:/freqtrade/config.json -it freqtrade
+```
+
+To run a restartable instance in the background (feel free to place your
+configuration and database files wherever it feels comfortable on your
+filesystem):
+
+```
+$ cd ~/.freq
+$ touch tradesv2.sqlite
+$ docker run -d \
+  --name freqtrade \
+  -v ~/.freq/config.json:/freqtrade/config.json \
+  -v ~/.freq/tradesv2.sqlite:/freqtrade/tradesv2.sqlite \
+  freqtrade
+```
+
+You can then use the following commands to monitor and manage your container:
+
+```
+$ docker logs freqtrade
+$ docker logs -f freqtrade
+$ docker restart freqtrade
+$ docker stop freqtrade
+$ docker start freqtrade
+```
+
+With the above setup you do not need to rebuild the image for configuration
+changes, it will suffice to edit `config.json` and restart the container.
 
 #### Contributing
 


### PR DESCRIPTION
I have reorganized the `Dockerfile` and added a `.dockerignore` file so that:

- Changes in the code that do not touch `requirements.txt` will not cause the build process to reinstall dependencies, only the last two layers are redone. Such builds only take a couple of seconds now.
- Building excludes unnecessary artifacts such as the ta-lib source code, build folders and tarball, as well as the .git tree of the app, so images are smaller.
- The image specifically omits `config.json`, promoting the user to bind mount it. This means that images are distributable, they can be checked in to a registry (as they don't contain credentials) and containers are more easily reconfigurable.

I documented the last part in the README file, also explaining to users how to bind mount the database file as well. That enables them to keep the state between updates, which works well as long as the schema does not change.