### PR TITLE
Better hyperopt objective

### DIFF
--- a/freqtrade/tests/test_backtesting.py
+++ b/freqtrade/tests/test_backtesting.py
@@ -13,17 +13,17 @@ from freqtrade.persistence import Trade
 
 logging.disable(logging.DEBUG) # disable debug logs that slow backtesting a lot
 
-def print_results(results):
-    print('Made {} buys. Average profit {:.2f}%. Total profit was {:.3f}. Average duration {:.1f} mins.'.format(
+def format_results(results):
+    return 'Made {} buys. Average profit {:.2f}%. Total profit was {:.3f}. Average duration {:.1f} mins.'.format(
         len(results.index),
         results.profit.mean() * 100.0,
         results.profit.sum(),
         results.duration.mean() * 5
-    ))
+    )
 
 def print_pair_results(pair, results):
     print('For currency {}:'.format(pair))
-    print_results(results[results.currency == pair])
+    print(format_results(results[results.currency == pair]))
 
 @pytest.fixture
 def pairs():
@@ -77,4 +77,4 @@ def test_backtest(conf, pairs, mocker, report=True):
     print('====================== BACKTESTING REPORT ================================')
     [print_pair_results(pair, results) for pair in pairs]
     print('TOTAL OVER ALL TRADES:')
-    print_results(results)
+    print(format_results(results))

--- a/freqtrade/tests/test_hyperopt.py
+++ b/freqtrade/tests/test_hyperopt.py
@@ -1,21 +1,14 @@
 # pragma pylint: disable=missing-docstring
 from operator import itemgetter
-import json
 import logging
 import os
 from functools import reduce
 from math import exp
-
 import pytest
-import arrow
 from pandas import DataFrame
 from qtpylib.indicators import crossed_above
 
 from hyperopt import fmin, tpe, hp, Trials, STATUS_OK
-
-from freqtrade.analyze import analyze_ticker
-from freqtrade.main import should_sell
-from freqtrade.persistence import Trade
 
 from freqtrade.tests.test_backtesting import backtest, format_results
 
@@ -94,7 +87,7 @@ def test_hyperopt(conf, pairs, mocker):
 
         total_profit = results.profit.sum() * 1000
         trade_count = len(results.index)
-        
+
         trade_loss = 1 - 0.8 * exp(-(trade_count - TARGET_TRADES) ** 2 / 10 ** 5)
         profit_loss = exp(-total_profit**3 / 10**11)
 

--- a/freqtrade/tests/test_hyperopt.py
+++ b/freqtrade/tests/test_hyperopt.py
@@ -15,7 +15,7 @@ from freqtrade.analyze import analyze_ticker
 from freqtrade.main import should_sell
 from freqtrade.persistence import Trade
 
-from freqtrade.tests.test_backtesting import backtest, print_results
+from freqtrade.tests.test_backtesting import backtest, format_results
 
 logging.disable(logging.DEBUG) # disable debug logs that slow backtesting a lot
 
@@ -83,9 +83,10 @@ def test_hyperopt(conf, pairs, mocker):
         mocker.patch('freqtrade.analyze.populate_buy_trend', side_effect=buy_strategy)
         results = backtest(conf, pairs, mocker)
 
-        print_results(results)
-
-        # set the value below to suit your number concurrent trades so its realistic to 20days of data
+        result = format_results(results)
+        print(result)
+        
+        # set TARGET_TRADES to suit your number concurrent trades so its realistic to 20days of data
         TARGET_TRADES = 1200
         if results.profit.sum() == 0 or results.profit.mean() == 0:
             return 49999999999 # avoid division by zero, return huge value to discard result


### PR DESCRIPTION
This PR does two things (sorry about mixing two changes to one commit):
- switches to a lot better objective function for HyperOpt
- includes the trading results in HyperOpt summary

The objective function works like this:
![visu3](https://user-images.githubusercontent.com/557751/32134468-a63a5240-bbf6-11e7-8db5-366241ad6fd4.jpg)

where `p` is total profit and `t` is trade count. And the darker the red, the more Hyperopt will prefer the result.

Summary of running HyperOpt after this PR looks like this now:

```
====================== HYPEROPT BACKTESTING REPORT ================================
Best parameters {'adx': 1, 'adx-value': 15.160153353316526, 'below_sma': 0, 'cci': 1, 'cci-value': -188.55517165634524, 'fastd': 0, 'mfi': 0, 'over_sar': 0, 'over_sma': 0, 'trigger': 0, 'uptrend_sma': 0}
Result: Made 1292 buys. Average profit 0.39%. Total profit was 4.977. Average duration 88.2 mins.
```
