### PR TITLE
Tests dec29

### DIFF
--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -53,7 +53,7 @@ def trim_dictlist(dl, num):
     new = {}
     for pair, pair_data in dl.items():
         # Can't figure out why -num wont work
-        #new[pair] = pair_data[-num:]
+        # new[pair] = pair_data[-num:]
         new[pair] = pair_data[-100:]
     return new
 

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -71,13 +71,13 @@ def load_data_test(what):
     base = 0.001
     if what == 'raise':
         return {'BTC_UNITEST':
-                [{'T': pair[x]['T'],  # Keep old dates
-                  'V': pair[x]['V'],  # Keep old volume
+                [{'T':  pair[x]['T'],  # Keep old dates
+                  'V':  pair[x]['V'],  # Keep old volume
                   'BV': pair[x]['BV'],  # keep too
-                  'O': x * base,        # But replace O,H,L,C
-                  'H': x * base + 0.0001,
-                  'L': x * base - 0.0001,
-                  'C': x * base} for x in range(0,datalen)]}
+                  'O':  x * base,        # But replace O,H,L,C
+                  'H':  x * base + 0.0001,
+                  'L':  x * base - 0.0001,
+                  'C':  x * base} for x in range(0, datalen)]}
     if what == 'lower':
         return {'BTC_UNITEST':
                 [{'T': pair[x]['T'],  # Keep old dates
@@ -86,9 +86,9 @@ def load_data_test(what):
                   'O': 1 - x * base,        # But replace O,H,L,C
                   'H': 1 - x * base + 0.0001,
                   'L': 1 - x * base - 0.0001,
-                  'C': 1 - x * base} for x in range(0,datalen)]}
+                  'C': 1 - x * base} for x in range(0, datalen)]}
     if what == 'sine':
-        hz = 0.1 # frequency
+        hz = 0.1  # frequency
         return {'BTC_UNITEST':
                 [{'T': pair[x]['T'],  # Keep old dates
                   'V': pair[x]['V'],  # Keep old volume
@@ -96,7 +96,7 @@ def load_data_test(what):
                   'O': math.sin(x*hz) / 1000 + base,        # But replace O,H,L,C
                   'H': math.sin(x*hz) / 1000 + base + 0.0001,
                   'L': math.sin(x*hz) / 1000 + base - 0.0001,
-                  'C': math.sin(x*hz) / 1000 + base} for x in range(0,datalen)]}
+                  'C': math.sin(x*hz) / 1000 + base} for x in range(0, datalen)]}
     return data
 
 

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -1,10 +1,13 @@
 # pragma pylint: disable=missing-docstring,W0212
 
 import math
+#  import json
 import pandas as pd
+# from unittest.mock import MagicMock
 from freqtrade import exchange, optimize
 from freqtrade.exchange import Bittrex
 from freqtrade.optimize.backtesting import backtest, generate_text_table, get_timeframe
+# import freqtrade.optimize.backtesting as backtesting
 
 
 def test_generate_text_table():
@@ -137,3 +140,28 @@ def test_backtest_pricecontours(default_conf, mocker):
     tests = [['raise', 17], ['lower', 0], ['sine', 17]]
     for [contour, numres] in tests:
         simple_backtest(default_conf, contour, numres)
+
+# Please make this work, the load_config needs to be mocked
+# and cleanups.
+# def test_backtest_start(default_conf, mocker):
+#    default_conf['exchange']['pair_whitelist'] = ['BTC_UNITEST']
+#    #mocker.patch.dict('freqtrade.main._CONF', default_conf)
+#    mocker.patch.multiple('freqtrade.misc',
+#                          load_config=MagicMock())
+#
+#    #mocker.patch('freqtrade.misc.load_config', side_effect=lambda s: {})
+#    #mocker.patch('freqtrade.misc.load_config', MagicMock())
+#    #side_effect=lambda s: {})
+#    #mocker.patch('freqtrade.misc.open', mocker.mock_open(
+#    #    read_data=json.dumps(default_conf)
+#    #))
+#
+#
+#    print(default_conf)
+#    args = MagicMock()
+#    args.level = 10
+#    backtesting.start(args)
+#
+#    Check what sideeffect backtstesting has done.
+#    Probably need to capture standard-output and
+#    check for the generated report table.

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -1,7 +1,6 @@
 # pragma pylint: disable=missing-docstring,W0212
 
 import math
-#  import json
 import pandas as pd
 # from unittest.mock import MagicMock
 from freqtrade import exchange, optimize
@@ -56,8 +55,7 @@ def trim_dictlist(dl, num):
     new = {}
     for pair, pair_data in dl.items():
         # Can't figure out why -num wont work
-        # new[pair] = pair_data[-num:]
-        new[pair] = pair_data[-100:]
+        new[pair] = pair_data[num:]
     return new
 
 
@@ -144,23 +142,17 @@ def test_backtest_pricecontours(default_conf, mocker):
 # Please make this work, the load_config needs to be mocked
 # and cleanups.
 # def test_backtest_start(default_conf, mocker):
