### PR TITLE
Add experimental feature to sell only if we make a profit

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -32,7 +32,8 @@
         ]
     },
     "experimental": {
-        "use_sell_signal": false
+        "use_sell_signal": false,
+        "sell_profit_only": false
     },
     "telegram": {
         "enabled": true,

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -234,7 +234,8 @@ CONF_SCHEMA = {
         'experimental': {
             'type': 'object',
             'properties': {
-                'use_sell_signal': {'type': 'boolean'}
+                'use_sell_signal': {'type': 'boolean'},
+                'sell_profit_only': {'type': 'boolean'}
             }
         },
         'telegram': {

--- a/freqtrade/tests/test_main.py
+++ b/freqtrade/tests/test_main.py
@@ -432,3 +432,99 @@ def test_execute_sell_without_conf(default_conf, ticker, ticker_sell_up, mocker)
     assert '0.00001172' in rpc_mock.call_args_list[-1][0][0]
     assert '(profit: ~6.11%, 0.00006126)' in rpc_mock.call_args_list[-1][0][0]
     assert 'USD' not in rpc_mock.call_args_list[-1][0][0]
+
+
+def test_sell_profit_only_enable_profit(default_conf, limit_buy_order, mocker):
+    default_conf['experimental'] = {}
+    default_conf['experimental']['sell_profit_only'] = True
+
+    mocker.patch.dict('freqtrade.main._CONF', default_conf)
+    mocker.patch('freqtrade.main.get_signal', side_effect=lambda s, t: True)
+    mocker.patch.multiple('freqtrade.rpc', init=MagicMock(), send_msg=MagicMock())
+    mocker.patch.multiple('freqtrade.main.exchange',
+                          validate_pairs=MagicMock(),
+                          get_ticker=MagicMock(return_value={
+                              'bid': 0.00002172,
+                              'ask': 0.00002173,
+                              'last': 0.00002172
+                          }),
+                          buy=MagicMock(return_value='mocked_limit_buy'))
+
+    init(default_conf, create_engine('sqlite://'))
+    create_trade(0.001)
+
+    trade = Trade.query.first()
+    trade.update(limit_buy_order)
+    assert handle_trade(trade) is True
+
+
+def test_sell_profit_only_disable_profit(default_conf, limit_buy_order, mocker):
+    default_conf['experimental'] = {}
+    default_conf['experimental']['sell_profit_only'] = False
+
+    mocker.patch.dict('freqtrade.main._CONF', default_conf)
+    mocker.patch('freqtrade.main.get_signal', side_effect=lambda s, t: True)
+    mocker.patch.multiple('freqtrade.rpc', init=MagicMock(), send_msg=MagicMock())
+    mocker.patch.multiple('freqtrade.main.exchange',
+                          validate_pairs=MagicMock(),
+                          get_ticker=MagicMock(return_value={
+                              'bid': 0.00002172,
+                              'ask': 0.00002173,
+                              'last': 0.00002172
+                          }),
+                          buy=MagicMock(return_value='mocked_limit_buy'))
+
+    init(default_conf, create_engine('sqlite://'))
+    create_trade(0.001)
+
+    trade = Trade.query.first()
+    trade.update(limit_buy_order)
+    assert handle_trade(trade) is True
+
+
+def test_sell_profit_only_enable_loss(default_conf, limit_buy_order, mocker):
+        default_conf['experimental'] = {}
+        default_conf['experimental']['sell_profit_only'] = True
+
+        mocker.patch.dict('freqtrade.main._CONF', default_conf)
+        mocker.patch('freqtrade.main.get_signal', side_effect=lambda s, t: True)
+        mocker.patch.multiple('freqtrade.rpc', init=MagicMock(), send_msg=MagicMock())
+        mocker.patch.multiple('freqtrade.main.exchange',
+                              validate_pairs=MagicMock(),
+                              get_ticker=MagicMock(return_value={
+                                  'bid': 0.00000172,
+                                  'ask': 0.00000173,
+                                  'last': 0.00000172
+                              }),
+                              buy=MagicMock(return_value='mocked_limit_buy'))
+
+        init(default_conf, create_engine('sqlite://'))
+        create_trade(0.001)
+
+        trade = Trade.query.first()
+        trade.update(limit_buy_order)
+        assert handle_trade(trade) is False
+
+
+def test_sell_profit_only_disable_loss(default_conf, limit_buy_order, mocker):
+        default_conf['experimental'] = {}
+        default_conf['experimental']['sell_profit_only'] = False
+
+        mocker.patch.dict('freqtrade.main._CONF', default_conf)
+        mocker.patch('freqtrade.main.get_signal', side_effect=lambda s, t: True)
+        mocker.patch.multiple('freqtrade.rpc', init=MagicMock(), send_msg=MagicMock())
+        mocker.patch.multiple('freqtrade.main.exchange',
+                              validate_pairs=MagicMock(),
+                              get_ticker=MagicMock(return_value={
+                                  'bid': 0.00000172,
+                                  'ask': 0.00000173,
+                                  'last': 0.00000172
+                              }),
+                              buy=MagicMock(return_value='mocked_limit_buy'))
+
+        init(default_conf, create_engine('sqlite://'))
+        create_trade(0.001)
+
+        trade = Trade.query.first()
+        trade.update(limit_buy_order)
+        assert handle_trade(trade) is True


### PR DESCRIPTION
Have you been upset with the bot when your selling strategy sells a trade with a big loss (e.g -29%)?
Did you wonder if you could force the bot to retain a losing trade until it goes up later (days, weeks)?

## Problem
When you activate the experimental feature `use_sell_signal` it overrides your `stoploss` and `minimal_roi`. Means the bot can with a loss even if you have setup it to only sell with profit.

In the following example, my configuration is
```json
{
    "max_open_trades": 10,
    "stake_currency": "BTC",
    "stake_amount": 0.002,
    "fiat_display_currency": "EUR",
    "dry_run": true,
    "minimal_roi": {
        "30":  0.01,
        "20":  0.02,
        "0":  0.04
    },
    "stoploss": -1.00,
    ...
   "experimental": {
        "use_sell_signal": true
    },
   ...
}
```
We see the `stoploss` is enable only if the bot loses -100% of the trade, and the `minimal_roi` sells everything above +1% if the trade is older than 30min.

Means It will never sell at a loss. However, the result of the simulation (below) shows that it continues to sell negative trades.

![selling-with-loss](https://user-images.githubusercontent.com/1137839/34458702-2676b1e4-ed91-11e7-84d7-ba6f25be9ce7.png)


## Goal of the PR
This PR solve this issue by adding an experimental parameter to force the bot to not sell trade that will generate a loss.

## New config parameter "sell_profit_only"
In the `config.json` within the `experimental` list, you can enable or disable the feature "Sell with profit only".

**Default value in the config**
```json
"experimental": {
        ...
        "sell_profit_only": false
    },
```

## Logic in detail
The logic implemented in this PR is very simple

In `main.py::handle_trade()` a new rule forces the bot to ignore a sell if the profit is negative.
```python
# Experimental: Check if the trade is profitable before selling it (avoid selling at loss)
    if _CONF.get('experimental', {}).get('sell_profit_only'):
        logger.debug('Checking if trade is profitable ...')
        if trade.calc_profit(rate=current_rate) <= 0:
            return False
```

## Unitests
This PR is unit tested.