### PR TITLE
The /status table command was getting slower when we had multiple trades opened

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -46,6 +46,11 @@ python3 ./freqtrade/main.py backtesting --realistic-simulation --refresh-pairs-c
 python3 ./freqtrade/main.py backtesting --realistic-simulation --live
 ```
 
+**Using a different on-disk ticker-data source**
+```bash
+python3 ./freqtrade/main.py backtesting --datadir freqtrade/tests/testdata-20180101
+```
+
 For help about backtesting usage, please refer to 
 [Backtesting commands](#backtesting-commands).
 

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -26,6 +26,9 @@ optional arguments:
                         specify configuration file (default: config.json)
   -v, --verbose         be verbose
   --version             show program's version number and exit
+  -dd PATH, --datadir PATH
+                        Path is from where backtesting and hyperopt will load the
+                        ticker data files (default freqdata/tests/testdata).
   --dynamic-whitelist [INT]
                         dynamically generate and update whitelist based on 24h
                         BaseVolume (Default 20 currencies)

--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -163,6 +163,11 @@ We strongly recommend to use `screen` to prevent any connection loss.
 python3 ./freqtrade/main.py -c config.json hyperopt
 ```
 
+### Execute hyperopt with different ticker-data source
+If you would like to learn parameters using an alternate ticke-data that
+you have on-disk, use the --datadir PATH option. Default hyperopt will
+use data from directory freqtrade/tests/testdata.
+
 ### Hyperopt with MongoDB
 Hyperopt with MongoDB, is like Hyperopt under steroids. As you saw by
 executing the previous command is the execution takes a long time. 

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -134,8 +134,8 @@ def get_balances():
     return _API.get_balances()
 
 
-def get_ticker(pair: str) -> dict:
-    return _API.get_ticker(pair)
+def get_ticker(pair: str, refresh: Optional[bool] = True) -> dict:
+    return _API.get_ticker(pair, refresh)
 
 
 @cached(TTLCache(maxsize=100, ttl=30))

--- a/freqtrade/exchange/bittrex.py
+++ b/freqtrade/exchange/bittrex.py
@@ -97,8 +97,8 @@ class Bittrex(Exchange):
         return data['result']
 
     def get_ticker(self, pair: str, refresh: Optional[bool] = True) -> dict:
-        data = _API.get_ticker(pair.replace('_', '-'))
         if refresh or pair not in self.cached_ticker.keys():
