### PR TITLE
execute sell if get_signal OR ROI reached

### DIFF
--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -179,17 +179,20 @@ def handle_trade(trade: Trade) -> bool:
     current_rate = exchange.get_ticker(trade.pair)['bid']
 
     # Check if minimal roi has been reached
-    if not min_roi_reached(trade, current_rate, datetime.utcnow()):
-        return False
+    if min_roi_reached(trade, current_rate, datetime.utcnow()):
+        logger.debug('Executing sell due to ROI ...')
+        execute_sell(trade, current_rate)
+        return True
 
     # Check if sell signal has been enabled and triggered
     if _CONF.get('experimental', {}).get('use_sell_signal'):
         logger.debug('Checking sell_signal ...')
-        if not get_signal(trade.pair, SignalType.SELL):
-            return False
+        if get_signal(trade.pair, SignalType.SELL):
+            logger.debug('Executing sell due to sell signal ...')
+            execute_sell(trade, current_rate)
+            return True
 
-    execute_sell(trade, current_rate)
-    return True
+    return False
 
 
 def get_target_bid(ticker: Dict[str, float]) -> float:

--- a/freqtrade/tests/test_main.py
+++ b/freqtrade/tests/test_main.py
@@ -216,6 +216,7 @@ def test_handle_trade(default_conf, limit_buy_order, limit_sell_order, mocker):
     assert trade.calc_profit() == 0.00006217
     assert trade.close_date is not None
 
+
 def test_handle_trade_roi(default_conf, ticker, limit_buy_order, mocker, caplog):
     default_conf.update({'experimental': {'use_sell_signal': True}})
     mocker.patch.dict('freqtrade.main._CONF', default_conf)
@@ -247,6 +248,7 @@ def test_handle_trade_roi(default_conf, ticker, limit_buy_order, mocker, caplog)
     assert handle_trade(trade)
     assert ('freqtrade', logging.DEBUG, 'Executing sell due to ROI ...') in caplog.record_tuples
 
+
 def test_handle_trade_experimental(default_conf, ticker, limit_buy_order, mocker, caplog):
     default_conf.update({'experimental': {'use_sell_signal': True}})
     mocker.patch.dict('freqtrade.main._CONF', default_conf)
@@ -271,7 +273,8 @@ def test_handle_trade_experimental(default_conf, ticker, limit_buy_order, mocker
     assert value_returned is False
     mocker.patch('freqtrade.main.get_signal', side_effect=lambda s, t: True)
     assert handle_trade(trade)
-    assert ('freqtrade', logging.DEBUG, 'Executing sell due to sell signal ...') in caplog.record_tuples
+    s = 'Executing sell due to sell signal ...'
+    assert ('freqtrade', logging.DEBUG, s) in caplog.record_tuples
 
 
 def test_close_trade(default_conf, ticker, limit_buy_order, limit_sell_order, mocker):


### PR DESCRIPTION
Change the logic, so that a sell-signal is unconditionally executed.
See issue https://github.com/gcarq/freqtrade/issues/166