### PR TITLE
Populate indicators under RLock

### DIFF
--- a/freqtrade/analyze.py
+++ b/freqtrade/analyze.py
@@ -5,6 +5,7 @@ import logging
 from datetime import timedelta
 from enum import Enum
 from typing import List, Dict
+from threading import RLock
 
 import arrow
 import talib.abstract as ta
@@ -14,7 +15,7 @@ from freqtrade.exchange import get_ticker_history
 from freqtrade.vendor.qtpylib.indicators import awesome_oscillator, crossed_above
 
 logger = logging.getLogger(__name__)
-
+lock = RLock()
 
 class SignalType(Enum):
     """ Enum to distinguish between buy and sell signals """
@@ -121,10 +122,12 @@ def analyze_ticker(ticker_history: List[Dict]) -> DataFrame:
     add several TA indicators and buy signal to it
     :return DataFrame with ticker data and indicator data
     """
-    dataframe = parse_ticker_dataframe(ticker_history)
+    with lock:
+        dataframe = parse_ticker_dataframe(ticker_history)
     dataframe = populate_indicators(dataframe)
     dataframe = populate_buy_trend(dataframe)
     dataframe = populate_sell_trend(dataframe)
+
     return dataframe
 
 


### PR DESCRIPTION
After introducing asyncio for `get_signal`, we have gotten numerous exceptions e.g. #255. The root cause seems to be that not all the indicators are thread safe, and it seems that they try to access other dataframes data during execution. Populate the dataframe indicators under `RLock`.

To prove that the bittrex data isn't malformed, and causing these exceptions, you can run the bot in debugger (e.g. in vs code)
- add a break point [here](https://github.com/gcarq/freqtrade/blob/fix/populate-df/freqtrade/analyze.py#L152)
- when breakpoint is hit `with open('ticker_hist.json', 'w') as f: json.dump(ticker_hist, f)`  
  
Then in python shell
```
import json
import freqtrade.analyze
with open ('ticker_hist.json', 'r') as f: ticker_hist = json.load(f)
df = freqtrade.analyze.analyze_ticker(ticker_hist)
```

Before I start updating the breaking tests, would this be a way to fix this issue or does someone have a better idea?