### PR TITLE
Logging improvements to Hyperopt

### DIFF
--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -137,15 +137,10 @@ def optimizer(params):
     _CURRENT_TRIES += 1
 
     result_data = {
-        'trade_count': trade_count,
-        'total_profit': total_profit,
         'loss': loss,
-        'avg_profit': results.profit_percent.mean() * 100.0,
-        'avg_duration': results.duration.mean() * 5,
         'current_tries': _CURRENT_TRIES,
         'total_tries': TOTAL_TRIES,
         'result': result,
-        'results': results
     }
     log_results(result_data)
 
@@ -154,7 +149,7 @@ def optimizer(params):
         'status': STATUS_OK,
         'result': result,
         'total_profit': total_profit,
-        'avg_profit': result_data['avg_profit'],
+        'avg_profit': results.profit_percent.mean() * 100.0,
     }
 
 

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -108,7 +108,7 @@ def log_results(results):
     profit = results['total_profit']
 
     if profit >= TOTAL_PROFIT_TO_BEAT:
-        logger.info('\n{:5d}/{}: {}'.format(current_try, total_tries, result))
+        logger.info('{:5d}/{}: {}'.format(current_try, total_tries, result))
     else:
         print('.', end='')
         sys.stdout.flush()
@@ -223,7 +223,7 @@ def start(args):
     # Initialize logger
     logging.basicConfig(
         level=args.loglevel,
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        format='\n%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     )
 
     logger.info('Using config: %s ...', args.config)

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -11,7 +11,6 @@ from operator import itemgetter
 from hyperopt import fmin, tpe, hp, Trials, STATUS_OK, STATUS_FAIL
 from hyperopt.mongoexp import MongoTrials
 from pandas import DataFrame
-import numpy as np
 
 from freqtrade import exchange, optimize
 from freqtrade.exchange import Bittrex

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -156,8 +156,8 @@ def optimizer(params):
 
 
 def format_results(results: DataFrame):
-    return ('Made {:6d} buys. Average profit {: 5.2f}%. '
-            'Total profit was {: 11.8f} BTC. Average duration {:5.1f} mins.').format(
+    return ('{:6d} trades. Avg profit {: 5.2f}%. '
+            'Total profit {: 11.8f} BTC. Avg duration {:5.1f} mins.').format(
                 len(results.index),
                 results.profit_percent.mean() * 100.0,
                 results.profit_BTC.sum(),

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -97,7 +97,7 @@ SPACE = {
 
 
 def log_results(results):
-    "if results is better than _TO_BEAT show it"
+    """ log results if it is better than any previous evaluation """
     global CURRENT_BEST_LOSS
 
     if results['loss'] < CURRENT_BEST_LOSS:

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -101,13 +101,12 @@ def log_results(results):
     "if results is better than _TO_BEAT show it"
     global CURRENT_BEST_LOSS
 
-    current_try = results['current_tries']
-    total_tries = results['total_tries']
-    result = results['result']
-
     if results['loss'] < CURRENT_BEST_LOSS:
         CURRENT_BEST_LOSS = results['loss']
-        logger.info('{:5d}/{}: {}'.format(current_try, total_tries, result))
+        logger.info('{:5d}/{}: {}'.format(
+            results['current_tries'],
+            results['total_tries'],
+            results['result']))
     else:
         print('.', end='')
         sys.stdout.flush()

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -223,7 +223,7 @@ def start(args):
     # Initialize logger
     logging.basicConfig(
         level=args.loglevel,
-        format='\n%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        format='\n%(message)s',
     )
 
     logger.info('Using config: %s ...', args.config)


### PR DESCRIPTION
- Consider eval with zero trades made a failure. This way I was able to remove all the `nan` filtering etc.
- Log result string only when eval round is better than any before on this run, otherwise prints a dot.
- Make log results go to a new line so they align and are easy to read.
- Shorten and remove noise from logged lines from hyperopt.

After changes the logging normally looks like this:
```
.................
 5803/10000:    160 trades. Avg profit  0.45%. Total profit  0.00682250 BTC. Avg duration  43.6 mins.
.....................................................................................
 5889/10000:    178 trades. Avg profit  0.41%. Total profit  0.00682182 BTC. Avg duration  43.6 mins.
..................................
```