### PR TITLE
Add trades count foreach pair in performance command

### DIFF
--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -476,10 +476,10 @@ def _performance(bot: Bot, update: Update) -> None:
         .order_by(text('profit_sum DESC')) \
         .all()
 
-    stats = '\n'.join('{index}.\t<code>[{pair}]({url})\t{profit:.2f}% ({count})</code>'.format(
+    stats = '\n'.join('{index}.\t<code>{pair}\t{profit:.2f}% ({count})</code>'.format(
         index=i + 1,
         pair=pair,
-        url=exchange.get_pair_detail_url(pair),
+        #url=exchange.get_pair_detail_url(pair),
         profit=round(rate * 100, 2),
         count=count
     ) for i, (pair, rate, count) in enumerate(pair_rates))

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -469,17 +469,19 @@ def _performance(bot: Bot, update: Update) -> None:
         send_msg('`trader is not running`', bot=bot)
         return
 
-    pair_rates = Trade.session.query(Trade.pair, func.sum(Trade.close_profit).label('profit_sum')) \
+    pair_rates = Trade.session.query(Trade.pair, func.sum(Trade.close_profit).label('profit_sum'),
+                                     func.count(Trade.pair).label('count')) \
         .filter(Trade.is_open.is_(False)) \
         .group_by(Trade.pair) \
         .order_by(text('profit_sum DESC')) \
         .all()
 
-    stats = '\n'.join('{index}.\t<code>{pair}\t{profit:.2f}%</code>'.format(
+    stats = '\n'.join('{index}.\t<code>{pair}\t{profit:.2f}% ({count})</code>'.format(
         index=i + 1,
         pair=pair,
-        profit=round(rate * 100, 2)
-    ) for i, (pair, rate) in enumerate(pair_rates))
+        profit=round(rate * 100, 2),
+        count=count
+    ) for i, (pair, rate, count) in enumerate(pair_rates))
 
     message = '<b>Performance:</b>\n{}'.format(stats)
     logger.debug(message)

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -479,7 +479,6 @@ def _performance(bot: Bot, update: Update) -> None:
     stats = '\n'.join('{index}.\t<code>{pair}\t{profit:.2f}% ({count})</code>'.format(
         index=i + 1,
         pair=pair,
-        #url=exchange.get_pair_detail_url(pair),
         profit=round(rate * 100, 2),
         count=count
     ) for i, (pair, rate, count) in enumerate(pair_rates))

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -476,9 +476,10 @@ def _performance(bot: Bot, update: Update) -> None:
         .order_by(text('profit_sum DESC')) \
         .all()
 
-    stats = '\n'.join('{index}.\t<code>{pair}\t{profit:.2f}% ({count})</code>'.format(
+    stats = '\n'.join('{index}.\t<code>[{pair}]({url})\t{profit:.2f}% ({count})</code>'.format(
         index=i + 1,
         pair=pair,
+        url=exchange.get_pair_detail_url(pair),
         profit=round(rate * 100, 2),
         count=count
     ) for i, (pair, rate, count) in enumerate(pair_rates))

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -404,7 +404,7 @@ def test_performance_handle(
     _performance(bot=MagicMock(), update=update)
     assert msg_mock.call_count == 1
     assert 'Performance' in msg_mock.call_args_list[0][0][0]
-    assert '<code>BTC_ETH\t6.20% (1)</code>' in msg_mock.call_args_list[0][0][0]
+    assert '<code>[BTC_ETH](https://www.bittrex.com/Market/Index?MarketName=BTC-ETH)\t6.20% (1)</code>' in msg_mock.call_args_list[0][0][0]
 
 
 def test_daily_handle(

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -404,7 +404,7 @@ def test_performance_handle(
     _performance(bot=MagicMock(), update=update)
     assert msg_mock.call_count == 1
     assert 'Performance' in msg_mock.call_args_list[0][0][0]
-    assert '<code>BTC_ETH\t6.20%</code>' in msg_mock.call_args_list[0][0][0]
+    assert '<code>BTC_ETH\t6.20% (1)</code>' in msg_mock.call_args_list[0][0][0]
 
 
 def test_daily_handle(

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -400,11 +400,10 @@ def test_performance_handle(
 
     trade.close_date = datetime.utcnow()
     trade.is_open = False
-
     _performance(bot=MagicMock(), update=update)
     assert msg_mock.call_count == 1
     assert 'Performance' in msg_mock.call_args_list[0][0][0]
-    assert '<code>[BTC_ETH](https://www.bittrex.com/Market/Index?MarketName=BTC-ETH)\t6.20% (1)</code>' in msg_mock.call_args_list[0][0][0]
+    assert '<code>BTC_ETH\t6.20% (1)</code>' in msg_mock.call_args_list[0][0][0]
 
 
 def test_daily_handle(


### PR DESCRIPTION
this PR aim is to add the number of trades of each pair, a nicer evolution could be to have both the number of trades with a profit and thoose with a loss.
