### PR TITLE
Reduce memory use in backtesting

### DIFF
--- a/freqtrade/tests/test_backtesting.py
+++ b/freqtrade/tests/test_backtesting.py
@@ -44,13 +44,13 @@ def conf():
 
 def backtest(conf, pairs, mocker):
     trades = []
+    mocked_history = mocker.patch('freqtrade.analyze.get_ticker_history')
     mocker.patch.dict('freqtrade.main._CONF', conf)
     mocker.patch('arrow.utcnow', return_value=arrow.get('2017-08-20T14:50:00'))
     for pair in pairs:
         with open('freqtrade/tests/testdata/'+pair+'.json') as data_file:
             data = json.load(data_file)
-
-            mocker.patch('freqtrade.analyze.get_ticker_history', return_value=data)
+            mocked_history.return_value = data
             ticker = analyze_ticker(pair)[['close', 'date', 'buy']].copy()
             # for each buy point
             for row in ticker[ticker.buy == 1].itertuples(index=True):

--- a/freqtrade/tests/test_backtesting.py
+++ b/freqtrade/tests/test_backtesting.py
@@ -45,12 +45,12 @@ def conf():
 def backtest(conf, pairs, mocker):
     trades = []
     mocker.patch.dict('freqtrade.main._CONF', conf)
+    mocker.patch('arrow.utcnow', return_value=arrow.get('2017-08-20T14:50:00'))
     for pair in pairs:
         with open('freqtrade/tests/testdata/'+pair+'.json') as data_file:
             data = json.load(data_file)
 
             mocker.patch('freqtrade.analyze.get_ticker_history', return_value=data)
-            mocker.patch('arrow.utcnow', return_value=arrow.get('2017-08-20T14:50:00'))
             ticker = analyze_ticker(pair)[['close', 'date', 'buy']].copy()
             # for each buy point
             for row in ticker[ticker.buy == 1].itertuples(index=True):

--- a/freqtrade/tests/test_hyperopt.py
+++ b/freqtrade/tests/test_hyperopt.py
@@ -79,9 +79,10 @@ def buy_strategy_generator(params):
 
 @pytest.mark.skipif(not os.environ.get('BACKTEST', False), reason="BACKTEST not set")
 def test_hyperopt(conf, pairs, mocker):
+    mocked_buy_trend = mocker.patch('freqtrade.analyze.populate_buy_trend')
     def optimizer(params):
-        buy_strategy = buy_strategy_generator(params)
-        mocker.patch('freqtrade.analyze.populate_buy_trend', side_effect=buy_strategy)
+        mocked_buy_trend.side_effect = buy_strategy_generator(params)
+
         results = backtest(conf, pairs, mocker)
 
         result = format_results(results)


### PR DESCRIPTION
Change where we mock to reduce the memory consumption drastically from

```
dict          51266     +1717
MagicProxy    34188     +1554
```
to

```
dict              15917      +303
MagicProxy         1776      +222
```