### PR TITLE
Fix issue #248: missing configuration when executing /forcesell

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ use the `last` price and values between those interpolate between ask and last
 price. Using `ask` price will guarantee quick success in bid, but bot will also
 end up paying more then would probably have been necessary.
 
-`fiat_currency` set the fiat to use for the conversion form coin to 
+`fiat_display_currency` set the fiat to use for the conversion form coin to 
 fiat in Telegram. The valid value are: "AUD", "BRL", "CAD", "CHF", 
 "CLP", "CNY", "CZK", "DKK", "EUR", "GBP", "HKD", "HUF", "IDR", "ILS", 
 "INR", "JPY", "KRW", "MXN", "MYR", "NOK", "NZD", "PHP", "PKR", "PLN",

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -280,6 +280,7 @@ CONF_SCHEMA = {
         'max_open_trades',
         'stake_currency',
         'stake_amount',
+        'fiat_display_currency',
         'dry_run',
         'minimal_roi',
         'bid_strategy',


### PR DESCRIPTION
Fix for issue #248 

## What is the issue
When `telegram._forcesell()`is executed it call `main.execute_sell()` outside of the main context. `main.py` populate the _CONF. However; when `_forcesell()` called `main.execute_sell()` _CONF is empty `{}` and the function cannot find what crypto-currency and fiat currency must be used.

## Comment
This is not a beautiful workaround, I am not proud of it, but a redesigning of main.py and telegram.py will be necessary for a better integration. Any better solution is welcome.