### PR TITLE
Memory fix hyperopt

### DIFF
--- a/freqtrade/analyze.py
+++ b/freqtrade/analyze.py
@@ -66,14 +66,14 @@ def populate_buy_trend(dataframe: DataFrame) -> DataFrame:
     :param dataframe: DataFrame
     :return: DataFrame with buy column
     """
-    dataframe.ix[
+    dataframe.loc[
         (dataframe['close'] < dataframe['sma']) &
         (dataframe['tema'] <= dataframe['blower']) &
         (dataframe['mfi'] < 25) &
         (dataframe['fastd'] < 25) &
         (dataframe['adx'] > 30),
         'buy'] = 1
-    dataframe.ix[dataframe['buy'] == 1, 'buy_price'] = dataframe['close']
+    dataframe.loc[dataframe['buy'] == 1, 'buy_price'] = dataframe['close']
 
     return dataframe
 
@@ -83,10 +83,10 @@ def populate_sell_trend(dataframe: DataFrame) -> DataFrame:
     :param dataframe: DataFrame
     :return: DataFrame with buy column
     """
-    dataframe.ix[
+    dataframe.loc[
         (crossed_above(dataframe['rsi'], 70)),
         'sell'] = 1
-    dataframe.ix[dataframe['sell'] == 1, 'sell_price'] = dataframe['close']
+    dataframe.loc[dataframe['sell'] == 1, 'sell_price'] = dataframe['close']
 
     return dataframe
 

--- a/freqtrade/analyze.py
+++ b/freqtrade/analyze.py
@@ -73,7 +73,6 @@ def populate_buy_trend(dataframe: DataFrame) -> DataFrame:
         (dataframe['fastd'] < 25) &
         (dataframe['adx'] > 30),
         'buy'] = 1
-    dataframe.loc[dataframe['buy'] == 1, 'buy_price'] = dataframe['close']
 
     return dataframe
 
@@ -86,7 +85,6 @@ def populate_sell_trend(dataframe: DataFrame) -> DataFrame:
     dataframe.loc[
         (crossed_above(dataframe['rsi'], 70)),
         'sell'] = 1
-    dataframe.loc[dataframe['sell'] == 1, 'sell_price'] = dataframe['close']
 
     return dataframe
 
@@ -106,6 +104,9 @@ def analyze_ticker(pair: str) -> DataFrame:
     dataframe = populate_indicators(dataframe)
     dataframe = populate_buy_trend(dataframe)
     dataframe = populate_sell_trend(dataframe)
+    # TODO: buy_price and sell_price are only used by the plotter, should probably be moved there
+    dataframe.loc[dataframe['buy'] == 1, 'buy_price'] = dataframe['close']
+    dataframe.loc[dataframe['sell'] == 1, 'sell_price'] = dataframe['close']
     return dataframe
 
 

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -163,9 +163,9 @@ def min_roi_reached(trade: Trade, current_rate: float, current_time: datetime) -
         logger.debug('Stop loss hit.')
         return True
 
+    # Check if time matches and current rate is above threshold
+    time_diff = (current_time - trade.open_date).total_seconds() / 60
     for duration, threshold in sorted(_CONF['minimal_roi'].items()):
-        # Check if time matches and current rate is above threshold
-        time_diff = (current_time - trade.open_date).total_seconds() / 60
         if time_diff > float(duration) and current_profit > threshold:
             return True
 

--- a/freqtrade/tests/test_analyze.py
+++ b/freqtrade/tests/test_analyze.py
@@ -5,7 +5,7 @@ import pytest
 from pandas import DataFrame
 
 from freqtrade.analyze import parse_ticker_dataframe, populate_buy_trend, populate_indicators, \
-    get_signal, SignalType
+    get_signal, SignalType, populate_sell_trend
 
 
 @pytest.fixture
@@ -26,7 +26,11 @@ def test_dataframe_correct_length(result):
 def test_populates_buy_trend(result):
     dataframe = populate_buy_trend(populate_indicators(result))
     assert 'buy' in dataframe.columns
-    assert 'buy_price' in dataframe.columns
+
+
+def test_populates_buy_trend(result):
+    dataframe = populate_sell_trend(populate_indicators(result))
+    assert 'sell' in dataframe.columns
 
 
 def test_returns_latest_buy_signal(mocker):

