### PR TITLE
Add pair_blacklist in config.json.example

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -29,6 +29,9 @@
             "BTC_POWR",
             "BTC_ADA",
             "BTC_XMR"
+        ],
+        "pair_blacklist": [
+            "BTC_DOGE"
         ]
     },
     "experimental": {


### PR DESCRIPTION
Very simple PR. Add the new  `pair_blacklist` param in the `config.json.example`.
Otherwise, it will become a hidden feature.