### PR TITLE
CI: enforce PEP8 conform code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,12 @@ install:
 - tar zxvf ta-lib-0.4.0-src.tar.gz
 - cd ta-lib && ./configure && sudo make && sudo make install && cd ..
 - export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-- pip install coveralls
+- pip install flake8 coveralls
 - pip install -r requirements.txt
 script:
 - pytest --cov=freqtrade --cov-config=.coveragerc freqtrade/tests/
 after_success:
-- coveralls
+- flake8 freqtrade && coveralls
 notifications:
   slack:
     secure: bKLXmOrx8e2aPZl7W8DA5BdPAXWGpI5UzST33oc1G/thegXcDVmHBTJrBs4sZak6bgAclQQrdZIsRd2eFYzHLalJEaw6pk7hoAw8SvLnZO0ZurWboz7qg2+aZZXfK4eKl/VUe4sM9M4e/qxjkK+yWG7Marg69c4v1ypF7ezUi1fPYILYw8u0paaiX0N5UX8XNlXy+PBlga2MxDjUY70MuajSZhPsY2pDUvYnMY1D/7XN3cFW0g+3O8zXjF0IF4q1Z/1ASQe+eYjKwPQacE+O8KDD+ZJYoTOFBAPllrtpO1jnOPFjNGf3JIbVMZw4bFjIL0mSQaiSUaUErbU3sFZ5Or79rF93XZ81V7uEZ55vD8KMfR2CB1cQJcZcj0v50BxLo0InkFqa0Y8Nra3sbpV4fV5Oe8pDmomPJrNFJnX6ULQhQ1gTCe0M5beKgVms5SITEpt4/Y0CmLUr6iHDT0CUiyMIRWAXdIgbGh1jfaWOMksybeRevlgDsIsNBjXmYI1Sw2ZZR2Eo2u4R6zyfyjOMLwYJ3vgq9IrACv2w5nmf0+oguMWHf6iWi2hiOqhlAN1W74+3HsYQcqnuM3LGOmuCnPprV1oGBqkPXjIFGpy21gNx4vHfO1noLUyJnMnlu2L7SSuN1CdLsnjJ1hVjpJjPfqB4nn8g12x87TqM1bOm+3Q=

--- a/README.md
+++ b/README.md
@@ -231,5 +231,5 @@ $ pytest freqtrade
 Feel like our bot is missing a feature? We welcome your pull requests! Few pointers for contributions:
 
 - Create your PR against the `develop` branch, not `master`.
