### PR TITLE
Allow to change the number of currencies used by dynamic-whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,18 +146,39 @@ Simple High Frequency Trading Bot for crypto currencies
 
 positional arguments:
   {backtesting}
-    backtesting         backtesting module
+    backtesting             backtesting module
 
 optional arguments:
-  -h, --help            show this help message and exit
+  -h, --help                show this help message and exit
   -c PATH, --config PATH
-                        specify configuration file (default: config.json)
-  -v, --verbose         be verbose
-  --version             show program's version number and exit
-  --dynamic-whitelist   dynamically generate and update whitelist based on 24h
-                        BaseVolume
+                            specify configuration file (default: config.json)
+  -v, --verbose             be verbose
+  --version                 show program's version number and exit
+  --dynamic-whitelist INT   dynamically generate and update whitelist based on 24h
+                            BaseVolume (Default 20 currencies)
 
 ```
+
+#### Dynamic whitelist example
+Per default `--dynamic-whitelist` will retrieve the 20 currencies based 
+on BaseVolume. This value can be changed when you run the script.
+
+**By Default**  
+Get the 20 currencies based on BaseVolume.  
+```bash
+freqtrade --dynamic-whitelist
+```
+
+**Customize the number of currencies to retrieve**  
+Get the 30 currencies based on BaseVolume.  
+```bash
+freqtrade --dynamic-whitelist 30
+```
+
+**Exception**  
+`--dynamic-whitelist` must be greater than 0. If you enter 0 or a
+negative value (e.g -2), `--dynamic-whitelist` will use the default
+value (20).
 
 ### Backtesting
 

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import argparse
 import copy
 import json
 import logging

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -112,8 +112,12 @@ def parse_args(args: List[str]):
     )
     parser.add_argument(
         '--dynamic-whitelist',
-        help='dynamically generate and update whitelist based on 24h BaseVolume',
-        action='store_true',
+        help='dynamically generate and update whitelist based on 24h BaseVolume (Default 20 currencies)',
+        dest='dynamic_whitelist',
+        const=20,
+        type=int,
+        metavar='INT',
+        nargs='?',
     )
     build_subcommands(parser)
     parsed_args = parser.parse_args(args)

--- a/freqtrade/tests/test_misc.py
+++ b/freqtrade/tests/test_misc.py
@@ -30,7 +30,7 @@ def test_parse_args_defaults():
     args = parse_args([])
     assert args is not None
     assert args.config == 'config.json'
-    assert args.dynamic_whitelist is False
+    assert args.dynamic_whitelist is None
     assert args.loglevel == 20
 
 
@@ -58,7 +58,16 @@ def test_parse_args_verbose():
 def test_parse_args_dynamic_whitelist():
     args = parse_args(['--dynamic-whitelist'])
     assert args is not None
-    assert args.dynamic_whitelist is True
+    assert args.dynamic_whitelist is 20
+
+def test_parse_args_dynamic_whitelist_10():
+    args = parse_args(['--dynamic-whitelist', '10'])
+    assert args is not None
+    assert args.dynamic_whitelist is 10
+
+def test_parse_args_dynamic_whitelist_invalid_values():
+    with pytest.raises(SystemExit, match=r'2'):
+        parse_args(['--dynamic-whitelist', 'abc'])
 
 
 def test_parse_args_backtesting(mocker):


### PR DESCRIPTION
This pull request is an answer to the issue #98 
It allows overriding the number of currencies used by `--dynamic-whitelist` (by default 20).
It does not change the current behavior of `--dynamic-whitelist`, it only extends it.

**By Default**  
Get the 20 currencies based on BaseVolume.  
```bash
freqtrade --dynamic-whitelist
```

**Customize the number of currencies to retrieve**  
Get the 30 currencies based on BaseVolume.  
```bash
freqtrade --dynamic-whitelist 30
```
