### PR TITLE
Telegram/show balance

### DIFF
--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -84,6 +84,8 @@ def get_balance(currency: str) -> float:
 
     return EXCHANGE.get_balance(currency)
 
+def get_balances():
+    return EXCHANGE.get_balances()
 
 def get_ticker(pair: str) -> dict:
     return EXCHANGE.get_ticker(pair)

--- a/freqtrade/exchange/bittrex.py
+++ b/freqtrade/exchange/bittrex.py
@@ -54,6 +54,12 @@ class Bittrex(Exchange):
             raise RuntimeError('{}: {}'.format(self.name.upper(), data['message']))
         return float(data['result']['Balance'] or 0.0)
 
+    def get_balances(self):
+        data = _API.get_balances()
+        if not data['success']:
+            raise RuntimeError('{}: {}'.format(self.name.upper(), data['message']))
+        return data['result']
+    
     def get_ticker(self, pair: str) -> dict:
         data = _API.get_ticker(pair.replace('_', '-'))
         if not data['success']:

--- a/freqtrade/exchange/interface.py
+++ b/freqtrade/exchange/interface.py
@@ -50,6 +50,21 @@ class Exchange(ABC):
         """
 
     @abstractmethod
+    def get_balances(self) -> List[dict]:
+        """
+        Gets account balances across currencies
+        :return: List of dicts, format: [
+          {
+            'Currency': str,
+            'Balance': float,
+            'Available': float,
+            'Pending': float,
+          }
+          ...
+        ]
+        """
+
+    @abstractmethod
     def get_ticker(self, pair: str) -> dict:
         """
         Gets ticker for given pair.

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -41,6 +41,7 @@ def init(config: dict) -> None:
     handles = [
         CommandHandler('status', _status),
         CommandHandler('profit', _profit),
+        CommandHandler('balance', _balance),
         CommandHandler('start', _start),
         CommandHandler('stop', _stop),
         CommandHandler('forcesell', _forcesell),
@@ -201,6 +202,26 @@ def _profit(bot: Bot, update: Update) -> None:
     )
     send_msg(markdown_msg, bot=bot)
 
+@authorized_only
+def _balance(bot: Bot, update: Update) -> None:
+    """
+    Hander for /balance
+    Returns current account balance per crypto
+    """
+    filter = {'Currency', 'CryptoAddress'}
+    output = ""
+
+    balances = exchange.get_balances()
+
+    for c in balances:
+        # output[c['Currency']] = {k: c[k] for k in c.keys() & {*set(c) - set(filter)}}
+        output += """*Currency*: {Currency}
+*Available*: {Available}
+*Balance*: {Balance}
+*Pending*: {Pending}
+
+""".format(**c)
+    send_msg(output)
 
 @authorized_only
 def _start(bot: Bot, update: Update) -> None:

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -208,19 +208,18 @@ def _balance(bot: Bot, update: Update) -> None:
     Hander for /balance
     Returns current account balance per crypto
     """
-    filter = {'Currency', 'CryptoAddress'}
     output = ""
 
     balances = exchange.get_balances()
 
-    for c in balances:
-        # output[c['Currency']] = {k: c[k] for k in c.keys() & {*set(c) - set(filter)}}
+    for currency in balances:
         output += """*Currency*: {Currency}
 *Available*: {Available}
 *Balance*: {Balance}
 *Pending*: {Pending}
 
-""".format(**c)
+""".format(**currency)
+
     send_msg(output)
 
 @authorized_only
@@ -347,6 +346,7 @@ def _help(bot: Bot, update: Update) -> None:
 */profit:* `Lists cumulative profit from all finished trades`
 */forcesell <trade_id>:* `Instantly sells the given trade, regardless of profit`
 */performance:* `Show performance of each finished trade grouped by pair`
+*/balance:* `Show account balance per currency`
 */help:* `This help message`
     """
     send_msg(message, bot=bot)


### PR DESCRIPTION
`/balance` now returns account balance per crypto in format of
```
Currency: BTC
Available: 1.0
Balance: 1.0
Pending: 0.0

Currency: NEO
Available: 1.5
Balance: 1.5
Pending: 0.0
```

Fixes #75 partly