### PR TITLE
Improve backtesting result formatting

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -41,27 +41,29 @@ def generate_text_table(
     Generates and returns a text table for the given backtest data and the results dataframe
     :return: pretty printed table with tabulate as str
     """
+    floatfmt = ('s', 'd', '.2f', '.8f', '.1f')
     tabular_data = []
-    headers = ['pair', 'buy count', 'avg profit', 'total profit', 'avg duration']
+    headers = ['pair', 'buy count', 'avg profit %',
+               'total profit ' + stake_currency, 'avg duration']
     for pair in data:
         result = results[results.currency == pair]
         tabular_data.append([
             pair,
             len(result.index),
-            '{:.2f}%'.format(result.profit_percent.mean() * 100.0),
-            '{:.08f} {}'.format(result.profit_BTC.sum(), stake_currency),
-            '{:.2f}'.format(result.duration.mean() * ticker_interval),
+            result.profit_percent.mean() * 100.0,
+            result.profit_BTC.sum(),
+            result.duration.mean() * ticker_interval,
         ])
 
     # Append Total
     tabular_data.append([
         'TOTAL',
         len(results.index),
-        '{:.2f}%'.format(results.profit_percent.mean() * 100.0),
-        '{:.08f} {}'.format(results.profit_BTC.sum(), stake_currency),
-        '{:.2f}'.format(results.duration.mean() * ticker_interval),
+        results.profit_percent.mean() * 100.0,
+        results.profit_BTC.sum(),
+        results.duration.mean() * ticker_interval,
     ])
-    return tabulate(tabular_data, headers=headers)
+    return tabulate(tabular_data, headers=headers, floatfmt=floatfmt)
 
 
 def backtest(stake_amount: float, processed: Dict[str, DataFrame],

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -175,6 +175,6 @@ def start(args):
         config['stake_amount'], preprocess(data), max_open_trades, args.realistic_simulation
     )
     logger.info(
-        '\n====================== BACKTESTING REPORT ======================================\n%s',
+        '\n====================== BACKTESTING REPORT ================================\n%s',
         generate_text_table(data, results, config['stake_currency'], args.ticker_interval)
     )

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -18,11 +18,12 @@ def test_generate_text_table():
             'duration': [10, 30]
         }
     )
+    print(generate_text_table({'BTC_ETH': {}}, results, 'BTC', 5))
     assert generate_text_table({'BTC_ETH': {}}, results, 'BTC', 5) == (
-        'pair       buy count  avg profit    total profit      avg duration\n'
-        '-------  -----------  ------------  --------------  --------------\n'
-        'BTC_ETH            2  15.00%        0.60000000 BTC             100\n'
-        'TOTAL              2  15.00%        0.60000000 BTC             100')
+        'pair       buy count    avg profit %    total profit BTC    avg duration\n'
+        '-------  -----------  --------------  ------------------  --------------\n'
+        'BTC_ETH            2           15.00          0.60000000           100.0\n'
+        'TOTAL              2           15.00          0.60000000           100.0')
 
 
 def test_get_timeframe():


### PR DESCRIPTION
`tabulate` has nice aligning of numbers but we were not using them because the columns contained `%` and `BTC`. I moved those to column headers. `tabulate` also has support for formatting so I could clean up the code a little.

Typical result now looks like:
```
====================== BACKTESTING REPORT ================================
pair         buy count    avg profit %    total profit BTC    avg duration
---------  -----------  --------------  ------------------  --------------
BTC_NAV            139            1.45          0.00601754            45.2
BTC_DGB            530           -0.09         -0.00154370            56.2
BTC_LSK            220           -0.25         -0.00164937            38.5
BTC_TRIG           157            1.12          0.00523099            44.3
BTC_XMR            229           -0.29         -0.00197289            45.5
BTC_XVG           1205            0.21          0.00728093            41.2
BTC_TRST           217           -0.46         -0.00302171            33.4
BTC_SWIFT          178           -1.52         -0.00813867            45.2
BTC_XEM            214           -0.48         -0.00299644            39.7
BTC_WAVES          214           -0.05         -0.00031410            31.5
BTC_ARK            236           -0.09         -0.00065559            32.2
BTC_XEL            121            1.70          0.00614261            31.1
BTC_SNT             78            0.44          0.00099623            58.9
BTC_PTOY           141            1.01          0.00424139            28.9
BTC_NXS            274           -0.45         -0.00370351            65.9
TOTAL             4153            0.05          0.00591371            43.4
```