-#    default_conf['exchange']['pair_whitelist'] = ['BTC_UNITEST']
-#    #mocker.patch.dict('freqtrade.main._CONF', default_conf)
-#    mocker.patch.multiple('freqtrade.misc',
-#                          load_config=MagicMock())
-#
-#    #mocker.patch('freqtrade.misc.load_config', side_effect=lambda s: {})
-#    #mocker.patch('freqtrade.misc.load_config', MagicMock())
-#    #side_effect=lambda s: {})
-#    #mocker.patch('freqtrade.misc.open', mocker.mock_open(
-#    #    read_data=json.dumps(default_conf)
-#    #))
-#
-#
-#    print(default_conf)
-#    args = MagicMock()
-#    args.level = 10
-#    backtesting.start(args)
+#   default_conf['exchange']['pair_whitelist'] = ['BTC_UNITEST']
+#   mocker.patch.dict('freqtrade.main._CONF', default_conf)
+#   # see https://pypi.python.org/pypi/pytest-mock/
+#   # and http://www.voidspace.org.uk/python/mock/patch.html
+#   # No usage example of simple function mocking,
+#   # and no documentation of side_effect
+#   mocker.patch('freqtrade.misc.load_config', new=lambda s, t: {})
+#   args = MagicMock()
+#   args.level = 10
+#   #load_config('foo')
+#   backtesting.start(args)
 #
 #    Check what sideeffect backtstesting has done.
 #    Probably need to capture standard-output and

--- a/freqtrade/tests/test_acl_pair.py
+++ b/freqtrade/tests/test_acl_pair.py
@@ -53,7 +53,7 @@ def test_refresh_whitelist(mocker):
     whitelist = ['BTC_ETH', 'BTC_TKN']
     pairslist = conf['exchange']['pair_whitelist']
     # Ensure all except those in whitelist are removed
-    assert_list_equal(whitelist, pairslist)
+    set(whitelist) == set(pairslist)
 
 
 def test_refresh_whitelist_dynamic(mocker):
@@ -65,7 +65,7 @@ def test_refresh_whitelist_dynamic(mocker):
     whitelist = ['BTC_ETH', 'BTC_TKN']
     refresh_whitelist(whitelist)
     pairslist = conf['exchange']['pair_whitelist']
-    assert_list_equal(whitelist, pairslist)
+    set(whitelist) == set(pairslist)
 
 
 def test_refresh_whitelist_dynamic_empty(mocker):
@@ -78,4 +78,4 @@ def test_refresh_whitelist_dynamic_empty(mocker):
     conf['exchange']['pair_whitelist'] = []
     refresh_whitelist(whitelist)
     pairslist = conf['exchange']['pair_whitelist']
-    assert_list_equal(whitelist, pairslist)
+    set(whitelist) == set(pairslist)

--- a/freqtrade/tests/test_acl_pair.py
+++ b/freqtrade/tests/test_acl_pair.py
@@ -5,13 +5,6 @@ from freqtrade.main import refresh_whitelist
 # perhaps try to anticipate that by using some python package
 
 
-def assert_list_equal(l1, l2):
-    for pair in l1:
-        assert pair in l2
-    for pair in l2:
-        assert pair in l1
-
-
 def whitelist_conf():
     return {
         "stake_currency": "BTC",
@@ -53,7 +46,7 @@ def test_refresh_whitelist(mocker):
     whitelist = ['BTC_ETH', 'BTC_TKN']
     pairslist = conf['exchange']['pair_whitelist']
     # Ensure all except those in whitelist are removed
-    set(whitelist) == set(pairslist)
+    assert set(whitelist) == set(pairslist)
 
 
 def test_refresh_whitelist_dynamic(mocker):
@@ -65,7 +58,7 @@ def test_refresh_whitelist_dynamic(mocker):
     whitelist = ['BTC_ETH', 'BTC_TKN']
     refresh_whitelist(whitelist)
     pairslist = conf['exchange']['pair_whitelist']
-    set(whitelist) == set(pairslist)
+    assert set(whitelist) == set(pairslist)
 
 
 def test_refresh_whitelist_dynamic_empty(mocker):
@@ -78,4 +71,4 @@ def test_refresh_whitelist_dynamic_empty(mocker):
     conf['exchange']['pair_whitelist'] = []
     refresh_whitelist(whitelist)
     pairslist = conf['exchange']['pair_whitelist']
-    set(whitelist) == set(pairslist)
+    assert set(whitelist) == set(pairslist)


### PR DESCRIPTION
There was a bug in my previous PR, which raised the testing time from 16s to 2m.

B.T.W do you know why following wont work? First line uses a num variable holding a positive value.
And by expressing [-num:]  we want to trim an array or list so the last num items are kept.
It wont work and I get the full list (thats where the bug came from).
The fix is just to put a static number.
# Can't figure out why -num wont work
+        # new[pair] = pair_data[-num:]
+        new[pair] = pair_data[-100:]