### PR TITLE
Share pytest fixtures. Cache testfile loading.

### DIFF
--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+@pytest.fixture(scope="module")
+def pairs():
+    return ['btc-neo', 'btc-eth', 'btc-omg', 'btc-edg', 'btc-pay',
+            'btc-pivx', 'btc-qtum', 'btc-mtl', 'btc-etc', 'btc-ltc']
+
+@pytest.fixture(scope="module")
+def conf():
+    return {
+        "minimal_roi": {
+            "40":  0.0,
+            "30":  0.01,
+            "20":  0.02,
+            "0":  0.04
+        },
+        "stoploss": -0.05
+    }

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -1,9 +1,7 @@
+# pragma pylint: disable=missing-docstring
+import json
 import pytest
 
-@pytest.fixture(scope="module")
-def pairs():
-    return ['btc-neo', 'btc-eth', 'btc-omg', 'btc-edg', 'btc-pay',
-            'btc-pivx', 'btc-qtum', 'btc-mtl', 'btc-etc', 'btc-ltc']
 
 @pytest.fixture(scope="module")
 def conf():
@@ -16,3 +14,13 @@ def conf():
         },
         "stoploss": -0.05
     }
+
+
+@pytest.fixture(scope="module")
+def backdata():
+    result = {}
+    for pair in ['btc-neo', 'btc-eth', 'btc-omg', 'btc-edg', 'btc-pay',
+                 'btc-pivx', 'btc-qtum', 'btc-mtl', 'btc-etc', 'btc-ltc']:
+        with open('freqtrade/tests/testdata/' + pair + '.json') as data_file:
+            result[pair] = json.load(data_file)
+    return result

--- a/freqtrade/tests/test_backtesting.py
+++ b/freqtrade/tests/test_backtesting.py
@@ -26,42 +26,41 @@ def print_pair_results(pair, results):
     print(format_results(results[results.currency == pair]))
 
 
-def backtest(conf, pairs, mocker):
+def backtest(conf, backdata, mocker):
     trades = []
     exchange._API = Bittrex({'key': '', 'secret': ''})
     mocked_history = mocker.patch('freqtrade.analyze.get_ticker_history')
     mocker.patch.dict('freqtrade.main._CONF', conf)
     mocker.patch('arrow.utcnow', return_value=arrow.get('2017-08-20T14:50:00'))
-    for pair in pairs:
-        with open('freqtrade/tests/testdata/' + pair + '.json') as data_file:
-            mocked_history.return_value = json.load(data_file)
-            ticker = analyze_ticker(pair)[['close', 'date', 'buy']].copy()
-            # for each buy point
-            for row in ticker[ticker.buy == 1].itertuples(index=True):
-                trade = Trade(
-                    open_rate=row.close,
-                    open_date=row.date,
-                    amount=1,
-                    fee=exchange.get_fee() * 2
-                )
-                # calculate win/lose forwards from buy point
-                for row2 in ticker[row.Index:].itertuples(index=True):
-                    if should_sell(trade, row2.close, row2.date):
-                        current_profit = trade.calc_profit(row2.close)
+    for pair, pair_data in backdata.items():
+        mocked_history.return_value = pair_data
+        ticker = analyze_ticker(pair)[['close', 'date', 'buy']].copy()
+        # for each buy point
+        for row in ticker[ticker.buy == 1].itertuples(index=True):
+            trade = Trade(
+                open_rate=row.close,
+                open_date=row.date,
+                amount=1,
+                fee=exchange.get_fee() * 2
+            )
+            # calculate win/lose forwards from buy point
+            for row2 in ticker[row.Index:].itertuples(index=True):
+                if should_sell(trade, row2.close, row2.date):
+                    current_profit = trade.calc_profit(row2.close)
 
-                        trades.append((pair, current_profit, row2.Index - row.Index))
-                        break
+                    trades.append((pair, current_profit, row2.Index - row.Index))
+                    break
     labels = ['currency', 'profit', 'duration']
     results = DataFrame.from_records(trades, columns=labels)
     return results
 
 
 @pytest.mark.skipif(not os.environ.get('BACKTEST', False), reason="BACKTEST not set")
