### PR TITLE
New buy strategy

### DIFF
--- a/freqtrade/analyze.py
+++ b/freqtrade/analyze.py
@@ -67,11 +67,10 @@ def populate_buy_trend(dataframe: DataFrame) -> DataFrame:
     :return: DataFrame with buy column
     """
     dataframe.loc[
-        (dataframe['close'] < dataframe['sma']) &
         (dataframe['tema'] <= dataframe['blower']) &
-        (dataframe['mfi'] < 25) &
-        (dataframe['fastd'] < 25) &
-        (dataframe['adx'] > 30),
+        (dataframe['rsi'] < 37) &
+        (dataframe['fastd'] < 48) &
+        (dataframe['adx'] > 31),
         'buy'] = 1
 
     return dataframe


### PR DESCRIPTION
With the new set of test data from #107 , this buy strategy change goes from:

```
pair         buy count  avg profit    total profit       avg duration
---------  -----------  ------------  ---------------  --------------
TOTAL              732  0.44%         3.24785698 BTC           233.44
```

to

```
pair         buy count  avg profit    total profit       avg duration
---------  -----------  ------------  ---------------  --------------
TOTAL             1277  0.82%         10.47936485 BTC          199.13
```

which doubles the avg profit and triples the total profit while making avg duration shorter.

With the old set of test data we go from:
`Made 872 buys. Average profit 0.35%. Total profit was 3.044. Average duration 96.8 mins.`
to
`Made 1264 buys. Average profit 0.40%. Total profit was 5.036. Average duration 73.5 mins.`

so also with these coins we get better avg and total profit and shorter trade duration.
