### PR TITLE
Hyperopt/simplify logging

### DIFF
--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -18,6 +18,7 @@ from freqtrade.vendor.qtpylib.indicators import crossed_above
 
 # Remove noisy log messages
 logging.getLogger('hyperopt.mongoexp').setLevel(logging.WARNING)
+logging.getLogger('hyperopt.tpe').setLevel(logging.WARNING)
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +27,10 @@ logger = logging.getLogger(__name__)
 TARGET_TRADES = 1100
 TOTAL_TRIES = None
 _CURRENT_TRIES = 0
+
+TOTAL_PROFIT_TO_BEAT = 4
+AVG_PROFIT_TO_BEAT = 0.2
+AVG_DURATION_TO_BEAT = 70
 
 # Configuration and data used by hyperopt
 PROCESSED = optimize.preprocess(optimize.load_data())


### PR DESCRIPTION
The current output will be the following if we don't beat the total profit threshold
```
[freqtrade] > python3 freqtrade/main.py hyperopt -e 10
..........2017-12-02 14:58:29,237 - freqtrade.optimize.hyperopt - INFO - Best parameters:
{
    "adx": 1,
    "adx-value": 43.0,
    "fastd": 0,
    "green_candle": 0,
    "mfi": 0,
    "over_sar": 1,
    "rsi": 1,
    "rsi-value": 32.0,
    "trigger": 0,
    "uptrend_long_ema": 0,
    "uptrend_short_ema": 0,
    "uptrend_sma": 0
}
2017-12-02 14:58:29,238 - freqtrade.optimize.hyperopt - INFO - Best Result:
Made     16 buys. Average profit  0.21%. Total profit was   0.034. Average duration  46.9 mins.
```

If someone has a better idea on how to define another formatter for `logging` and use that instead of printing+flushing let me know and I'll fix.