### PR TITLE
catch MIN_TRADE_REQUIREMENT_NOT_MET as non-critical exception

### DIFF
--- a/freqtrade/exchange/bittrex.py
+++ b/freqtrade/exchange/bittrex.py
@@ -45,8 +45,12 @@ class Bittrex(Exchange):
         Validates the given bittrex response
         and raises a ContentDecodingError if a non-fatal issue happened.
         """
-        if response['message'] == 'NO_API_RESPONSE':
-            raise ContentDecodingError('Unable to decode bittrex response')
+        temp_error_messages = [
+            'NO_API_RESPONSE',
+            'MIN_TRADE_REQUIREMENT_NOT_MET',
+        ]
+        if response['message'] in temp_error_messages:
+            raise ContentDecodingError('Got {}'.format(response['message']))
 
     @property
     def fee(self) -> float:

--- a/freqtrade/tests/test_exchange_bittrex.py
+++ b/freqtrade/tests/test_exchange_bittrex.py
@@ -1,0 +1,32 @@
+# pragma pylint: disable=missing-docstring,C0103
+
+import pytest
+from requests.exceptions import ContentDecodingError
+
+from freqtrade.exchange import Bittrex
+
+
+def test_validate_response_success():
+    response = {
+        'message': '',
+        'result': [],
+    }
+    Bittrex._validate_response(response)
+
+
+def test_validate_response_no_api_response():
+    response = {
+        'message': 'NO_API_RESPONSE',
+        'result': None,
+    }
+    with pytest.raises(ContentDecodingError, match=r'.*NO_API_RESPONSE.*'):
+        Bittrex._validate_response(response)
+
+
+def test_validate_response_min_trade_requirement_not_met():
+    response = {
+        'message': 'MIN_TRADE_REQUIREMENT_NOT_MET',
+        'result': None,
+    }
+    with pytest.raises(ContentDecodingError, match=r'.*MIN_TRADE_REQUIREMENT_NOT_MET.*'):
+        Bittrex._validate_response(response)


### PR DESCRIPTION
This PR catches `MIN_TRADE_REQUIREMENT_NOT_MET` as non fatal exception.

The root cause will be fixed in another PR.
Bittrex has a minimum trade value of  100,000 Satoshis [(src)](https://support.bittrex.com/hc/en-us/articles/115003004171-What-are-my-trade-limits-), since our fee calculation is now more precise it could happen that we try to create an invalid LIMIT_BUY order. This happens especially with coins that are only worth some satoshis. @glonlas My assumption is that this happens because of an precision rounding error:
```
Status: Got OperationalException:
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/freqtrade/main.py", line 73, in _process
    state_changed = create_trade(float(_CONF['stake_amount']))
  File "/usr/lib/python3.6/site-packages/freqtrade/main.py", line 224, in create_trade
    order_id = exchange.buy(pair, buy_limit, amount)
  File "/usr/lib/python3.6/site-packages/freqtrade/exchange/__init__.py", line 102, in buy
    return _API.buy(pair, rate, amount)
  File "/usr/lib/python3.6/site-packages/freqtrade/exchange/bittrex.py", line 64, in buy
    amount=amount))
freqtrade.OperationalException: MIN_TRADE_REQUIREMENT_NOT_MET params=(BTC_XDN, 2.85e-06, 350.87719298245617)

Issue /start if you think it is safe to restart.
```