### PR TITLE
rework dry_run

### DIFF
--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -1,7 +1,7 @@
 import enum
 import logging
 from random import randint
-from typing import List, Dict
+from typing import List, Dict, Any
 
 import arrow
 
@@ -15,7 +15,7 @@ _API: Exchange = None
 _CONF: dict = {}
 
 # Holds all open sell orders for dry_run
-_DRY_RUN_OPEN_ORDERS: Dict[str, Dict] = {}
+_DRY_RUN_OPEN_ORDERS: Dict[str, Any] = {}
 
 
 class Exchanges(enum.Enum):

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -135,7 +135,7 @@ def cancel_order(order_id: str) -> None:
 
 def get_order(order_id: str) -> Dict:
     if _CONF['dry_run']:
-        order = _DRY_RUN_OPEN_ORDERS.pop(order_id)
+        order = _DRY_RUN_OPEN_ORDERS[order_id]
         order.update({
             'id': order_id
         })

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -201,12 +201,11 @@ def create_trade(stake_amount: float) -> Optional[Trade]:
     return Trade(pair=pair,
                  stake_amount=stake_amount,
                  amount=amount,
-                 fee=fee * 2,
+                 fee=fee*2,
                  open_rate=buy_limit,
                  open_date=datetime.utcnow(),
                  exchange=exchange.get_name().upper(),
-                 open_order_id=order_id,
-                 is_open=True)
+                 open_order_id=order_id)
 
 
 def init(config: dict, db_url: Optional[str] = None) -> None:

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -93,7 +93,7 @@ def execute_sell(trade: Trade, limit: float) -> None:
     trade.close_date = datetime.utcnow()
 
     fmt_exp_profit = round(trade.calc_profit(limit) * 100, 2)
-    message = '*{}:* Selling [{}]({}) with limit `{:f} (profit: ~{}%)`'.format(
+    message = '*{}:* Selling [{}]({}) with limit `{:.8f} (profit: ~{:.2f}%)`'.format(
         trade.exchange,
         trade.pair.replace('_', '/'),
         exchange.get_pair_detail_url(trade.pair),
@@ -189,7 +189,7 @@ def create_trade(stake_amount: float) -> Optional[Trade]:
 
     order_id = exchange.buy(pair, buy_limit, amount)
     # Create trade entity and return
-    message = '*{}:* Buying [{}]({}) with limit `{:f}`'.format(
+    message = '*{}:* Buying [{}]({}) with limit `{:.8f}`'.format(
         exchange.get_name().upper(),
         pair.replace('_', '/'),
         exchange.get_pair_detail_url(pair),

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -129,9 +129,9 @@ def _status(bot: Bot, update: Update) -> None:
 *Current Pair:* [{pair}]({market_url})
 *Open Since:* `{date}`
 *Amount:* `{amount}`
-*Open Rate:* `{open_rate}`
+*Open Rate:* `{open_rate:.8f}`
 *Close Rate:* `{close_rate}`
-*Current Rate:* `{current_rate}`
+*Current Rate:* `{current_rate:.8f}`
 *Close Profit:* `{close_profit}`
 *Current Profit:* `{current_profit:.2f}%`
 *Open Order:* `{open_order}`
@@ -194,7 +194,7 @@ def _profit(bot: Bot, update: Update) -> None:
 
     bp_pair, bp_rate = best_pair
     markdown_msg = """
-*ROI:* `{profit_btc:.6f} ({profit:.2f}%)`
+*ROI:* `{profit_btc:.8f} ({profit:.2f}%)`
 *Trade Count:* `{trade_count}`
 *First Trade opened:* `{first_trade_date}`
 *Latest Trade opened:* `{latest_trade_date}`

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -200,7 +200,6 @@ def _profit(bot: Bot, update: Update) -> None:
 *Latest Trade opened:* `{latest_trade_date}`
 *Avg. Duration:* `{avg_duration}`
 *Best Performing:* `{best_pair}: {best_rate:.2f}%`
-{dry_run_info}
     """.format(
         profit_btc=round(sum(profit_amounts), 8),
         profit=round(sum(profits) * 100, 2),
@@ -210,8 +209,6 @@ def _profit(bot: Bot, update: Update) -> None:
         avg_duration=str(timedelta(seconds=sum(durations) / float(len(durations)))).split('.')[0],
         best_pair=bp_pair,
         best_rate=round(bp_rate * 100, 2),
-        dry_run_info='\n*NOTE:* These values are mocked because *dry_run* is enabled!'
-        if _CONF['dry_run'] else ''
     )
     send_msg(markdown_msg, bot=bot)
 
@@ -328,11 +325,7 @@ def _performance(bot: Bot, update: Update) -> None:
         profit=round(rate * 100, 2)
     ) for i, (pair, rate) in enumerate(pair_rates))
 
-    message = '<b>Performance:</b>\n{}\n{}'.format(
-        stats,
-        '<b>NOTE:</b> These values are mocked because <b>dry_run</b> is enabled.'
-        if _CONF['dry_run'] else ''
-    )
+    message = '<b>Performance:</b>\n{}'.format(stats)
     logger.debug(message)
     send_msg(message, parse_mode=ParseMode.HTML)
 

--- a/freqtrade/tests/test_telegram.py
+++ b/freqtrade/tests/test_telegram.py
@@ -142,7 +142,7 @@ def test_profit_handle(conf, update, mocker):
 
     _profit(bot=MagicBot(), update=update)
     assert msg_mock.call_count == 2
-    assert '*ROI:* `1.507013 (10.05%)`' in msg_mock.call_args_list[-1][0][0]
+    assert '*ROI:* `1.50701325 (10.05%)`' in msg_mock.call_args_list[-1][0][0]
     assert 'Best Performing:* `BTC_ETH: 10.05%`' in msg_mock.call_args_list[-1][0][0]
 
 
@@ -175,7 +175,7 @@ def test_forcesell_handle(conf, update, mocker):
 
     assert msg_mock.call_count == 2
     assert 'Selling [BTC/ETH]' in msg_mock.call_args_list[-1][0][0]
-    assert '0.072561 (profit: ~-0.64%)' in msg_mock.call_args_list[-1][0][0]
+    assert '0.07256061 (profit: ~-0.64%)' in msg_mock.call_args_list[-1][0][0]
 
 
 def test_performance_handle(conf, update, mocker):


### PR DESCRIPTION
This PR re-enables real values for `/performance` and `/profit` in combination with `dry_run: true`.
It also fixes float precision rendering issues for some telegram commands.