### PR TITLE
implement trade count lock for backtesting

### DIFF
--- a/freqtrade/analyze.py
+++ b/freqtrade/analyze.py
@@ -79,6 +79,7 @@ def populate_buy_trend(dataframe: DataFrame) -> DataFrame:
 
     return dataframe
 
+
 def populate_sell_trend(dataframe: DataFrame) -> DataFrame:
     """
     Based on TA indicators, populates the sell signal for the given dataframe

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -150,6 +150,12 @@ def build_subcommands(parser: argparse.ArgumentParser) -> None:
         type=int,
         metavar='INT',
     )
+    backtest.add_argument(
+        '--limit-max-trades',
+        help='uses max_open_trades from config to simulate real world limitations',
+        action='store_true',
+        dest='limit_max_trades',
+    )
 
 
 def start_backtesting(args) -> None:
@@ -165,6 +171,7 @@ def start_backtesting(args) -> None:
         'BACKTEST_LIVE': 'true' if args.live else '',
         'BACKTEST_CONFIG': args.config,
         'BACKTEST_TICKER_INTERVAL': str(args.ticker_interval),
+        'BACKTEST_LIMIT_MAX_TRADES': 'true' if args.limit_max_trades else '',
     })
     path = os.path.join(os.path.dirname(__file__), 'tests', 'test_backtesting.py')
     pytest.main(['-s', path])

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -54,6 +54,7 @@ def default_conf():
 @pytest.fixture(scope="module")
 def backtest_conf():
     return {
+        "max_open_trades": 3,
         "stake_currency": "BTC",
         "stake_amount": 0.01,
         "minimal_roi": {

--- a/freqtrade/tests/test_backtesting.py
+++ b/freqtrade/tests/test_backtesting.py
@@ -83,33 +83,45 @@ def generate_text_table(data: Dict[str, Dict], results: DataFrame, stake_currenc
     return tabulate(tabular_data, headers=headers)
 
 
-def backtest(backtest_conf, processed, mocker):
+def backtest(config: Dict, processed, mocker, max_open_trades=0):
+    """
+    Implements backtesting functionality
+    :param config: config to use
+    :param processed: a processed dictionary with format {pair, data}
+    :param mocker: mocker instance
+    :param max_open_trades: maximum number of concurrent trades (default: 0, disabled)
+    :return: DataFrame
+    """
     trades = []
     trade_count_lock = {}
     exchange._API = Bittrex({'key': '', 'secret': ''})
-    mocker.patch.dict('freqtrade.main._CONF', backtest_conf)
+    mocker.patch.dict('freqtrade.main._CONF', config)
     for pair, pair_data in processed.items():
         pair_data['buy'], pair_data['sell'] = 0, 0
         ticker = populate_sell_trend(populate_buy_trend(pair_data))
         # for each buy point
         for row in ticker[ticker.buy == 1].itertuples(index=True):
-            # Check if max_open_trades has already been reached for the given date
-            if not trade_count_lock.get(row.date, 0) < backtest_conf['max_open_trades']:
-                continue
+            if max_open_trades > 0:
+                # Check if max_open_trades has already been reached for the given date
+                if not trade_count_lock.get(row.date, 0) < max_open_trades:
+                    continue
 
-            # Increase lock
-            trade_count_lock[row.date] = trade_count_lock.get(row.date, 0) + 1
+            if max_open_trades > 0:
+                # Increase lock
+                trade_count_lock[row.date] = trade_count_lock.get(row.date, 0) + 1
+
             trade = Trade(
                 open_rate=row.close,
                 open_date=row.date,
-                amount=backtest_conf['stake_amount'],
+                amount=config['stake_amount'],
                 fee=exchange.get_fee() * 2
             )
 
             # calculate win/lose forwards from buy point
             for row2 in ticker[row.Index + 1:].itertuples(index=True):
-                # Increase trade_count_lock for every iteration
-                trade_count_lock[row2.date] = trade_count_lock.get(row2.date, 0) + 1
+                if max_open_trades > 0:
+                    # Increase trade_count_lock for every iteration
+                    trade_count_lock[row2.date] = trade_count_lock.get(row2.date, 0) + 1
 
                 if min_roi_reached(trade, row2.close, row2.date) or row2.sell == 1:
                     current_profit = trade.calc_profit(row2.close)
@@ -118,6 +130,13 @@ def backtest(backtest_conf, processed, mocker):
                     break
     labels = ['currency', 'profit', 'duration']
     return DataFrame.from_records(trades, columns=labels)
+
+
+def get_max_open_trades(config):
+    if not os.environ.get('BACKTEST_LIMIT_MAX_TRADES'):
+        return 0
+    print('Using max_open_trades: {} ...'.format(config['max_open_trades']))
+    return config['max_open_trades']
 
 
 @pytest.mark.skipif(not os.environ.get('BACKTEST'), reason="BACKTEST not set")
@@ -150,8 +169,6 @@ def test_backtest(backtest_conf, mocker):
         config['stake_currency'], config['stake_amount']
     ))
 
-    print('Using max_open_trades: {} ...'.format(config['max_open_trades']))
-
     # Print timeframe
     min_date, max_date = get_timeframe(data)
     print('Measuring data from {} up to {} ...'.format(
@@ -159,8 +176,6 @@ def test_backtest(backtest_conf, mocker):
     ))
 
     # Execute backtest and print results
-    results = backtest(config, preprocess(data), mocker)
-    print('====================== BACKTESTING REPORT ======================================\n\n'
-          'NOTE: This Report doesn\'t respect the limits of max_open_trades, \n'
-          '      so the projected values should be taken with a grain of salt.\n')
+    results = backtest(config, preprocess(data), mocker, get_max_open_trades(config))
+    print('====================== BACKTESTING REPORT ======================================\n\n')
     print(generate_text_table(data, results, config['stake_currency']))

--- a/freqtrade/tests/test_misc.py
+++ b/freqtrade/tests/test_misc.py
@@ -109,6 +109,7 @@ def test_start_backtesting(mocker):
         live=True,
         loglevel=20,
         ticker_interval=1,
+        limit_max_trades=True,
     )
     start_backtesting(args)
     assert env_mock == {
@@ -116,6 +117,7 @@ def test_start_backtesting(mocker):
         'BACKTEST_LIVE': 'true',
         'BACKTEST_CONFIG': 'config.json',
         'BACKTEST_TICKER_INTERVAL': '1',
+        'BACKTEST_LIMIT_MAX_TRADES': 'true',
     }
     assert pytest_mock.call_count == 1
 


### PR DESCRIPTION
Implements a trade count lock to ensure the boundaries of `max_open_trades`. It also fixes a off-by-one issue during iteration.

NOTE: The logic is not perfect because some trades can overlap, to avoid this we need to sort all ticker data to process the data with the longest history first (not covered with this PR).

