### PR TITLE
align numbers in hyperopt print out

### DIFF
--- a/freqtrade/tests/test_backtesting.py
+++ b/freqtrade/tests/test_backtesting.py
@@ -23,8 +23,8 @@ logger = logging.getLogger(__name__)
 
 
 def format_results(results: DataFrame):
-    return ('Made {} buys. Average profit {:.2f}%. '
-            'Total profit was {:.3f}. Average duration {:.1f} mins.').format(
+    return ('Made {:6d} buys. Average profit {: 5.2f}%. '
+            'Total profit was {: 7.3f}. Average duration {:5.1f} mins.').format(
                 len(results.index),
                 results.profit.mean() * 100.0,
                 results.profit.sum(),

--- a/freqtrade/tests/test_hyperopt.py
+++ b/freqtrade/tests/test_hyperopt.py
@@ -94,7 +94,7 @@ def test_hyperopt(backtest_conf, mocker):
         # pylint: disable=W0603
         global current_tries
         current_tries += 1
-        print('{}/{}: {}'.format(current_tries, TOTAL_TRIES, result))
+        print('{:5d}/{}: {}'.format(current_tries, TOTAL_TRIES, result))
 
         return {
             'loss': trade_loss + profit_loss,


### PR DESCRIPTION
Aligns numbers in Hyperopt print-out for easier reading:

```
  103/6000: Made     71 buys. Average profit -0.29%. Total profit was  -0.204. Average duration 408.7 mins.
  104/6000: Made     15 buys. Average profit -0.63%. Total profit was  -0.095. Average duration 417.0 mins.
  105/6000: Made     15 buys. Average profit -0.94%. Total profit was  -0.141. Average duration 452.0 mins.
  106/6000: Made   5437 buys. Average profit -0.27%. Total profit was -14.414. Average duration 369.1 mins.
  107/6000: Made    321 buys. Average profit -0.24%. Total profit was  -0.769. Average duration 382.5 mins.
  108/6000: Made      5 buys. Average profit  0.03%. Total profit was   0.002. Average duration 220.0 mins.
```