### PR TITLE
Improve  /daily command

### DIFF
--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -223,11 +223,10 @@ def _daily(bot: Bot, update: Update) -> None:
     try:
         timescale = int(update.message.text.replace('/daily', '').strip())
     except:
-        send_msg('*Daily <n>:* `must be an integer greater than 0`', bot=bot)
-        return
+        timescale = 5
             
     if not (isinstance(timescale, int) and timescale > 0):
-        send_msg('*Daily <n>:* `must be an integer greater than 0`', bot=bot)
+        send_msg('*Daily [n]:* `must be an integer greater than 0`', bot=bot)
         return
 
     for day in range(0, timescale):
@@ -238,7 +237,7 @@ def _daily(bot: Bot, update: Update) -> None:
          curdayprofit = 0
          for trade in trades:
              curdayprofit += trade.close_profit * trade.stake_amount
-         profit_days[date.fromordinal(today-day)] = curdayprofit
+         profit_days[date.fromordinal(today-day)] = format(curdayprofit, '.8f')
 
     stats = []
     for key, value in profit_days.items():
@@ -518,9 +517,9 @@ def send_msg(msg: str, bot: Bot = None, parse_mode: ParseMode = ParseMode.MARKDO
 
     bot = bot or _UPDATER.bot
 
-    keyboard = [['/daily', '/status table', '/profit', '/performance', ],
-                ['/balance', '/status', '/count'],
-                ['/start', '/stop', '/help']]
+    keyboard = [['/daily', '/profit', '/balance' ],
+                ['/status', '/status table', '/performance'],
+                ['/count', '/start', '/stop', '/help']]
 
     reply_markup = ReplyKeyboardMarkup(keyboard)
 

--- a/freqtrade/tests/test_rpc_telegram.py
+++ b/freqtrade/tests/test_rpc_telegram.py
@@ -355,7 +355,7 @@ def test_daily_handle(
     #try invalid data
     msg_mock.reset_mock()
     update_state(State.RUNNING)
-    update.message.text = '/daily'
+    update.message.text = '/daily -2'
     _daily(bot=MagicMock(), update=update)
     assert msg_mock.call_count == 1
     assert 'must be an integer greater than 0' in msg_mock.call_args_list[0][0][0]   


### PR DESCRIPTION
The PR is to improve the `/daily`command on Telegram.

Long story short...
![update_daily](https://user-images.githubusercontent.com/1137839/34028490-561db9ea-e118-11e7-8ccb-42d6c5e5f8cf.png)


## Issues this PR solve
Since the `/daily` command was pushed we saw few UX issues: 
* Command keyboard is not readible anymore, words are truncated
* The result format from `/daily` is not readible
* There is no default number on `/daily`, clicking on it send us to an error message, not a great UX