-- New features need to contain unit tests.
+- New features need to contain unit tests and must be PEP8 conform (`max-line-length = 100`).
 - If you are unsure, discuss the feature on [slack](https://join.slack.com/t/highfrequencybot/shared_invite/enQtMjQ5NTM0OTYzMzY3LWMxYzE3M2MxNDdjMGM3ZTYwNzFjMGIwZGRjNTc3ZGU3MGE3NzdmZGMwNmU3NDM5ZTNmM2Y3NjRiNzk4NmM4OGE) or in a [issue](https://github.com/gcarq/freqtrade/issues) before a PR.

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -60,7 +60,10 @@ def _process(dynamic_whitelist: Optional[int] = 0) -> bool:
     try:
         # Refresh whitelist based on wallet maintenance
         refresh_whitelist(
-            gen_pair_whitelist(_CONF['stake_currency'], topn = dynamic_whitelist) if dynamic_whitelist else None
+            gen_pair_whitelist(
+                _CONF['stake_currency'],
+                topn=dynamic_whitelist
+            ) if dynamic_whitelist else None
         )
         # Query trades from persistence layer
         trades = Trade.query.filter(Trade.is_open.is_(True)).all()
@@ -329,7 +332,9 @@ def main() -> None:
     if args.dry_run_db:
         if _CONF.get('dry_run', False):
             _CONF.update({'dry_run_db': True})
-            logger.info('Dry_run will use the DB file: "tradesv3.dry_run.sqlite". (--dry_run_db detected)')
+            logger.info(
+                'Dry_run will use the DB file: "tradesv3.dry_run.sqlite". (--dry_run_db detected)'
+            )
         else:
             logger.info('Dry run is disabled. (--dry_run_db ignored)')
 

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -112,7 +112,7 @@ def parse_args(args: List[str]):
     )
     parser.add_argument(
         '--dynamic-whitelist',
-        help='dynamically generate and update whitelist based on 24h BaseVolume (Default 20 currencies)',
+        help='dynamically generate and update whitelist based on 24h BaseVolume (Default 20 currencies)',  # noqa
         dest='dynamic_whitelist',
         const=20,
         type=int,
@@ -122,7 +122,7 @@ def parse_args(args: List[str]):
     parser.add_argument(
         '--dry-run-db',
         help='Force dry run to use a local DB "tradesv3.dry_run.sqlite" instead of memory DB. Work only if dry_run is \
-             enabled.',
+             enabled.',  # noqa
         action='store_true',
         dest='dry_run_db',
     )

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -35,7 +35,8 @@ def get_timeframe(data: Dict[str, Dict]) -> Tuple[arrow.Arrow, arrow.Arrow]:
     return arrow.get(min_date), arrow.get(max_date)
 
 
-def generate_text_table(data: Dict[str, Dict], results: DataFrame, stake_currency, ticker_interval) -> str:
+def generate_text_table(
+        data: Dict[str, Dict], results: DataFrame, stake_currency, ticker_interval) -> str:
     """
     Generates and returns a text table for the given backtest data and the results dataframe
     :return: pretty printed table with tabulate as str

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -49,7 +49,7 @@ OPTIMIZE_CONFIG = {
 }
 
 # Monkey patch config
-from freqtrade import main
+from freqtrade import main  # noqa
 main._CONF = OPTIMIZE_CONFIG
 
 
@@ -102,6 +102,7 @@ SPACE = {
     ]),
 }
 
+
 def log_results(results):
     "if results is better than _TO_BEAT show it"
 
@@ -117,6 +118,7 @@ def log_results(results):
     else:
         print('.', end='')
         sys.stdout.flush()
+
 
 def optimizer(params):
     global _CURRENT_TRIES
@@ -148,7 +150,7 @@ def optimizer(params):
         'result': result,
         'results': results
         }
-    
+
     # logger.info('{:5d}/{}: {}'.format(_CURRENT_TRIES, TOTAL_TRIES, result))
     log_results(result_data)
 

--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -87,7 +87,8 @@ class Trade(_DECL_BASE):
         :param order: order retrieved by exchange.get_order()
         :return: None
         """
-        if not order['closed']:
+        # Ignore open and cancelled orders
+        if not order['closed'] or order['rate'] is None:
             return
 
         logger.info('Updating trade (id=%d) ...', self.id)

--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -96,21 +96,27 @@ class Trade(_DECL_BASE):
             self.open_rate = order['rate']
             self.amount = order['amount']
             logger.info('LIMIT_BUY has been fulfilled for %s.', self)
+            self.open_order_id = None
         elif order['type'] == 'LIMIT_SELL':
-            # Set close rate and set actual profit
-            self.close_rate = order['rate']
-            self.close_profit = self.calc_profit()
-            self.close_date = datetime.utcnow()
-            self.is_open = False
-            logger.info(
-                'Marking %s as closed as the trade is fulfilled and found no open orders for it.',
-                self
-            )
+            self.close(order['rate'])
         else:
             raise ValueError('Unknown order type: {}'.format(order['type']))
-
-        self.open_order_id = None
         Trade.session.flush()
+
+    def close(self, rate: float) -> None:
+        """
+        Sets close_rate to the given rate, calculates total profit
+        and marks trade as closed
+        """
+        self.close_rate = rate
+        self.close_profit = self.calc_profit()
+        self.close_date = datetime.utcnow()
+        self.is_open = False
+        self.open_order_id = None
+        logger.info(
+            'Marking %s as closed as the trade is fulfilled and found no open orders for it.',
+            self
+        )
 
     def calc_profit(self, rate: Optional[float] = None) -> float:
         """

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -379,7 +379,7 @@ def _exec_forcesell(trade: Trade) -> None:
         # Cancel open LIMIT_BUY orders and close trade
         if order and not order['closed'] and order['type'] == 'LIMIT_BUY':
             exchange.cancel_order(trade.open_order_id)
-            trade.close(order.get('rate', trade.open_rate))
+            trade.close(order.get('rate') or trade.open_rate)
             # TODO: sell amount which has been bought already
             return
 

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -1,10 +1,10 @@
 import logging
 import re
 from datetime import timedelta, date
+from decimal import Decimal
 from typing import Callable, Any
 
 import arrow
-from decimal import Decimal
 from pandas import DataFrame
 from sqlalchemy import and_, func, text, between
 from tabulate import tabulate

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -371,28 +371,6 @@ def _stop(bot: Bot, update: Update) -> None:
         send_msg('*Status:* `already stopped`', bot=bot)
 
 
-def _exec_forcesell(trade: Trade) -> None:
-    # Check if there is there is an open order
-    if trade.open_order_id:
-        order = exchange.get_order(trade.open_order_id)
-
-        # Cancel open LIMIT_BUY orders and close trade
-        if order and not order['closed'] and order['type'] == 'LIMIT_BUY':
-            exchange.cancel_order(trade.open_order_id)
-            trade.close(order.get('rate') or trade.open_rate)
-            # TODO: sell amount which has been bought already
-            return
-
-        # Ignore trades with an attached LIMIT_SELL order
-        if order and not order['closed'] and order['type'] == 'LIMIT_SELL':
-            return
-
-    # Get current rate and execute sell
-    current_rate = exchange.get_ticker(trade.pair)['bid']
-    from freqtrade.main import execute_sell
-    execute_sell(trade, current_rate)
-
-
 @authorized_only
 def _forcesell(bot: Bot, update: Update) -> None:
     """
@@ -528,6 +506,28 @@ def shorten_date(_date):
     new_date = re.sub('days?', 'd', new_date)
     new_date = re.sub('^an?', '1', new_date)
     return new_date
+
+
+def _exec_forcesell(trade: Trade) -> None:
+    # Check if there is there is an open order
+    if trade.open_order_id:
+        order = exchange.get_order(trade.open_order_id)
+
+        # Cancel open LIMIT_BUY orders and close trade
+        if order and not order['closed'] and order['type'] == 'LIMIT_BUY':
+            exchange.cancel_order(trade.open_order_id)
+            trade.close(order.get('rate') or trade.open_rate)
+            # TODO: sell amount which has been bought already
+            return
+
+        # Ignore trades with an attached LIMIT_SELL order
+        if order and not order['closed'] and order['type'] == 'LIMIT_SELL':
+            return
+
+    # Get current rate and execute sell
+    current_rate = exchange.get_ticker(trade.pair)['bid']
+    from freqtrade.main import execute_sell
+    execute_sell(trade, current_rate)
 
 
 def send_msg(msg: str, bot: Bot = None, parse_mode: ParseMode = ParseMode.MARKDOWN) -> None:

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -93,7 +93,7 @@ def authorized_only(command_handler: Callable[[Bot, Update], None]) -> Callable[
     :return: decorated function
     """
     def wrapper(*args, **kwargs):
-        bot, update = kwargs.get('bot') or args[0], kwargs.get('update') or args[1]
+        update = kwargs.get('update') or args[1]
 
         # Reject unauthorized messages
         chat_id = int(_CONF['telegram']['chat_id'])
@@ -551,7 +551,10 @@ def send_msg(msg: str, bot: Bot = None, parse_mode: ParseMode = ParseMode.MARKDO
 
     try:
         try:
-            bot.send_message(_CONF['telegram']['chat_id'], msg, parse_mode=parse_mode, reply_markup=reply_markup)
+            bot.send_message(
+                _CONF['telegram']['chat_id'], msg,
+                parse_mode=parse_mode, reply_markup=reply_markup
+            )
         except NetworkError as network_err:
             # Sometimes the telegram server resets the current connection,
             # if this is the case we send the message again.
@@ -559,6 +562,9 @@ def send_msg(msg: str, bot: Bot = None, parse_mode: ParseMode = ParseMode.MARKDO
                 'Got Telegram NetworkError: %s! Trying one more time.',
                 network_err.message
             )
-            bot.send_message(_CONF['telegram']['chat_id'], msg, parse_mode=parse_mode, reply_markup=reply_markup)
+            bot.send_message(
+                _CONF['telegram']['chat_id'], msg,
+                parse_mode=parse_mode, reply_markup=reply_markup
+            )
     except TelegramError as telegram_err:
         logger.warning('Got TelegramError: %s! Giving up on that message.', telegram_err.message)

--- a/freqtrade/tests/test_main.py
+++ b/freqtrade/tests/test_main.py
@@ -137,7 +137,9 @@ def test_create_trade_minimal_amount(default_conf, ticker, mocker):
     mocker.patch.dict('freqtrade.main._CONF', default_conf)
     mocker.patch.multiple('freqtrade.rpc', init=MagicMock(), send_msg=MagicMock())
     mocker.patch('freqtrade.main.get_signal', side_effect=lambda s, t: True)
-    buy_mock = mocker.patch('freqtrade.main.exchange.buy', MagicMock(return_value='mocked_limit_buy'))
+    buy_mock = mocker.patch(
+        'freqtrade.main.exchange.buy', MagicMock(return_value='mocked_limit_buy')
+    )
     mocker.patch.multiple('freqtrade.main.exchange',
                           validate_pairs=MagicMock(),
                           get_ticker=ticker)

--- a/freqtrade/tests/test_misc.py
+++ b/freqtrade/tests/test_misc.py
@@ -60,10 +60,12 @@ def test_parse_args_dynamic_whitelist():
     assert args is not None
     assert args.dynamic_whitelist is 20
 
+
 def test_parse_args_dynamic_whitelist_10():
     args = parse_args(['--dynamic-whitelist', '10'])
     assert args is not None
     assert args.dynamic_whitelist is 10
+
 
 def test_parse_args_dynamic_whitelist_invalid_values():
     with pytest.raises(SystemExit, match=r'2'):

--- a/freqtrade/tests/test_optimize_backtesting.py
+++ b/freqtrade/tests/test_optimize_backtesting.py
@@ -7,6 +7,7 @@ from freqtrade.optimize.backtesting import backtest
 
 import pytest
 
+
 def test_backtest(default_conf, mocker):
     mocker.patch.dict('freqtrade.main._CONF', default_conf)
     exchange._API = Bittrex({'key': '', 'secret': ''})

--- a/freqtrade/tests/test_rpc_telegram.py
+++ b/freqtrade/tests/test_rpc_telegram.py
@@ -341,6 +341,7 @@ def test_performance_handle(
     assert 'Performance' in msg_mock.call_args_list[0][0][0]
     assert '<code>BTC_ETH\t10.05%</code>' in msg_mock.call_args_list[0][0][0]
 
+
 def test_daily_handle(
         default_conf, update, ticker, limit_buy_order, limit_sell_order, mocker):
     mocker.patch.dict('freqtrade.main._CONF', default_conf)
@@ -355,7 +356,7 @@ def test_daily_handle(
                           validate_pairs=MagicMock(),
                           get_ticker=ticker)
     init(default_conf, create_engine('sqlite://'))
-    
+
     # Create some test data
     create_trade(15.0)
     trade = Trade.query.first()
@@ -370,22 +371,22 @@ def test_daily_handle(
     trade.close_date = datetime.utcnow()
     trade.is_open = False
 
-    #try valid data
+    # try valid data
     update.message.text = '/daily 7'
     _daily(bot=MagicMock(), update=update)
     assert msg_mock.call_count == 1
     assert 'Daily' in msg_mock.call_args_list[0][0][0]
     assert str(date.today()) + '  1.50701325 BTC' in msg_mock.call_args_list[0][0][0]
-    
-    #try invalid data
+
+    # try invalid data
     msg_mock.reset_mock()
     update_state(State.RUNNING)
     update.message.text = '/daily -2'
     _daily(bot=MagicMock(), update=update)
     assert msg_mock.call_count == 1
-    assert 'must be an integer greater than 0' in msg_mock.call_args_list[0][0][0]   
-    
-    
+    assert 'must be an integer greater than 0' in msg_mock.call_args_list[0][0][0]
+
+
 def test_count_handle(default_conf, update, ticker, mocker):
     mocker.patch.dict('freqtrade.main._CONF', default_conf)
     mocker.patch('freqtrade.main.get_signal', side_effect=lambda s, t: True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
-#ignore = E226,E302,E41
+#ignore =
 max-line-length = 100
 max-complexity = 12

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[flake8]
+#ignore = E226,E302,E41
+max-line-length = 100
+max-complexity = 12


### PR DESCRIPTION
This PR enforces PEP8 conform code for each CI build to succeed.
I've also fixed all open PEP8 warnings within this PR.

The configuration for `flake8` is specified in `setup.cfg`:
```
[flake8]
#ignore =
max-line-length = 100
max-complexity = 12
```
I would like to keep the `max-line-length = 100`, because 80 is too restrictive on modern screens.
We should lower the `max-complexity` though (default is 10). I had to raise it for now, because `hyeropt.optimizer` and `main()` need to be refactored for this.

Should be merged after #192 