-def test_backtest(conf, pairs, mocker, report=True):
-    results = backtest(conf, pairs, mocker)
+def test_backtest(conf, backdata, mocker, report=True):
+    results = backtest(conf, backdata, mocker)
 
     print('====================== BACKTESTING REPORT ================================')
-    for pair in pairs:
+    for pair in backdata:
         print_pair_results(pair, results)
     print('TOTAL OVER ALL TRADES:')
     print(format_results(results))

--- a/freqtrade/tests/test_backtesting.py
+++ b/freqtrade/tests/test_backtesting.py
@@ -26,25 +26,6 @@ def print_pair_results(pair, results):
     print(format_results(results[results.currency == pair]))
 
 
-@pytest.fixture
-def pairs():
-    return ['btc-neo', 'btc-eth', 'btc-omg', 'btc-edg', 'btc-pay',
-            'btc-pivx', 'btc-qtum', 'btc-mtl', 'btc-etc', 'btc-ltc']
-
-
-@pytest.fixture
-def conf():
-    return {
-        "minimal_roi": {
-            "50": 0.0,
-            "40": 0.01,
-            "30": 0.02,
-            "0": 0.045
-        },
-        "stoploss": -0.40
-    }
-
-
 def backtest(conf, pairs, mocker):
     trades = []
     exchange._API = Bittrex({'key': '', 'secret': ''})

--- a/freqtrade/tests/test_hyperopt.py
+++ b/freqtrade/tests/test_hyperopt.py
@@ -18,25 +18,6 @@ logging.disable(logging.DEBUG)  # disable debug logs that slow backtesting a lot
 TARGET_TRADES = 1200
 
 
-@pytest.fixture
-def pairs():
-    return ['btc-neo', 'btc-eth', 'btc-omg', 'btc-edg', 'btc-pay',
-            'btc-pivx', 'btc-qtum', 'btc-mtl', 'btc-etc', 'btc-ltc']
-
-
-@pytest.fixture
-def conf():
-    return {
-        "minimal_roi": {
-            "40": 0.0,
-            "30": 0.01,
-            "20": 0.02,
-            "0": 0.04
-        },
-        "stoploss": -0.05
-    }
-
-
 def buy_strategy_generator(params):
     print(params)
 

--- a/freqtrade/tests/test_hyperopt.py
+++ b/freqtrade/tests/test_hyperopt.py
@@ -63,13 +63,13 @@ def buy_strategy_generator(params):
 
 
 @pytest.mark.skipif(not os.environ.get('BACKTEST', False), reason="BACKTEST not set")
-def test_hyperopt(conf, pairs, mocker):
+def test_hyperopt(conf, backdata, mocker):
     mocked_buy_trend = mocker.patch('freqtrade.analyze.populate_buy_trend')
 
     def optimizer(params):
         mocked_buy_trend.side_effect = buy_strategy_generator(params)
 
-        results = backtest(conf, pairs, mocker)
+        results = backtest(conf, backdata, mocker)
 
         result = format_results(results)
         print(result)
@@ -129,7 +129,7 @@ def test_hyperopt(conf, pairs, mocker):
     }
     trials = Trials()
     best = fmin(fn=optimizer, space=space, algo=tpe.suggest, max_evals=4, trials=trials)
-    print('\n\n\n\n====================== HYPEROPT BACKTESTING REPORT ================================')
+    print('\n\n\n\n==================== HYPEROPT BACKTESTING REPORT ==============================')
     print('Best parameters {}'.format(best))
     newlist = sorted(trials.results, key=itemgetter('loss'))
     print('Result: {}'.format(newlist[0]['result']))


### PR DESCRIPTION
Moved testdata file loading to a shared pytest fixture so so that they are loaded once and cached. Now hyperopt does not load the json's again and again for each eval.