### PR TITLE
In backtesting, ensure we don't buy the same pair again before selling

### DIFF
--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -147,10 +147,10 @@ def build_subcommands(parser: argparse.ArgumentParser) -> None:
         metavar='INT',
     )
     backtest.add_argument(
-        '--limit-max-trades',
+        '--realistic-simulation',
         help='uses max_open_trades from config to simulate real world limitations',
         action='store_true',
-        dest='limit_max_trades',
+        dest='realistic_simulation',
     )
 
 
@@ -167,7 +167,7 @@ def start_backtesting(args) -> None:
         'BACKTEST_LIVE': 'true' if args.live else '',
         'BACKTEST_CONFIG': args.config,
         'BACKTEST_TICKER_INTERVAL': str(args.ticker_interval),
-        'BACKTEST_LIMIT_MAX_TRADES': 'true' if args.limit_max_trades else '',
+        'BACKTEST_REALISTIC_SIMULATION': 'true' if args.realistic_simulation else '',
     })
     path = os.path.join(os.path.dirname(__file__), 'tests', 'test_backtesting.py')
     pytest.main(['-s', path])

--- a/freqtrade/tests/test_backtesting.py
+++ b/freqtrade/tests/test_backtesting.py
@@ -102,9 +102,9 @@ def backtest(config: Dict, processed, mocker, max_open_trades=0):
         # for each buy point
         lock_pair_until = None
         for row in ticker[ticker.buy == 1].itertuples(index=True):
-            if lock_pair_until is not None and row.Index <= lock_pair_until:
-                continue
             if max_open_trades > 0:
+                if lock_pair_until is not None and row.Index <= lock_pair_until:
+                    continue
                 # Check if max_open_trades has already been reached for the given date
                 if not trade_count_lock.get(row.date, 0) < max_open_trades:
                     continue

--- a/freqtrade/tests/test_backtesting.py
+++ b/freqtrade/tests/test_backtesting.py
@@ -83,13 +83,14 @@ def generate_text_table(data: Dict[str, Dict], results: DataFrame, stake_currenc
     return tabulate(tabular_data, headers=headers)
 
 
-def backtest(config: Dict, processed, mocker, max_open_trades=0):
+def backtest(config: Dict, processed, mocker, max_open_trades=0, realistic=True):
     """
     Implements backtesting functionality
     :param config: config to use
     :param processed: a processed dictionary with format {pair, data}
     :param mocker: mocker instance
     :param max_open_trades: maximum number of concurrent trades (default: 0, disabled)
+    :param realistic: do we try to simulate realistic trades? (default: True)
     :return: DataFrame
     """
     trades = []
@@ -102,9 +103,10 @@ def backtest(config: Dict, processed, mocker, max_open_trades=0):
         # for each buy point
         lock_pair_until = None
         for row in ticker[ticker.buy == 1].itertuples(index=True):
-            if max_open_trades > 0:
+            if realistic:
                 if lock_pair_until is not None and row.Index <= lock_pair_until:
                     continue
+            if max_open_trades > 0:
                 # Check if max_open_trades has already been reached for the given date
                 if not trade_count_lock.get(row.date, 0) < max_open_trades:
                     continue
@@ -137,7 +139,7 @@ def backtest(config: Dict, processed, mocker, max_open_trades=0):
 
 
 def get_max_open_trades(config):
-    if not os.environ.get('BACKTEST_LIMIT_MAX_TRADES'):
+    if not os.environ.get('BACKTEST_REALISTIC_SIMULATION'):
         return 0
     print('Using max_open_trades: {} ...'.format(config['max_open_trades']))
     return config['max_open_trades']
@@ -180,6 +182,7 @@ def test_backtest(backtest_conf, mocker):
     ))
 
     # Execute backtest and print results
-    results = backtest(config, preprocess(data), mocker, get_max_open_trades(config))
+    realistic = os.environ.get('BACKTEST_REALISTIC_SIMULATION')
+    results = backtest(config, preprocess(data), mocker, get_max_open_trades(config), realistic)
     print('====================== BACKTESTING REPORT ======================================\n\n')
     print(generate_text_table(data, results, config['stake_currency']))

--- a/freqtrade/tests/test_misc.py
+++ b/freqtrade/tests/test_misc.py
@@ -109,7 +109,7 @@ def test_start_backtesting(mocker):
         live=True,
         loglevel=20,
         ticker_interval=1,
-        limit_max_trades=True,
+        realistic_simulation=True,
     )
     start_backtesting(args)
     assert env_mock == {
@@ -117,7 +117,7 @@ def test_start_backtesting(mocker):
         'BACKTEST_LIVE': 'true',
         'BACKTEST_CONFIG': 'config.json',
         'BACKTEST_TICKER_INTERVAL': '1',
-        'BACKTEST_LIMIT_MAX_TRADES': 'true',
+        'BACKTEST_REALISTIC_SIMULATION': 'true',
     }
     assert pytest_mock.call_count == 1
 


### PR DESCRIPTION
I may be wrong, but the way I understand the backtesting loop, we iterate through all buy signals regardless of their relative positions to sell signal, which might get us in the following situation:

```
if > is a buy signal, and < a sell signal:
(1)   (2) (3)  (4)  (5)
->-----<--->---->----<--
  -----     ---------: Trades to keep
                 ----: overlapping trades that make no sense
```
That is because when we sell, we don't change the loop that looks for buy signals, so when (3) buys, we sell at (5), but the next iteration will be (4), with again a sell signal at (5). The recent addition of `max_open_trades` doesn't help with this problem.

Instead, this PR ensures that when we iterate on (4), the `lock_pair_until` will let us know that we should ignore this signal.

I chose to ignore any buy signal that might occur on the same 5-min tick than a sell signal (`row.Index <= lock_pair_until` instead of maybe `<`), because it looks more real to me, but that's open to debate I guess.

I should note that this has noticable impacts on results: for instance in my case total profits for a backtest drop from 11BTC to 3.