### PR TITLE
Parallel build in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ os:
 language: python
 python:
 - 3.6
+env:
+  - BACKTEST=
+  - BACKTEST=true
 addons:
   apt:
     packages:

--- a/freqtrade/tests/test_hyperopt.py
+++ b/freqtrade/tests/test_hyperopt.py
@@ -147,7 +147,7 @@ def test_hyperopt(conf, pairs, mocker):
         ]),
     }
     trials = Trials()
-    best = fmin(fn=optimizer, space=space, algo=tpe.suggest, max_evals=40, trials=trials)
+    best = fmin(fn=optimizer, space=space, algo=tpe.suggest, max_evals=4, trials=trials)
     print('\n\n\n\n====================== HYPEROPT BACKTESTING REPORT ================================')
     print('Best parameters {}'.format(best))
     newlist = sorted(trials.results, key=itemgetter('loss'))


### PR DESCRIPTION
We've had too many PR's that break the backtesting because the developer does not remember to run those tests. This PR adds them so that Travis will run two parallel builds, one with only unit tests and the other with backtesting and hyperopt. For hyperopt I dropped the number of eval rounds to 4 so it mainly checks that it works.

This is how it looked when we had a broken the backtesting but unit tests worked fine.

![paralllel](https://user-images.githubusercontent.com/557751/32412857-f1515316-c20c-11e7-9229-08fc20b5a254.jpg)

