### PR TITLE
Improve telegram /profit command

### DIFF
--- a/freqtrade/tests/test_rpc_telegram.py
+++ b/freqtrade/tests/test_rpc_telegram.py
@@ -189,7 +189,7 @@ def test_profit_handle(default_conf, update, ticker, limit_buy_order, limit_sell
 
     _profit(bot=MagicMock(), update=update)
     assert msg_mock.call_count == 1
-    assert '*ROI:* `1.50701325 (10.05%)`' in msg_mock.call_args_list[-1][0][0]
+    assert '*ROI All trades:* `0.00765279 BTC (10.05%)`' in msg_mock.call_args_list[-1][0][0]
     assert 'Best Performing:* `BTC_ETH: 10.05%`' in msg_mock.call_args_list[-1][0][0]
 
 


### PR DESCRIPTION
## Issue
The command `/profit` doesn't calculate the ROI on closed trade only, but on all trades. This is confusing especially when the `/help`says `/profit: Lists cumulative profit from all finished trades`.

The picture below shows the current behavior when I call 3 times in a row `/profit`.
![profits](https://user-images.githubusercontent.com/1137839/34034569-f122c384-e133-11e7-8ea8-c94f2c02d514.png)

The ROI change because it compares close + open with the current market.

## How this PR solve the issue
This PR solves this issue, by showing the ROI for closed trades only + the global ROI (Open + Closed)
![profit_new](https://user-images.githubusercontent.com/1137839/34034703-62c9120e-e134-11e7-9d75-fc767dda092b.png)