+            data = _API.get_ticker(pair.replace('_', '-'))
             if not data['success']:
                 Bittrex._validate_response(data)
                 raise OperationalException('{message} params=({pair})'.format(

--- a/freqtrade/exchange/bittrex.py
+++ b/freqtrade/exchange/bittrex.py
@@ -98,7 +98,7 @@ class Bittrex(Exchange):
 
     def get_ticker(self, pair: str, refresh: Optional[bool] = True) -> dict:
         data = _API.get_ticker(pair.replace('_', '-'), refresh)
-        if refresh:
+        if refresh or pair not in self.cached_ticker.keys():
             if not data['success']:
                 Bittrex._validate_response(data)
                 raise OperationalException('{message} params=({pair})'.format(

--- a/freqtrade/exchange/bittrex.py
+++ b/freqtrade/exchange/bittrex.py
@@ -97,7 +97,7 @@ class Bittrex(Exchange):
         return data['result']
 
     def get_ticker(self, pair: str, refresh: Optional[bool] = True) -> dict:
-        data = _API.get_ticker(pair.replace('_', '-'), refresh)
+        data = _API.get_ticker(pair.replace('_', '-'))
         if refresh or pair not in self.cached_ticker.keys():
             if not data['success']:
                 Bittrex._validate_response(data)

--- a/freqtrade/exchange/interface.py
+++ b/freqtrade/exchange/interface.py
@@ -66,7 +66,7 @@ class Exchange(ABC):
         """
         Gets ticker for given pair.
         :param pair: Pair as str, format: BTC_ETC
-        :param refresh: Shall we query a new value or a cached value is enought
+        :param refresh: Shall we query a new value or a cached value is enough
         :return: dict, format: {
             'bid': float,
             'ask': float,

--- a/freqtrade/exchange/interface.py
+++ b/freqtrade/exchange/interface.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 
 class Exchange(ABC):
@@ -62,10 +62,11 @@ class Exchange(ABC):
         """
 
     @abstractmethod
-    def get_ticker(self, pair: str) -> dict:
+    def get_ticker(self, pair: str, refresh: Optional[bool] = True) -> dict:
         """
         Gets ticker for given pair.
         :param pair: Pair as str, format: BTC_ETC
+        :param refresh: Shall we query a new value or a cached value is enought
         :return: dict, format: {
             'bid': float,
             'ask': float,

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -126,6 +126,14 @@ def parse_args(args: List[str], description: str):
         dest='dry_run_db',
     )
     parser.add_argument(
+        '-dd', '--datadir',
+        help='path to backtest data (default freqdata/tests/testdata',
+        dest='datadir',
+        default='freqtrade/tests/testdata',
+        type=str,
+        metavar='PATH',
+    )
+    parser.add_argument(
         '--dynamic-whitelist',
         help='dynamically generate and update whitelist based on 24h BaseVolume (Default 20 currencies)',  # noqa
         dest='dynamic_whitelist',

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -162,7 +162,7 @@ def start(args):
             data[pair] = exchange.get_ticker_history(pair, args.ticker_interval)
     else:
         logger.info('Using local backtesting data (using whitelist in given config) ...')
-        data = optimize.load_data(pairs=pairs, ticker_interval=args.ticker_interval,
+        data = optimize.load_data(args.datadir, pairs=pairs, ticker_interval=args.ticker_interval,
                                   refresh_pairs=args.refresh_pairs)
 
         logger.info('Using stake_currency: %s ...', config['stake_currency'])

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -36,7 +36,7 @@ CURRENT_BEST_LOSS = 100
 EXPECTED_MAX_PROFIT = 3.85
 
 # Configuration and data used by hyperopt
-PROCESSED = optimize.preprocess(optimize.load_data())
+PROCESSED = None  # optimize.preprocess(optimize.load_data())
 OPTIMIZE_CONFIG = hyperopt_optimize_conf()
 
 # Monkey patch config
@@ -224,7 +224,7 @@ def start(args):
     config = load_config(args.config)
     pairs = config['exchange']['pair_whitelist']
     PROCESSED = optimize.preprocess(optimize.load_data(
-        pairs=pairs, ticker_interval=args.ticker_interval))
+        args.datadir, pairs=pairs, ticker_interval=args.ticker_interval))
 
     if args.mongodb:
         logger.info('Using mongodb ...')

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -140,7 +140,7 @@ def _status(bot: Bot, update: Update) -> None:
             if trade.open_order_id:
                 order = exchange.get_order(trade.open_order_id)
             # calculate profit and send message to user
-            current_rate = exchange.get_ticker(trade.pair)['bid']
+            current_rate = exchange.get_ticker(trade.pair, False)['bid']
             current_profit = trade.calc_profit_percent(current_rate)
             fmt_close_profit = '{:.2f}%'.format(
                 round(trade.close_profit * 100, 2)
@@ -193,7 +193,7 @@ def _status_table(bot: Bot, update: Update) -> None:
         trades_list = []
         for trade in trades:
             # calculate profit and send message to user
-            current_rate = exchange.get_ticker(trade.pair)['bid']
+            current_rate = exchange.get_ticker(trade.pair, False)['bid']
             trades_list.append([
                 trade.id,
                 trade.pair,
@@ -301,7 +301,7 @@ def _profit(bot: Bot, update: Update) -> None:
             profit_closed_percent.append(profit_percent)
         else:
             # Get current rate
-            current_rate = exchange.get_ticker(trade.pair)['bid']
+            current_rate = exchange.get_ticker(trade.pair, False)['bid']
             profit_percent = trade.calc_profit_percent(rate=current_rate)
 
         profit_all_coin.append(trade.calc_profit(rate=Decimal(trade.close_rate or current_rate)))
@@ -579,7 +579,7 @@ def _exec_forcesell(trade: Trade) -> None:
             return
 
     # Get current rate and execute sell
-    current_rate = exchange.get_ticker(trade.pair)['bid']
+    current_rate = exchange.get_ticker(trade.pair, False)['bid']
     from freqtrade.main import execute_sell
     execute_sell(trade, current_rate)
 

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -177,7 +177,6 @@ def test_get_ticker(mocker, ticker):
 
     # if not caching the result we should get the same ticker
     ticker = get_ticker(pair='BTC_ETH', refresh=False)
-    print(str(ticker))
     assert ticker['bid'] == 0.00001098
     assert ticker['ask'] == 0.00001099
 

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -181,7 +181,7 @@ def test_get_ticker(mocker, ticker):
     assert ticker['bid'] == 0.00001098
     assert ticker['ask'] == 0.00001099
 
-    # force ticker refresh 
+    # force ticker refresh
     ticker = get_ticker(pair='BTC_ETH', refresh=True)
     assert ticker['bid'] == 0.5
     assert ticker['ask'] == 1

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -162,24 +162,27 @@ def test_get_balances_prod(default_conf, mocker):
 def test_get_ticker(mocker, ticker):
 
     api_mock = MagicMock()
-    api_mock.get_ticker = MagicMock(return_value=ticker())
-    mocker.patch('freqtrade.exchange._API', api_mock)
+    tick = {"success": True, 'result': {'Bid': 0.00001098, 'Ask': 0.00001099, 'Last': 0.0001}}
+    api_mock.get_ticker = MagicMock(return_value=tick)
+    mocker.patch('freqtrade.exchange.bittrex._API', api_mock)
 
     ticker = get_ticker(pair='BTC_ETH')
     assert ticker['bid'] == 0.00001098
     assert ticker['ask'] == 0.00001099
 
+    # change the ticker
+    tick = {"success": True, 'result': {"Bid": 0.5, "Ask": 1, "Last": 42}}
+    api_mock.get_ticker = MagicMock(return_value=tick)
+    mocker.patch('freqtrade.exchange.bittrex._API', api_mock)
+
     # if not caching the result we should get the same ticker
     ticker = get_ticker(pair='BTC_ETH', refresh=False)
+    print(str(ticker))
     assert ticker['bid'] == 0.00001098
     assert ticker['ask'] == 0.00001099
 
-    # change the ticker
-    api_mock.get_ticker = MagicMock(return_value={"bid": 0, "ask": 1})
-    mocker.patch('freqtrade.exchange._API', api_mock)
-
     ticker = get_ticker(pair='BTC_ETH', refresh=True)
-    assert ticker['bid'] == 0
+    assert ticker['bid'] == 0.5
     assert ticker['ask'] == 1
 
 

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -166,6 +166,7 @@ def test_get_ticker(mocker, ticker):
     api_mock.get_ticker = MagicMock(return_value=tick)
     mocker.patch('freqtrade.exchange.bittrex._API', api_mock)
 
+    # retrieve original ticker
     ticker = get_ticker(pair='BTC_ETH')
     assert ticker['bid'] == 0.00001098
     assert ticker['ask'] == 0.00001099
@@ -180,6 +181,7 @@ def test_get_ticker(mocker, ticker):
     assert ticker['bid'] == 0.00001098
     assert ticker['ask'] == 0.00001099
 
+    # force ticker refresh 
     ticker = get_ticker(pair='BTC_ETH', refresh=True)
     assert ticker['bid'] == 0.5
     assert ticker['ask'] == 1

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -11,7 +11,8 @@ from freqtrade.exchange import init, validate_pairs, buy, sell, get_balance, get
 
 
 def test_init(default_conf, mocker, caplog):
-    mocker.patch('freqtrade.exchange.validate_pairs', side_effect=lambda s: True)
+    mocker.patch('freqtrade.exchange.validate_pairs',
+                 side_effect=lambda s: True)
     init(config=default_conf)
     assert ('freqtrade.exchange',
             logging.INFO,
@@ -25,7 +26,7 @@ def test_init_exception(default_conf, mocker):
     with pytest.raises(
             OperationalException,
             match='Exchange {} is not supported'.format(default_conf['exchange']['name'])):
-                init(config=default_conf)
+        init(config=default_conf)
 
 
 def test_validate_pairs(default_conf, mocker):
@@ -49,7 +50,8 @@ def test_validate_pairs_not_available(default_conf, mocker):
 
 def test_validate_pairs_not_compatible(default_conf, mocker):
     api_mock = MagicMock()
-    api_mock.get_markets = MagicMock(return_value=['BTC_ETH', 'BTC_TKN', 'BTC_TRST', 'BTC_SWT'])
+    api_mock.get_markets = MagicMock(
+        return_value=['BTC_ETH', 'BTC_TKN', 'BTC_TRST', 'BTC_SWT'])
     default_conf['stake_currency'] = 'ETH'
     mocker.patch('freqtrade.exchange._API', api_mock)
     mocker.patch.dict('freqtrade.exchange._CONF', default_conf)
@@ -79,7 +81,8 @@ def test_buy_dry_run(default_conf, mocker):
 
 def test_buy_prod(default_conf, mocker):
     api_mock = MagicMock()
-    api_mock.buy = MagicMock(return_value='dry_run_buy_{}'.format(randint(0, 10**6)))
+    api_mock.buy = MagicMock(
+        return_value='dry_run_buy_{}'.format(randint(0, 10**6)))
     mocker.patch('freqtrade.exchange._API', api_mock)
 
     default_conf['dry_run'] = False
@@ -97,7 +100,8 @@ def test_sell_dry_run(default_conf, mocker):
 
 def test_sell_prod(default_conf, mocker):
     api_mock = MagicMock()
-    api_mock.sell = MagicMock(return_value='dry_run_sell_{}'.format(randint(0, 10**6)))
+    api_mock.sell = MagicMock(
+        return_value='dry_run_sell_{}'.format(randint(0, 10**6)))
     mocker.patch('freqtrade.exchange._API', api_mock)
 
     default_conf['dry_run'] = False
@@ -141,7 +145,8 @@ def test_get_balances_prod(default_conf, mocker):
     }
 
     api_mock = MagicMock()
-    api_mock.get_balances = MagicMock(return_value=[balance_item, balance_item, balance_item])
+    api_mock.get_balances = MagicMock(
+        return_value=[balance_item, balance_item, balance_item])
     mocker.patch('freqtrade.exchange._API', api_mock)
 
     default_conf['dry_run'] = False
@@ -163,7 +168,19 @@ def test_get_ticker(mocker, ticker):
     ticker = get_ticker(pair='BTC_ETH')
     assert ticker['bid'] == 0.00001098
     assert ticker['ask'] == 0.00001099
+
+    # if not caching the result we should get the same ticker
+    ticker = get_ticker(pair='BTC_ETH', refresh=False)
     assert ticker['bid'] == 0.00001098
+    assert ticker['ask'] == 0.00001099
+
+    # change the ticker
+    api_mock.get_ticker = MagicMock(return_value={"bid": 0, "ask": 1})
+    mocker.patch('freqtrade.exchange._API', api_mock)
+
+    ticker = get_ticker(pair='BTC_ETH', refresh=True)
+    assert ticker['bid'] == 0
+    assert ticker['ask'] == 1
 
 
 def test_cancel_order_dry_run(default_conf, mocker):
@@ -174,7 +191,8 @@ def test_cancel_order_dry_run(default_conf, mocker):
 
 
 def test_get_name(default_conf, mocker):
-    mocker.patch('freqtrade.exchange.validate_pairs', side_effect=lambda s: True)
+    mocker.patch('freqtrade.exchange.validate_pairs',
+                 side_effect=lambda s: True)
     default_conf['exchange']['name'] = 'bittrex'
     init(default_conf)
 
@@ -182,7 +200,8 @@ def test_get_name(default_conf, mocker):
 
 
 def test_get_fee(default_conf, mocker):
-    mocker.patch('freqtrade.exchange.validate_pairs', side_effect=lambda s: True)
+    mocker.patch('freqtrade.exchange.validate_pairs',
+                 side_effect=lambda s: True)
     init(default_conf)
 
     assert get_fee() == 0.0025

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -32,7 +32,7 @@ def test_generate_text_table():
 
 def test_get_timeframe():
     data = preprocess(optimize.load_data(
-        ticker_interval=1, pairs=['BTC_UNITEST']))
+        None, ticker_interval=1, pairs=['BTC_UNITEST']))
     min_date, max_date = get_timeframe(data)
     assert min_date.isoformat() == '2017-11-04T23:02:00+00:00'
     assert max_date.isoformat() == '2017-11-14T22:59:00+00:00'
@@ -42,7 +42,7 @@ def test_backtest(default_conf, mocker):
     mocker.patch.dict('freqtrade.main._CONF', default_conf)
     exchange._API = Bittrex({'key': '', 'secret': ''})
 
-    data = optimize.load_data(ticker_interval=5, pairs=['BTC_ETH'])
+    data = optimize.load_data(None, ticker_interval=5, pairs=['BTC_ETH'])
     results = backtest(default_conf['stake_amount'],
                        optimize.preprocess(data), 10, True)
     assert not results.empty
@@ -53,7 +53,7 @@ def test_backtest_1min_ticker_interval(default_conf, mocker):
     exchange._API = Bittrex({'key': '', 'secret': ''})
 
     # Run a backtesting for an exiting 5min ticker_interval
-    data = optimize.load_data(ticker_interval=1, pairs=['BTC_UNITEST'])
+    data = optimize.load_data(None, ticker_interval=1, pairs=['BTC_UNITEST'])
     results = backtest(default_conf['stake_amount'],
                        optimize.preprocess(data), 1, True)
     assert not results.empty
@@ -67,7 +67,7 @@ def trim_dictlist(dl, num):
 
 
 def load_data_test(what):
-    data = optimize.load_data(ticker_interval=1, pairs=['BTC_UNITEST'])
+    data = optimize.load_data(None, ticker_interval=1, pairs=['BTC_UNITEST'])
     data = trim_dictlist(data, -100)
     pair = data['BTC_UNITEST']
     datalen = len(pair)
@@ -124,7 +124,7 @@ def simple_backtest(config, contour, num_results):
 
 def test_backtest2(default_conf, mocker):
     mocker.patch.dict('freqtrade.main._CONF', default_conf)
-    data = optimize.load_data(ticker_interval=5, pairs=['BTC_ETH'])
+    data = optimize.load_data(None, ticker_interval=5, pairs=['BTC_ETH'])
     results = backtest(default_conf['stake_amount'],
                        optimize.preprocess(data), 10, True)
     assert not results.empty
@@ -149,8 +149,8 @@ def test_backtest_pricecontours(default_conf, mocker):
         simple_backtest(default_conf, contour, numres)
 
 
-def mocked_load_data(pairs=[], ticker_interval=0, refresh_pairs=False):
-    tickerdata = optimize.load_tickerdata_file('BTC_UNITEST', 1)
+def mocked_load_data(datadir, pairs=[], ticker_interval=0, refresh_pairs=False):
+    tickerdata = optimize.load_tickerdata_file(datadir, 'BTC_UNITEST', 1)
     pairdata = {'BTC_UNITEST': tickerdata}
     return trim_dictlist(pairdata, -100)
 
@@ -165,6 +165,7 @@ def test_backtest_start(default_conf, mocker, caplog):
     args.ticker_interval = 1
     args.level = 10
     args.live = False
+    args.datadir = None
     backtesting.start(args)
     # check the logs, that will contain the backtest result
     exists = ['Using max_open_trades: 1 ...',

--- a/freqtrade/tests/optimize/test_optimize.py
+++ b/freqtrade/tests/optimize/test_optimize.py
@@ -5,7 +5,7 @@ import logging
 from shutil import copyfile
 from freqtrade import exchange, optimize
 from freqtrade.exchange import Bittrex
-from freqtrade.optimize.__init__ import testdata_path, download_pairs,\
+from freqtrade.optimize.__init__ import make_testdata_path, download_pairs,\
      download_backtesting_testdata, load_tickerdata_file
 
 # Change this if modifying BTC_UNITEST testdatafile
@@ -51,7 +51,7 @@ def test_load_data_5min_ticker(default_conf, ticker_history, mocker, caplog):
 
     file = 'freqtrade/tests/testdata/BTC_ETH-5.json'
     _backup_file(file, copy_file=True)
-    optimize.load_data(pairs=['BTC_ETH'])
+    optimize.load_data(None, pairs=['BTC_ETH'])
     assert os.path.isfile(file) is True
     assert ('freqtrade.optimize',
             logging.INFO,
@@ -68,7 +68,7 @@ def test_load_data_1min_ticker(default_conf, ticker_history, mocker, caplog):
 
     file = 'freqtrade/tests/testdata/BTC_ETH-1.json'
     _backup_file(file, copy_file=True)
-    optimize.load_data(ticker_interval=1, pairs=['BTC_ETH'])
+    optimize.load_data(None, ticker_interval=1, pairs=['BTC_ETH'])
     assert os.path.isfile(file) is True
     assert ('freqtrade.optimize',
             logging.INFO,
@@ -85,7 +85,7 @@ def test_load_data_with_new_pair_1min(default_conf, ticker_history, mocker, capl
 
     file = 'freqtrade/tests/testdata/BTC_MEME-1.json'
     _backup_file(file)
-    optimize.load_data(ticker_interval=1, pairs=['BTC_MEME'])
+    optimize.load_data(None, ticker_interval=1, pairs=['BTC_MEME'])
     assert os.path.isfile(file) is True
     assert ('freqtrade.optimize',
             logging.INFO,
@@ -95,7 +95,7 @@ def test_load_data_with_new_pair_1min(default_conf, ticker_history, mocker, capl
 
 
 def test_testdata_path():
-    assert os.path.join('freqtrade', 'tests', 'testdata') in testdata_path()
+    assert os.path.join('freqtrade', 'tests', 'testdata') in make_testdata_path(None)
 
 
 def test_download_pairs(default_conf, ticker_history, mocker):
@@ -113,7 +113,7 @@ def test_download_pairs(default_conf, ticker_history, mocker):
     _backup_file(file2_1)
     _backup_file(file2_5)
 
-    assert download_pairs(pairs=['BTC-MEME', 'BTC-CFI']) is True
+    assert download_pairs(None, pairs=['BTC-MEME', 'BTC-CFI']) is True
 
     assert os.path.isfile(file1_1) is True
     assert os.path.isfile(file1_5) is True
@@ -139,7 +139,7 @@ def test_download_pairs_exception(default_conf, ticker_history, mocker, caplog):
     _backup_file(file1_1)
     _backup_file(file1_5)
 
-    download_pairs(pairs=['BTC-MEME'])
+    download_pairs(None, pairs=['BTC-MEME'])
     # clean files freshly downloaded
     _clean_test_file(file1_1)
     _clean_test_file(file1_5)
@@ -157,7 +157,7 @@ def test_download_backtesting_testdata(default_conf, ticker_history, mocker):
     # Download a 1 min ticker file
     file1 = 'freqtrade/tests/testdata/BTC_XEL-1.json'
     _backup_file(file1)
-    download_backtesting_testdata(pair="BTC-XEL", interval=1)
+    download_backtesting_testdata(None, pair="BTC-XEL", interval=1)
     assert os.path.isfile(file1) is True
     _clean_test_file(file1)
 
@@ -165,12 +165,12 @@ def test_download_backtesting_testdata(default_conf, ticker_history, mocker):
     file2 = 'freqtrade/tests/testdata/BTC_STORJ-5.json'
     _backup_file(file2)
 
-    download_backtesting_testdata(pair="BTC-STORJ", interval=5)
+    download_backtesting_testdata(None, pair="BTC-STORJ", interval=5)
     assert os.path.isfile(file2) is True
     _clean_test_file(file2)
 
 
 def test_load_tickerdata_file():
-    assert not load_tickerdata_file('BTC_UNITEST', 7)
-    tickerdata = load_tickerdata_file('BTC_UNITEST', 1)
+    assert not load_tickerdata_file(None, 'BTC_UNITEST', 7)
+    tickerdata = load_tickerdata_file(None, 'BTC_UNITEST', 1)
     assert _btc_unittest_length == len(tickerdata)

--- a/freqtrade/tests/test_dataframe.py
+++ b/freqtrade/tests/test_dataframe.py
@@ -7,7 +7,7 @@ _pairs = ['BTC_ETH']
 
 
 def load_dataframe_pair(pairs):
-    ld = freqtrade.optimize.load_data(ticker_interval=5, pairs=pairs)
+    ld = freqtrade.optimize.load_data(None, ticker_interval=5, pairs=pairs)
     assert isinstance(ld, dict)
     assert isinstance(pairs[0], str)
     dataframe = ld[pairs[0]]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ scikit-learn==0.19.1
 scipy==1.0.0
 jsonschema==2.6.0
 numpy==1.14.0
-TA-Lib==0.4.10
+TA-Lib==0.4.14
 pytest==3.3.2
 pytest-mock==1.6.3
 pytest-cov==2.5.1


### PR DESCRIPTION
For each trades opened, the telegram bot was fetching the last bid price making a request towards bittrex.com. This PR allow the use of cached values retrieved in the _process function and fix issue #278. 

By opportunity all calls to get the bid prices where replaced in the Bot.