### PR TITLE
add experimental flag support

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -29,6 +29,9 @@
             "BTC_LUN"
         ]
     },
+    "experimental": {
+        "use_sell_signal": true
+    },
     "telegram": {
         "enabled": true,
         "token": "token",

--- a/config.json.example
+++ b/config.json.example
@@ -30,7 +30,7 @@
         ]
     },
     "experimental": {
-        "use_sell_signal": true
+        "use_sell_signal": false
     },
     "telegram": {
         "enabled": true,

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -202,6 +202,12 @@ CONF_SCHEMA = {
             'required': ['ask_last_balance']
         },
         'exchange': {'$ref': '#/definitions/exchange'},
+        'experimental': {
+            'type': 'object',
+            'properties': {
+                'use_sell_signal': {'type': 'boolean'}
+            }
+        },
         'telegram': {
             'type': 'object',
             'properties': {


### PR DESCRIPTION
Add support to configure experimental features, to quickly test new strategies and untested features.

This PR also adds the `use_sell_signal` which is set to `false` per default.
```
    "experimental": {
        "use_sell_signal": false
    }
```