### PR TITLE
Help command to Telegram bot

### DIFF
--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -45,6 +45,7 @@ def init(config: dict) -> None:
         CommandHandler('stop', _stop),
         CommandHandler('forcesell', _forcesell),
         CommandHandler('performance', _performance),
+        CommandHandler('help', _help),
     ]
     for handle in handles:
         _updater.dispatcher.add_handler(handle)
@@ -299,6 +300,27 @@ def _performance(bot: Bot, update: Update) -> None:
     message = '<b>Performance:</b>\n{}\n'.format(stats)
     logger.debug(message)
     send_msg(message, parse_mode=ParseMode.HTML)
+
+
+@authorized_only
+def _help(bot: Bot, update: Update) -> None:
+    """
+    Handler for /help.
+    Show commands of the bot
+    :param bot: telegram bot
+    :param update: message update
+    :return: None
+    """
+    message = """
+*/start:* `Starts the trader`
+*/stop:* `Stops the trader`
+*/status:* `Lists all open trades`
+*/profit:* `Lists cumulative profit from all finished trades`
+*/forcesell <trade_id>:* `Instantly sells the given trade, regardless of profit`
+*/performance:* `Show performance of each finished trade grouped by pair`
+*/help:* `This help message`
+    """
+    send_msg(message, bot=bot)
 
 
 def send_msg(msg: str, bot: Bot = None, parse_mode: ParseMode = ParseMode.MARKDOWN) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -e git+https://github.com/ericsomdahl/python-bittrex.git@d7033d0#egg=python-bittrex
 SQLAlchemy==1.1.14
-python-telegram-bot==8.0
+python-telegram-bot==8.1.1
 arrow==0.10.0
 requests==2.18.4
 urllib3==1.22

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name='freqtrade',
       install_requires=[
           'python-bittrex==0.1.3',
           'SQLAlchemy==1.1.13',
-          'python-telegram-bot==8.0',
+          'python-telegram-bot==8.1.1',
           'arrow==0.10.0',
           'requests==2.18.4',
           'urllib3==1.22',


### PR DESCRIPTION
Adds a `/help` command that lists all available commands.

Fixes #48 .