### PR TITLE
Removing tilde and change profit to loss when negative profit is made

### DIFF
--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -137,8 +137,9 @@ def execute_sell(trade: Trade, limit: float) -> None:
             _CONF['stake_currency'],
             _CONF['fiat_display_currency']
         )
-        message += '` (profit: ~{profit_percent:.2f}%, {profit_coin:.8f} {coin}`' \
+        message += '` ({gain}: {profit_percent:.2f}%, {profit_coin:.8f} {coin}`' \
                    '` / {profit_fiat:.3f} {fiat})`'.format(
+                        gain="profit" if fmt_exp_profit > 0 else "loss",
                         profit_percent=fmt_exp_profit,
                         profit_coin=profit_trade,
                         coin=_CONF['stake_currency'],
@@ -148,7 +149,8 @@ def execute_sell(trade: Trade, limit: float) -> None:
     # Because telegram._forcesell does not have the configuration
     # Ignore the FIAT value and does not show the stake_currency as well
     else:
-        message += '` (profit: ~{profit_percent:.2f}%, {profit_coin:.8f})`'.format(
+        message += '` ({gain}: {profit_percent:.2f}%, {profit_coin:.8f})`'.format(
+            gain="profit" if fmt_exp_profit > 0 else "loss",
             profit_percent=fmt_exp_profit,
             profit_coin=profit_trade
         )

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -240,7 +240,7 @@ def test_forcesell_handle(default_conf, update, ticker, ticker_sell_up, mocker):
     assert rpc_mock.call_count == 2
     assert 'Selling [BTC/ETH]' in rpc_mock.call_args_list[-1][0][0]
     assert '0.00001172' in rpc_mock.call_args_list[-1][0][0]
-    assert 'profit: ~6.11%, 0.00006126' in rpc_mock.call_args_list[-1][0][0]
+    assert 'profit: 6.11%, 0.00006126' in rpc_mock.call_args_list[-1][0][0]
     assert '0.919 USD' in rpc_mock.call_args_list[-1][0][0]
 
 
@@ -277,7 +277,7 @@ def test_forcesell_down_handle(default_conf, update, ticker, ticker_sell_down, m
     assert rpc_mock.call_count == 2
     assert 'Selling [BTC/ETH]' in rpc_mock.call_args_list[-1][0][0]
     assert '0.00001044' in rpc_mock.call_args_list[-1][0][0]
-    assert 'profit: ~-5.48%, -0.00005492' in rpc_mock.call_args_list[-1][0][0]
+    assert 'loss: -5.48%, -0.00005492' in rpc_mock.call_args_list[-1][0][0]
     assert '-0.824 USD' in rpc_mock.call_args_list[-1][0][0]
 
 
@@ -332,7 +332,7 @@ def test_forcesell_all_handle(default_conf, update, ticker, mocker):
     assert rpc_mock.call_count == 4
     for args in rpc_mock.call_args_list:
         assert '0.00001098' in args[0][0]
-        assert 'profit: ~-0.59%, -0.00000591 BTC' in args[0][0]
+        assert 'loss: -0.59%, -0.00000591 BTC' in args[0][0]
         assert '-0.089 USD' in args[0][0]
 
 

--- a/freqtrade/tests/test_main.py
+++ b/freqtrade/tests/test_main.py
@@ -362,7 +362,7 @@ def test_execute_sell_up(default_conf, ticker, ticker_sell_up, mocker):
     assert rpc_mock.call_count == 2
     assert 'Selling [BTC/ETH]' in rpc_mock.call_args_list[-1][0][0]
     assert '0.00001172' in rpc_mock.call_args_list[-1][0][0]
-    assert 'profit: ~6.11%, 0.00006126' in rpc_mock.call_args_list[-1][0][0]
+    assert 'profit: 6.11%, 0.00006126' in rpc_mock.call_args_list[-1][0][0]
     assert '0.919 USD' in rpc_mock.call_args_list[-1][0][0]
 
 
@@ -399,7 +399,7 @@ def test_execute_sell_down(default_conf, ticker, ticker_sell_down, mocker):
     assert rpc_mock.call_count == 2
     assert 'Selling [BTC/ETH]' in rpc_mock.call_args_list[-1][0][0]
     assert '0.00001044' in rpc_mock.call_args_list[-1][0][0]
-    assert 'profit: ~-5.48%, -0.00005492' in rpc_mock.call_args_list[-1][0][0]
+    assert 'loss: -5.48%, -0.00005492' in rpc_mock.call_args_list[-1][0][0]
     assert '-0.824 USD' in rpc_mock.call_args_list[-1][0][0]
 
 
@@ -430,5 +430,5 @@ def test_execute_sell_without_conf(default_conf, ticker, ticker_sell_up, mocker)
     assert rpc_mock.call_count == 2
     assert 'Selling [BTC/ETH]' in rpc_mock.call_args_list[-1][0][0]
     assert '0.00001172' in rpc_mock.call_args_list[-1][0][0]
-    assert '(profit: ~6.11%, 0.00006126)' in rpc_mock.call_args_list[-1][0][0]
+    assert '(profit: 6.11%, 0.00006126)' in rpc_mock.call_args_list[-1][0][0]
     assert 'USD' not in rpc_mock.call_args_list[-1][0][0]


### PR DESCRIPTION
This PR fix issue #273 and a request made on Slack to change profit to loss when profit is in fact negative