### PR TITLE
Add param for Dry run to use a DB file instead of memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,24 +140,29 @@ changes, it will suffice to edit `config.json` and restart the container.
 
 ### Usage
 ```
-usage: freqtrade [-h] [-c PATH] [-v] [--version] [--dynamic-whitelist]
-                 {backtesting} ...
+usage: main.py [-h] [-c PATH] [-v] [--version] [--dynamic-whitelist [INT]]
+               [--dry-run-db]
+               {backtesting,hyperopt} ...
 
 Simple High Frequency Trading Bot for crypto currencies
 
 positional arguments:
-  {backtesting}
-    backtesting             backtesting module
+  {backtesting,hyperopt}
+    backtesting         backtesting module
+    hyperopt            hyperopt module
 
 optional arguments:
-  -h, --help                show this help message and exit
+  -h, --help            show this help message and exit
   -c PATH, --config PATH
-                            specify configuration file (default: config.json)
-  -v, --verbose             be verbose
-  --version                 show program's version number and exit
-  --dynamic-whitelist INT   dynamically generate and update whitelist based on 24h
-                            BaseVolume (Default 20 currencies)
-
+                        specify configuration file (default: config.json)
+  -v, --verbose         be verbose
+  --version             show program's version number and exit
+  --dynamic-whitelist [INT]
+                        dynamically generate and update whitelist based on 24h
+                        BaseVolume (Default 20 currencies)
+  --dry-run-db          Force dry run to use a local DB
+                        "tradesv3.dry_run.sqlite" instead of memory DB. Work
+                        only if dry_run is enabled.
 ```
 
 #### Dynamic whitelist example

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -325,6 +325,14 @@ def main() -> None:
     if args.dynamic_whitelist:
         logger.info('Using dynamically generated whitelist. (--dynamic-whitelist detected)')
 
+    # If the user ask for Dry run with a local DB instead of memory
+    if args.dry_run_db:
+        if _CONF.get('dry_run', False):
+            _CONF.update({'dry_run_db': True})
+            logger.info('Dry_run will use the DB file: "tradesv3.dry_run.sqlite". (--dry_run_db detected)')
+        else:
+            logger.info('Dry run is disabled. (--dry_run_db ignored)')
+
     try:
         init(_CONF)
         old_state = None

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -119,6 +119,13 @@ def parse_args(args: List[str]):
         metavar='INT',
         nargs='?',
     )
+    parser.add_argument(
+        '--dry-run-db',
+        help='Force dry run to use a local DB "tradesv3.dry_run.sqlite" instead of memory DB. Work only if dry_run is \
+             enabled.',
+        action='store_true',
+        dest='dry_run_db',
+    )
     build_subcommands(parser)
     parsed_args = parser.parse_args(args)
 

--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -29,10 +29,15 @@ def init(config: dict, engine: Optional[Engine] = None) -> None:
     _CONF.update(config)
     if not engine:
         if _CONF.get('dry_run', False):
-            engine = create_engine('sqlite://',
-                                   connect_args={'check_same_thread': False},
-                                   poolclass=StaticPool,
-                                   echo=False)
+            # the user wants dry run to use a DB
+            if _CONF.get('dry_run_db', False):
+                engine = create_engine('sqlite:///tradesv3.dry_run.sqlite')
+            # Otherwise dry run will store in memory
+            else:
+                engine = create_engine('sqlite://',
+                                       connect_args={'check_same_thread': False},
+                                       poolclass=StaticPool,
+                                       echo=False)
         else:
             engine = create_engine('sqlite:///tradesv3.sqlite')
 


### PR DESCRIPTION
Add a command line param `--dry-run-db ` that will use `tradesv3.dry_run.sqlite` instead of memory.

1. Works only if dry run is enabled.
2. Is ignored if dry run is disabled.
3. Create `tradesv3.dry_run.sqlite` if does not exist

## Help message
```
 --dry-run-db          Force dry run to use a local DB
                        "tradesv3.dry_run.sqlite" instead of memory DB. Work
                        only if dry_run is enabled.
```