### PR TITLE
fix LIMIT_BUY amount calculation

### DIFF
--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -204,10 +204,9 @@ def create_trade(stake_amount: float) -> bool:
     else:
         return False
 
-    # Calculate amount and subtract fee
-    fee = exchange.get_fee()
+    # Calculate amount
     buy_limit = get_target_bid(exchange.get_ticker(pair))
-    amount = (1 - fee) * stake_amount / buy_limit
+    amount = stake_amount / buy_limit
 
     order_id = exchange.buy(pair, buy_limit, amount)
     # Create trade entity and return
@@ -222,7 +221,7 @@ def create_trade(stake_amount: float) -> bool:
         pair=pair,
         stake_amount=stake_amount,
         amount=amount,
-        fee=fee * 2,
+        fee=exchange.get_fee() * 2,
         open_rate=buy_limit,
         open_date=datetime.utcnow(),
         exchange=exchange.get_name().upper(),

--- a/freqtrade/tests/test_main.py
+++ b/freqtrade/tests/test_main.py
@@ -41,7 +41,7 @@ def test_process_trade_creation(default_conf, ticker, health, mocker):
     assert trade.open_date is not None
     assert trade.exchange == Exchanges.BITTREX.name
     assert trade.open_rate == 0.072661
-    assert trade.amount == 0.6864067381401302
+    assert trade.amount == 0.6881270557795791
 
 
 def test_process_exchange_failures(default_conf, ticker, health, mocker):


### PR DESCRIPTION
This PR should fix #132.
Turns out we don't need to apply fees ourselfs when opening a LIMIT_BUY order.
Fees are now only considered while calculating the profit.