### PR TITLE
Fix hyperopt when using MongoDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 # Freqtrade rules
 freqtrade/tests/testdata/*.json
+hyperopt_conf.py
+config.json
+*.sqlite
+.hyperopt
+logfile.txt
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -75,12 +80,6 @@ target/
 
 # pyenv
 .python-version
-
-config.json
-preprocessor.py
-*.sqlite
-.hyperopt
-logfile.txt
 
 .env
 .venv

--- a/freqtrade/optimize/__init__.py
+++ b/freqtrade/optimize/__init__.py
@@ -5,6 +5,7 @@ import json
 import os
 from typing import Optional, List, Dict
 from freqtrade.exchange import get_ticker_history
+from freqtrade.optimize.hyperopt_conf import hyperopt_optimize_conf
 
 from pandas import DataFrame
 
@@ -13,7 +14,7 @@ from freqtrade.analyze import populate_indicators, parse_ticker_dataframe
 logger = logging.getLogger(__name__)
 
 
-def load_data(pairs: List[str], ticker_interval: int = 5,
+def load_data(ticker_interval: int = 5, pairs: Optional[List[str]] = None,
               refresh_pairs: Optional[bool] = False) -> Dict[str, List]:
     """
     Loads ticker history data for the given parameters
@@ -24,12 +25,14 @@ def load_data(pairs: List[str], ticker_interval: int = 5,
     path = testdata_path()
     result = {}
 
+    _pairs = pairs or hyperopt_optimize_conf()['exchange']['pair_whitelist']
+
     # If the user force the refresh of pairs
     if refresh_pairs:
         logger.info('Download data for all pairs and store them in freqtrade/tests/testsdata')
-        download_pairs(pairs)
+        download_pairs(_pairs)
 
-    for pair in pairs:
+    for pair in _pairs:
         file = '{abspath}/{pair}-{ticker_interval}.json'.format(
             abspath=path,
             pair=pair,

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -16,6 +16,7 @@ from freqtrade import exchange, optimize
 from freqtrade.exchange import Bittrex
 from freqtrade.misc import load_config
 from freqtrade.optimize.backtesting import backtest
+from freqtrade.optimize.hyperopt_conf import hyperopt_optimize_conf
 from freqtrade.vendor.qtpylib.indicators import crossed_above
 
 # Remove noisy log messages
@@ -35,19 +36,8 @@ AVG_PROFIT_TO_BEAT = 0.2
 AVG_DURATION_TO_BEAT = 50
 
 # Configuration and data used by hyperopt
-PROCESSED = []
-OPTIMIZE_CONFIG = {
-    'max_open_trades': 3,
-    'stake_currency': 'BTC',
-    'stake_amount': 0.01,
-    'minimal_roi': {
-        '40':  0.0,
-        '30':  0.01,
-        '20':  0.02,
-        '0':  0.04,
-    },
-    'stoploss': -0.10,
-}
+PROCESSED = optimize.preprocess(optimize.load_data())
+OPTIMIZE_CONFIG = hyperopt_optimize_conf()
 
 # Monkey patch config
 from freqtrade import main  # noqa

--- a/freqtrade/optimize/hyperopt_conf.py
+++ b/freqtrade/optimize/hyperopt_conf.py
@@ -1,0 +1,41 @@
+"""
+File that contains the configuration for Hyperopt
+"""
+
+
+def hyperopt_optimize_conf() -> dict:
+    """
+    This function is used to define which parameters Hyperopt must used.
+    The "pair_whitelist" is only used is your are using Hyperopt with MongoDB,
+    without MongoDB, Hyperopt will use the pair your have set in your config file.
+    :return:
+    """
+    return {
+        'max_open_trades': 3,
+        'stake_currency': 'BTC',
+        'stake_amount': 0.01,
+        "minimal_roi": {
+            '40':  0.0,
+            '30':  0.01,
+            '20':  0.02,
+            '0':  0.04,
+        },
+        'stoploss': -0.10,
+        "bid_strategy": {
+            "ask_last_balance": 0.0
+        },
+        "exchange": {
+            "pair_whitelist": [
+                "BTC_ETH",
+                "BTC_LTC",
+                "BTC_ETC",
+                "BTC_DASH",
+                "BTC_ZEC",
+                "BTC_XLM",
+                "BTC_NXT",
+                "BTC_POWR",
+                "BTC_ADA",
+                "BTC_XMR"
+            ]
+        }
+    }

--- a/freqtrade/tests/test_optimize_hyperopt_config.py
+++ b/freqtrade/tests/test_optimize_hyperopt_config.py
@@ -1,0 +1,16 @@
+# pragma pylint: disable=missing-docstring,W0212
+
+from freqtrade.optimize.hyperopt_conf import hyperopt_optimize_conf
+
+
+def test_hyperopt_optimize_conf():
+    hyperopt_conf = hyperopt_optimize_conf()
+
+    assert "max_open_trades" in hyperopt_conf
+    assert "stake_currency" in hyperopt_conf
+    assert "stake_amount" in hyperopt_conf
+    assert "minimal_roi" in hyperopt_conf
+    assert "stoploss" in hyperopt_conf
+    assert "bid_strategy" in hyperopt_conf
+    assert "exchange" in hyperopt_conf
+    assert "pair_whitelist" in hyperopt_conf['exchange']


### PR DESCRIPTION
This PR fixes the regression of Hyperopt that does not work anymore when MongoDB is used.
This solution returns to the previous version of Hyperopt logic, where a static pairs list was set in the code (previously `freqtrade/optimize/__init__.py`).

## What has changed?
Returned to a static list of pairs (but not anymore in `__init__`. Instead of having to update `freqtrade/optimize/__init__.py` and `freqtrade/optimize/hyperopt.py` to setup HyperOpt as we did previously, I have decided to move the hyperopt configuration into `freqtrade/optimize/hyperopt_conf.py`. This file is untracked, users can modify without risking to push it on git.

## Why a static list of pairs instead of your pairs in your config?
I was not able when HyperOpt uses MongoDB to dynamically pass the params from the config file.
Because the path to the config file can change with the param `-c`, I cannot only read `~/config.json`.

## How looks like the new hyperopt config?
The config is now unified in `freqtrade/optimize/hyperopt_conf.py`
```python
def hyperopt_optimize_conf():
    return {
        'max_open_trades': 3,
        'stake_currency': 'BTC',
        'stake_amount': 0.01,
        "minimal_roi": {
            '40':  0.0,
            '30':  0.01,
            '20':  0.02,
            '0':  0.04,
        },
        'stoploss': -0.10,
        "bid_strategy": {
            "ask_last_balance": 0.0
        },
        "exchange": {
            "pair_whitelist": [
                "BTC_ETH",
                "BTC_LTC",
                "BTC_ETC",
                "BTC_DASH",
                "BTC_ZEC",
                "BTC_XLM",
                "BTC_NXT",
                "BTC_POWR",
                "BTC_ADA",
                "BTC_XMR"
            ]
        }
    }

```