### PR TITLE
/forcesell: handle trades with open orders

### DIFF
--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -87,7 +87,8 @@ class Trade(_DECL_BASE):
         :param order: order retrieved by exchange.get_order()
         :return: None
         """
-        if not order['closed']:
+        # Ignore open and cancelled orders
+        if not order['closed'] or order['rate'] is None:
             return
 
         logger.info('Updating trade (id=%d) ...', self.id)

--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -96,21 +96,27 @@ class Trade(_DECL_BASE):
             self.open_rate = order['rate']
             self.amount = order['amount']
             logger.info('LIMIT_BUY has been fulfilled for %s.', self)
+            self.open_order_id = None
         elif order['type'] == 'LIMIT_SELL':
-            # Set close rate and set actual profit
-            self.close_rate = order['rate']
-            self.close_profit = self.calc_profit()
-            self.close_date = datetime.utcnow()
-            self.is_open = False
-            logger.info(
-                'Marking %s as closed as the trade is fulfilled and found no open orders for it.',
-                self
-            )
+            self.close(order['rate'])
         else:
             raise ValueError('Unknown order type: {}'.format(order['type']))
-
-        self.open_order_id = None
         Trade.session.flush()
+
+    def close(self, rate: float) -> None:
+        """
+        Sets close_rate to the given rate, calculates total profit
+        and marks trade as closed
+        """
+        self.close_rate = rate
+        self.close_profit = self.calc_profit()
+        self.close_date = datetime.utcnow()
+        self.is_open = False
+        self.open_order_id = None
+        logger.info(
+            'Marking %s as closed as the trade is fulfilled and found no open orders for it.',
+            self
+        )
 
     def calc_profit(self, rate: Optional[float] = None) -> float:
         """

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -379,7 +379,7 @@ def _exec_forcesell(trade: Trade) -> None:
         # Cancel open LIMIT_BUY orders and close trade
         if order and not order['closed'] and order['type'] == 'LIMIT_BUY':
             exchange.cancel_order(trade.open_order_id)
-            trade.close(order.get('rate', trade.open_rate))
+            trade.close(order.get('rate') or trade.open_rate)
             # TODO: sell amount which has been bought already
             return
 

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -1,10 +1,10 @@
 import logging
 import re
 from datetime import timedelta, date
+from decimal import Decimal
 from typing import Callable, Any
 
 import arrow
-from decimal import Decimal
 from pandas import DataFrame
 from sqlalchemy import and_, func, text, between
 from tabulate import tabulate

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -371,28 +371,6 @@ def _stop(bot: Bot, update: Update) -> None:
         send_msg('*Status:* `already stopped`', bot=bot)
 
 
-def _exec_forcesell(trade: Trade) -> None:
-    # Check if there is there is an open order
-    if trade.open_order_id:
-        order = exchange.get_order(trade.open_order_id)
-
-        # Cancel open LIMIT_BUY orders and close trade
-        if order and not order['closed'] and order['type'] == 'LIMIT_BUY':
-            exchange.cancel_order(trade.open_order_id)
-            trade.close(order.get('rate') or trade.open_rate)
-            # TODO: sell amount which has been bought already
-            return
-
-        # Ignore trades with an attached LIMIT_SELL order
-        if order and not order['closed'] and order['type'] == 'LIMIT_SELL':
-            return
-
-    # Get current rate and execute sell
-    current_rate = exchange.get_ticker(trade.pair)['bid']
-    from freqtrade.main import execute_sell
-    execute_sell(trade, current_rate)
-
-
 @authorized_only
 def _forcesell(bot: Bot, update: Update) -> None:
     """
@@ -528,6 +506,28 @@ def shorten_date(_date):
     new_date = re.sub('days?', 'd', new_date)
     new_date = re.sub('^an?', '1', new_date)
     return new_date
+
+
+def _exec_forcesell(trade: Trade) -> None:
+    # Check if there is there is an open order
+    if trade.open_order_id:
+        order = exchange.get_order(trade.open_order_id)
+
+        # Cancel open LIMIT_BUY orders and close trade
+        if order and not order['closed'] and order['type'] == 'LIMIT_BUY':
+            exchange.cancel_order(trade.open_order_id)
+            trade.close(order.get('rate') or trade.open_rate)
+            # TODO: sell amount which has been bought already
+            return
+
+        # Ignore trades with an attached LIMIT_SELL order
+        if order and not order['closed'] and order['type'] == 'LIMIT_SELL':
+            return
+
+    # Get current rate and execute sell
+    current_rate = exchange.get_ticker(trade.pair)['bid']
+    from freqtrade.main import execute_sell
+    execute_sell(trade, current_rate)
 
 
 def send_msg(msg: str, bot: Bot = None, parse_mode: ParseMode = ParseMode.MARKDOWN) -> None:


### PR DESCRIPTION
The goal of the PR is to handle trades with open order correctly.

**Scenario:** Bot decides to create a trade for `BTC_QTUM` and places a `LIMIT_BUY` order. `BTC_QTUM` soars and the order will no longer be fulfilled. Issuing `/forcesell` just raises `INSUFFICIENT_FUNDS` and doesn't the attached order.

should fix #102

How it will be handled with this PR:
* If there is an open LIMIT_BUY order attached: cancel the order.
  (It is possible that some amount of the order got filled already, as stated in the TODO, but I would like to tackle this in another PR).
* IF there is an open LIMIT_SELL order attached: do nothing.

*EDIT:* I've also fixed some indentation and formatting issues in `rpc/telegram.py`