### PR TITLE
Backtesting speed optimizations

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -84,7 +84,8 @@ def backtest(stake_amount: float, processed: Dict[str, DataFrame],
         ticker = populate_sell_trend(populate_buy_trend(pair_data))
         # for each buy point
         lock_pair_until = None
-        for row in ticker[ticker.buy == 1].itertuples(index=True):
+        buy_subset = ticker[ticker.buy == 1][['buy', 'open', 'close', 'date', 'sell']]
+        for row in buy_subset.itertuples(index=True):
             if realistic:
                 if lock_pair_until is not None and row.Index <= lock_pair_until:
                     continue
@@ -106,7 +107,8 @@ def backtest(stake_amount: float, processed: Dict[str, DataFrame],
             )
 
             # calculate win/lose forwards from buy point
-            for row2 in ticker[row.Index + 1:].itertuples(index=True):
+            sell_subset = ticker[row.Index + 1:][['close', 'date', 'sell']]
+            for row2 in sell_subset.itertuples(index=True):
                 if max_open_trades > 0:
                     # Increase trade_count_lock for every iteration
                     trade_count_lock[row2.date] = trade_count_lock.get(row2.date, 0) + 1

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -5,6 +5,7 @@ import pandas as pd
 # from unittest.mock import MagicMock
 from freqtrade import exchange, optimize
 from freqtrade.exchange import Bittrex
+from freqtrade.optimize import preprocess
 from freqtrade.optimize.backtesting import backtest, generate_text_table, get_timeframe
 # import freqtrade.optimize.backtesting as backtesting
 
@@ -27,7 +28,7 @@ def test_generate_text_table():
 
 
 def test_get_timeframe():
-    data = optimize.load_data(ticker_interval=1, pairs=['BTC_UNITEST'])
+    data = preprocess(optimize.load_data(ticker_interval=1, pairs=['BTC_UNITEST']))
     min_date, max_date = get_timeframe(data)
     assert min_date.isoformat() == '2017-11-04T23:02:00+00:00'
     assert max_date.isoformat() == '2017-11-14T22:59:00+00:00'


### PR DESCRIPTION
This PR makes two improvements to backtesting speed:
- Faster date range printing
- Less data passing in the core loop

First is 136x faster than the original, on my laptop it reduces roughly 7 seconds off from backtest run.

Second picks just the columns we need from the dataframe before converting them to tuples. This makes the tuples faster to create and reduces garbage collection too.

The whole backtesting run on my laptop went from:

`python freqtrade/main.py backtesting  76.48s user 0.48s system 98% cpu 1:17.90 total`

to

`python freqtrade/main.py backtesting  51.60s user 0.91s system 98% cpu 53.067 total`

Total time was reduced by 32%.