--- a/freqtrade/tests/test_backtesting.py
+++ b/freqtrade/tests/test_backtesting.py
@@ -58,8 +58,7 @@ def backtest(backtest_conf, processed, mocker):
                     trades.append((pair, current_profit, row2.Index - row.Index))
                     break
     labels = ['currency', 'profit', 'duration']
-    results = DataFrame.from_records(trades, columns=labels)
-    return results
+    return DataFrame.from_records(trades, columns=labels)
 
 
 @pytest.mark.skipif(not os.environ.get('BACKTEST', False), reason="BACKTEST not set")

--- a/freqtrade/tests/test_backtesting.py
+++ b/freqtrade/tests/test_backtesting.py
@@ -40,8 +40,9 @@ def backtest(backtest_conf, processed, mocker):
     mocker.patch.dict('freqtrade.main._CONF', backtest_conf)
     mocker.patch('arrow.utcnow', return_value=arrow.get('2017-08-20T14:50:00'))
     for pair, pair_data in processed.items():
-        ticker = populate_sell_trend(populate_buy_trend(pair_data))[['close', 'date', 'buy', 'sell']].copy()
-
+        pair_data['buy'] = 0
+        pair_data['sell'] = 0
+        ticker = populate_sell_trend(populate_buy_trend(pair_data))
         # for each buy point
         for row in ticker[ticker.buy == 1].itertuples(index=True):
             trade = Trade(

--- a/freqtrade/tests/test_hyperopt.py
+++ b/freqtrade/tests/test_hyperopt.py
@@ -59,7 +59,6 @@ def buy_strategy_generator(params):
         dataframe.loc[
             reduce(lambda x, y: x & y, conditions),
             'buy'] = 1
-        dataframe.loc[dataframe['buy'] == 1, 'buy_price'] = dataframe['close']
 
         return dataframe
     return populate_buy_trend

--- a/freqtrade/tests/test_hyperopt.py
+++ b/freqtrade/tests/test_hyperopt.py
@@ -9,7 +9,7 @@ import pytest
 from hyperopt import fmin, tpe, hp, Trials, STATUS_OK
 from pandas import DataFrame
 
-from freqtrade.tests.test_backtesting import backtest, format_results
+from freqtrade.tests.test_backtesting import backtest, format_results, preprocess
 from freqtrade.vendor.qtpylib.indicators import crossed_above
 
 logging.disable(logging.DEBUG)  # disable debug logs that slow backtesting a lot
@@ -67,12 +67,13 @@ def buy_strategy_generator(params):
 
 @pytest.mark.skipif(not os.environ.get('BACKTEST', False), reason="BACKTEST not set")
 def test_hyperopt(backtest_conf, backdata, mocker):
-    mocked_buy_trend = mocker.patch('freqtrade.analyze.populate_buy_trend')
+    mocked_buy_trend = mocker.patch('freqtrade.tests.test_backtesting.populate_buy_trend')
+    processed = preprocess(backdata)
 
     def optimizer(params):
         mocked_buy_trend.side_effect = buy_strategy_generator(params)
 
-        results = backtest(backtest_conf, backdata, mocker)
+        results = backtest(backtest_conf, processed, mocker)
 
         result = format_results(results)
 

--- a/freqtrade/tests/test_hyperopt.py
+++ b/freqtrade/tests/test_hyperopt.py
@@ -146,3 +146,8 @@ def test_hyperopt(backtest_conf, backdata, mocker):
     print('Best parameters {}'.format(best))
     newlist = sorted(trials.results, key=itemgetter('loss'))
     print('Result: {}'.format(newlist[0]['result']))
+
+
+if __name__ == '__main__':
+    # for profiling with cProfile and line_profiler
+    pytest.main([__file__, '-s'])


### PR DESCRIPTION
Considerably reduce the memory consumption of hyperopt backtesting. Few other optimizations included also.

Here's a screenshot of memory consumption at around 2000 evaluations of hyperopt:
![memconsume](https://user-images.githubusercontent.com/557751/32947753-388c08c4-cba5-11e7-8849-c9bdbdaf1d60.JPG)
