### PR TITLE
Added order timeout handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,6 @@ optional arguments:
                         "tradesv3.dry_run.sqlite" instead of memory DB. Work
                         only if dry_run is enabled.
 ```
-
 More details on:
 - [How to run the bot](https://github.com/gcarq/freqtrade/blob/develop/docs/bot-usage.md#bot-commands)
 - [How to use Backtesting](https://github.com/gcarq/freqtrade/blob/develop/docs/bot-usage.md#backtesting-commands)
@@ -197,4 +196,3 @@ To run this bot we recommend you a cloud instance with a minimum of:
 - [TA-Lib](https://mrjbq7.github.io/ta-lib/install.html)
 - [virtualenv](https://virtualenv.pypa.io/en/stable/installation/) (Recommended)
 - [Docker](https://www.docker.com/products/docker) (Recommended)
-

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ optional arguments:
                         "tradesv3.dry_run.sqlite" instead of memory DB. Work
                         only if dry_run is enabled.
 ```
+
 More details on:
 - [How to run the bot](https://github.com/gcarq/freqtrade/blob/develop/docs/bot-usage.md#bot-commands)
 - [How to use Backtesting](https://github.com/gcarq/freqtrade/blob/develop/docs/bot-usage.md#backtesting-commands)
@@ -196,3 +197,4 @@ To run this bot we recommend you a cloud instance with a minimum of:
 - [TA-Lib](https://mrjbq7.github.io/ta-lib/install.html)
 - [virtualenv](https://virtualenv.pypa.io/en/stable/installation/) (Recommended)
 - [Docker](https://www.docker.com/products/docker) (Recommended)
+

--- a/config.json.example
+++ b/config.json.example
@@ -11,7 +11,7 @@
         "0":  0.04
     },
     "stoploss": -0.10,
-    "opentradetimeout": 600,
+    "unfilledtimeout": 600,
     "bid_strategy": {
         "ask_last_balance": 0.0
     },

--- a/config.json.example
+++ b/config.json.example
@@ -11,6 +11,7 @@
         "0":  0.04
     },
     "stoploss": -0.10,
+    "opentradetimeout": 600,
     "bid_strategy": {
         "ask_last_balance": 0.0
     },

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,7 @@ The table below will list all configuration parameters.
 | `dry_run` | true | Yes | Define if the bot must be in Dry-run or production mode. 
 | `minimal_roi` | See below | Yes | Set the threshold in percent the bot will use to sell a trade. More information below. 
 | `stoploss` | -0.10 | No | Value of the stoploss in percent used by the bot. More information below. 
+| `opentradetimeout` | 0 | No | The number of minutes until an open trade will be cancelled.
 | `bid_strategy.ask_last_balance` | 0.0 | Yes | Set the bidding price. More information below.
 | `exchange.name` | bittrex | Yes | Name of the exchange class to use.
 | `exchange.key` | key | No | API key to use for the exchange. Only required when you are in production mode.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,7 @@ The table below will list all configuration parameters.
 | `dry_run` | true | Yes | Define if the bot must be in Dry-run or production mode. 
 | `minimal_roi` | See below | Yes | Set the threshold in percent the bot will use to sell a trade. More information below. 
 | `stoploss` | -0.10 | No | Value of the stoploss in percent used by the bot. More information below. 
-| `opentradetimeout` | 0 | No | The number of minutes until an open trade will be cancelled.
+| `unfilledtimeout` | 0 | No | How long (in minutes) the bot will wait for an unfilled order to complete, after which the order will be cancelled.
 | `bid_strategy.ask_last_balance` | 0.0 | Yes | Set the bidding price. More information below.
 | `exchange.name` | bittrex | Yes | Name of the exchange class to use.
 | `exchange.key` | key | No | API key to use for the exchange. Only required when you are in production mode.

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -5,7 +5,7 @@ import logging
 import sys
 import time
 import traceback
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Dict, Optional, List
 
 import requests
@@ -98,6 +98,10 @@ def _process(nb_assets: Optional[int] = 0) -> bool:
                 # Check if we can sell our current pair
                 state_changed = handle_trade(trade) or state_changed
 
+            if 'opentradetimeout' in _CONF and trade.open_order_id:
+                # Check and handle any timed out trades
+                check_handle_timedout(trade)
+
             Trade.session.flush()
     except (requests.exceptions.RequestException, json.JSONDecodeError) as error:
         logger.warning(
@@ -113,6 +117,50 @@ def _process(nb_assets: Optional[int] = 0) -> bool:
         logger.exception('Got OperationalException. Stopping trader ...')
         update_state(State.STOPPED)
     return state_changed
+
+
+def check_handle_timedout(trade: Trade) -> bool:
+    """
+    Check if a trade is timed out and cancel if neccessary
+    :param trade: Trade instance
+    :return: True if the trade is timed out, false otherwise
+    """
+    timeoutthreashold = datetime.utcnow() - timedelta(minutes=_CONF['opentradetimeout'])
+    order = exchange.get_order(trade.open_order_id)
+
+    if trade.open_date < timeoutthreashold:
+        # Buy timeout - cancel order
+        exchange.cancel_order(trade.open_order_id)
+        if order['remaining'] == order['amount']:
+            # if trade is not partially completed, just delete the trade
+            Trade.session.delete(trade)
+            Trade.session.flush()
+            logger.info('Buy order timeout for %s.', trade)
+        else:
+            # if trade is partially complete, edit the stake details for the trade
+            # and close the order
+            trade.amount = order['amount'] - order['remaining']
+            trade.stake_amount = trade.amount * trade.open_rate
+            trade.open_order_id = None
+            logger.info('Partial buy order timeout for %s.', trade)
+        return True
+    elif trade.close_date is not None and trade.close_date < timeoutthreashold:
+        # Sell timeout - cancel order and update trade
+        if order['remaining'] == order['amount']:
+            # if trade is not partially completed, just cancel the trade
+            exchange.cancel_order(trade.open_order_id)
+            trade.close_rate = None
+            trade.close_profit = None
+            trade.close_date = None
+            trade.is_open = True
+            trade.open_order_id = None
+            logger.info('Sell order timeout for %s.', trade)
+            return True
+        else:
+            # TODO: figure out how to handle partially complete sell orders
+            return False
+    else:
+        return False
 
 
 def execute_sell(trade: Trade, limit: float) -> None:

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -98,7 +98,7 @@ def _process(nb_assets: Optional[int] = 0) -> bool:
                 # Check if we can sell our current pair
                 state_changed = handle_trade(trade) or state_changed
 
-            if 'opentradetimeout' in _CONF and trade.open_order_id:
+            if 'unfilledtimeout' in _CONF and trade.open_order_id:
                 # Check and handle any timed out trades
                 check_handle_timedout(trade)
 
@@ -125,7 +125,7 @@ def check_handle_timedout(trade: Trade) -> bool:
     :param trade: Trade instance
     :return: True if the trade is timed out, false otherwise
     """
-    timeoutthreashold = datetime.utcnow() - timedelta(minutes=_CONF['opentradetimeout'])
+    timeoutthreashold = datetime.utcnow() - timedelta(minutes=_CONF['unfilledtimeout'])
     order = exchange.get_order(trade.open_order_id)
 
     if trade.open_date < timeoutthreashold:

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -218,7 +218,7 @@ CONF_SCHEMA = {
             'minProperties': 1
         },
         'stoploss': {'type': 'number', 'maximum': 0, 'exclusiveMaximum': True},
-        'opentradetimeout': {'type': 'integer', 'minimum': 0},
+        'unfilledtimeout': {'type': 'integer', 'minimum': 0},
         'bid_strategy': {
             'type': 'object',
             'properties': {

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -218,6 +218,7 @@ CONF_SCHEMA = {
             'minProperties': 1
         },
         'stoploss': {'type': 'number', 'maximum': 0, 'exclusiveMaximum': True},
+        'opentradetimeout': {'type': 'integer', 'minimum': 0},
         'bid_strategy': {
             'type': 'object',
             'properties': {

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -25,6 +25,7 @@ def default_conf():
             "0":  0.04
         },
         "stoploss": -0.10,
+        "opentradetimeout": 600,
         "bid_strategy": {
             "ask_last_balance": 0.0
         },

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -25,7 +25,7 @@ def default_conf():
             "0":  0.04
         },
         "stoploss": -0.10,
-        "opentradetimeout": 600,
+        "unfilledtimeout": 600,
         "bid_strategy": {
             "ask_last_balance": 0.0
         },


### PR DESCRIPTION
For issues #150 and #229.

Added the ability to cancel any orders that exceed the parameter `opentradetimeout`.

Works for incomplete buy and sell orders

Works for partially completed buy orders (sets the stake_amount to what was fulfilled at the time)

No handling for partially complete sell orders - not sure how to handle these. Suggestions welcome :)