### PR TITLE
Add stoploss, sell_only_profit and use_sell_signal conf parameters to backtest function

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -118,23 +118,23 @@ def backtest(stake_amount: float, processed: Dict[str, DataFrame],
                 current_profit_percent = trade.calc_profit_percent(rate=row2.close)
                 if (sell_profit_only and current_profit_percent < 0):
                     continue
-                if min_roi_reached(trade, row2.close, row2.date)
-                or (row2.sell == 1 and use_sell_signal)
-                or current_profit_percent <= stoploss:
-                    current_profit_btc = trade.calc_profit(rate=row2.close)
-                    lock_pair_until = row2.Index
+                if min_roi_reached(trade, row2.close, row2.date) or \
+                    (row2.sell == 1 and use_sell_signal) or \
+                        current_profit_percent <= stoploss:
+                        current_profit_btc = trade.calc_profit(rate=row2.close)
+                        lock_pair_until = row2.Index
 
-                    trades.append(
-                        (
-                            pair,
-                            current_profit_percent,
-                            current_profit_btc,
-                            row2.Index - row.Index,
-                            current_profit_btc > 0,
-                            current_profit_btc < 0
+                        trades.append(
+                            (
+                                pair,
+                                current_profit_percent,
+                                current_profit_btc,
+                                row2.Index - row.Index,
+                                current_profit_btc > 0,
+                                current_profit_btc < 0
+                            )
                         )
-                    )
-                    break
+                        break
     labels = ['currency', 'profit_percent', 'profit_BTC', 'duration', 'profit', 'loss']
     return DataFrame.from_records(trades, columns=labels)
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -41,7 +41,7 @@ def generate_text_table(
     floatfmt = ('s', 'd', '.2f', '.8f', '.1f')
     tabular_data = []
     headers = ['pair', 'buy count', 'avg profit %',
-               'total profit ' + stake_currency, 'avg duration', 'profit','loss']
+               'total profit ' + stake_currency, 'avg duration', 'profit', 'loss']
     for pair in data:
         result = results[results.currency == pair]
         tabular_data.append([
@@ -62,14 +62,14 @@ def generate_text_table(
         results.profit_BTC.sum(),
         results.duration.mean() * ticker_interval,
         results.profit.sum(),
-        results.loss.sum(),
-        
+        results.loss.sum()
     ])
     return tabulate(tabular_data, headers=headers, floatfmt=floatfmt)
 
 
 def backtest(stake_amount: float, processed: Dict[str, DataFrame],
-             max_open_trades: int = 0, realistic: bool = True, sell_profit_only: bool = False, stoploss: int = -1.00, use_sell_signal: bool = False) -> DataFrame:
+             max_open_trades: int = 0, realistic: bool = True, sell_profit_only: bool = False,
+             stoploss: int = -1.00, use_sell_signal: bool = False) -> DataFrame:
     """
     Implements backtesting functionality
     :param stake_amount: btc amount to use for each trade
@@ -116,9 +116,11 @@ def backtest(stake_amount: float, processed: Dict[str, DataFrame],
                     trade_count_lock[row2.date] = trade_count_lock.get(row2.date, 0) + 1
 
                 current_profit_percent = trade.calc_profit_percent(rate=row2.close)
-                if (sell_profit_only and current_profit_percent < 0) :
+                if (sell_profit_only and current_profit_percent < 0):
                     continue
-                if min_roi_reached(trade, row2.close, row2.date) or (row2.sell == 1 and use_sell_signal) or current_profit_percent <= stoploss:
+                if min_roi_reached(trade, row2.close, row2.date)
+                or (row2.sell == 1 and use_sell_signal)
+                or current_profit_percent <= stoploss:
                     current_profit_btc = trade.calc_profit(rate=row2.close)
                     lock_pair_until = row2.Index
 
@@ -127,13 +129,13 @@ def backtest(stake_amount: float, processed: Dict[str, DataFrame],
                             pair,
                             current_profit_percent,
                             current_profit_btc,
-                            row2.Index - row.Index,  
+                            row2.Index - row.Index,
                             current_profit_btc > 0,
                             current_profit_btc < 0
                         )
                     )
                     break
-    labels = ['currency', 'profit_percent', 'profit_BTC', 'duration', 'profit','loss']
+    labels = ['currency', 'profit_percent', 'profit_BTC', 'duration', 'profit', 'loss']
     return DataFrame.from_records(trades, columns=labels)
 
 
@@ -181,7 +183,9 @@ def start(args):
 
     # Execute backtest and print results
     results = backtest(
-        config['stake_amount'], preprocessed, max_open_trades, args.realistic_simulation, config.get('experimental',{}).get('sell_profit_only', False), config.get('stoploss'), config.get('experimental',{}).get('use_sell_signal',False)
+        config['stake_amount'], preprocessed, max_open_trades, args.realistic_simulation,
+        config.get('experimental', {}).get('sell_profit_only', False), config.get('stoploss'),
+        config.get('experimental', {}).get('use_sell_signal', False)
     )
     logger.info(
         '\n====================== BACKTESTING REPORT ================================\n%s',

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -41,7 +41,7 @@ def generate_text_table(
     floatfmt = ('s', 'd', '.2f', '.8f', '.1f')
     tabular_data = []
     headers = ['pair', 'buy count', 'avg profit %',
-               'total profit ' + stake_currency, 'avg duration']
+               'total profit ' + stake_currency, 'avg duration', 'profit','loss']
     for pair in data:
         result = results[results.currency == pair]
         tabular_data.append([
@@ -50,6 +50,8 @@ def generate_text_table(
             result.profit_percent.mean() * 100.0,
             result.profit_BTC.sum(),
             result.duration.mean() * ticker_interval,
+            result.profit.sum(),
+            result.loss.sum()
         ])
 
     # Append Total
@@ -59,12 +61,15 @@ def generate_text_table(
         results.profit_percent.mean() * 100.0,
         results.profit_BTC.sum(),
         results.duration.mean() * ticker_interval,
+        results.profit.sum(),
+        results.loss.sum(),
+        
     ])
     return tabulate(tabular_data, headers=headers, floatfmt=floatfmt)
 
 
 def backtest(stake_amount: float, processed: Dict[str, DataFrame],
-             max_open_trades: int = 0, realistic: bool = True, sell_profit_only: bool = False, stoploss: int = -1.00) -> DataFrame:
+             max_open_trades: int = 0, realistic: bool = True, sell_profit_only: bool = False, stoploss: int = -1.00, use_sell_signal: bool = False) -> DataFrame:
     """
     Implements backtesting functionality
     :param stake_amount: btc amount to use for each trade
@@ -113,7 +118,7 @@ def backtest(stake_amount: float, processed: Dict[str, DataFrame],
                 current_profit_percent = trade.calc_profit_percent(rate=row2.close)
                 if (sell_profit_only and current_profit_percent < 0) :
                     continue
-                if min_roi_reached(trade, row2.close, row2.date) or row2.sell == 1 or current_profit_percent < stoploss:
+                if min_roi_reached(trade, row2.close, row2.date) or (row2.sell == 1 and use_sell_signal) or current_profit_percent <= stoploss:
                     current_profit_btc = trade.calc_profit(rate=row2.close)
                     lock_pair_until = row2.Index
 
@@ -122,11 +127,13 @@ def backtest(stake_amount: float, processed: Dict[str, DataFrame],
                             pair,
                             current_profit_percent,
                             current_profit_btc,
-                            row2.Index - row.Index
+                            row2.Index - row.Index,  
+                            current_profit_btc > 0,
+                            current_profit_btc < 0
                         )
                     )
                     break
-    labels = ['currency', 'profit_percent', 'profit_BTC', 'duration']
+    labels = ['currency', 'profit_percent', 'profit_BTC', 'duration', 'profit','loss']
     return DataFrame.from_records(trades, columns=labels)
 
 
@@ -174,7 +181,7 @@ def start(args):
 
     # Execute backtest and print results
     results = backtest(
-        config['stake_amount'], preprocessed, max_open_trades, args.realistic_simulation, config.get('experimental',{}).get('sell_profit_only', False), config.get('stoploss')
+        config['stake_amount'], preprocessed, max_open_trades, args.realistic_simulation, config.get('experimental',{}).get('sell_profit_only', False), config.get('stoploss'), config.get('experimental',{}).get('use_sell_signal',False)
     )
     logger.info(
         '\n====================== BACKTESTING REPORT ================================\n%s',

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -17,8 +17,8 @@ def test_generate_text_table():
             'profit_percent': [0.1, 0.2],
             'profit_BTC': [0.2, 0.4],
             'duration': [10, 30],
-            'profit': [2,0],
-            'loss': [0,0]
+            'profit': [2, 0],
+            'loss': [0, 0]
         }
     )
     print(generate_text_table({'BTC_ETH': {}}, results, 'BTC', 5))

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -16,15 +16,17 @@ def test_generate_text_table():
             'currency': ['BTC_ETH', 'BTC_ETH'],
             'profit_percent': [0.1, 0.2],
             'profit_BTC': [0.2, 0.4],
-            'duration': [10, 30]
+            'duration': [10, 30],
+            'profit': [2,0],
+            'loss': [0,0]
         }
     )
     print(generate_text_table({'BTC_ETH': {}}, results, 'BTC', 5))
     assert generate_text_table({'BTC_ETH': {}}, results, 'BTC', 5) == (
-        'pair       buy count    avg profit %    total profit BTC    avg duration\n'
-        '-------  -----------  --------------  ------------------  --------------\n'
-        'BTC_ETH            2           15.00          0.60000000           100.0\n'
-        'TOTAL              2           15.00          0.60000000           100.0')
+        'pair       buy count    avg profit %    total profit BTC    avg duration    profit    loss\n'
+        '-------  -----------  --------------  ------------------  --------------  --------  ------\n'
+        'BTC_ETH            2           15.00          0.60000000           100.0         2       0\n'
+        'TOTAL              2           15.00          0.60000000           100.0         2       0')
 
 
 def test_get_timeframe():

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -23,14 +23,15 @@ def test_generate_text_table():
     )
     print(generate_text_table({'BTC_ETH': {}}, results, 'BTC', 5))
     assert generate_text_table({'BTC_ETH': {}}, results, 'BTC', 5) == (
-        'pair       buy count    avg profit %    total profit BTC    avg duration    profit    loss\n'
-        '-------  -----------  --------------  ------------------  --------------  --------  ------\n'
-        'BTC_ETH            2           15.00          0.60000000           100.0         2       0\n'
-        'TOTAL              2           15.00          0.60000000           100.0         2       0')
+        'pair       buy count    avg profit %    total profit BTC    avg duration    profit    loss\n'  # noqa
+        '-------  -----------  --------------  ------------------  --------------  --------  ------\n'  # noqa
+        'BTC_ETH            2           15.00          0.60000000           100.0         2       0\n'  # noqa
+        'TOTAL              2           15.00          0.60000000           100.0         2       0')  # noqa
 
 
 def test_get_timeframe():
-    data = preprocess(optimize.load_data(ticker_interval=1, pairs=['BTC_UNITEST']))
+    data = preprocess(optimize.load_data(
+        ticker_interval=1, pairs=['BTC_UNITEST']))
     min_date, max_date = get_timeframe(data)
     assert min_date.isoformat() == '2017-11-04T23:02:00+00:00'
     assert max_date.isoformat() == '2017-11-14T22:59:00+00:00'
@@ -41,7 +42,8 @@ def test_backtest(default_conf, mocker):
     exchange._API = Bittrex({'key': '', 'secret': ''})
 
     data = optimize.load_data(ticker_interval=5, pairs=['BTC_ETH'])
-    results = backtest(default_conf['stake_amount'], optimize.preprocess(data), 10, True)
+    results = backtest(default_conf['stake_amount'],
+                       optimize.preprocess(data), 10, True)
     assert not results.empty
 
 
@@ -51,7 +53,8 @@ def test_backtest_1min_ticker_interval(default_conf, mocker):
 
     # Run a backtesting for an exiting 5min ticker_interval
     data = optimize.load_data(ticker_interval=1, pairs=['BTC_UNITEST'])
-    results = backtest(default_conf['stake_amount'], optimize.preprocess(data), 1, True)
+    results = backtest(default_conf['stake_amount'],
+                       optimize.preprocess(data), 1, True)
     assert not results.empty
 
 
@@ -76,13 +79,13 @@ def load_data_test(what):
     base = 0.001
     if what == 'raise':
         return {'BTC_UNITEST':
-                [{'T':  pair[x]['T'],  # Keep old dates
-                  'V':  pair[x]['V'],  # Keep old volume
+                [{'T': pair[x]['T'],  # Keep old dates
+                  'V': pair[x]['V'],  # Keep old volume
                   'BV': pair[x]['BV'],  # keep too
-                  'O':  x * base,        # But replace O,H,L,C
-                  'H':  x * base + 0.0001,
-                  'L':  x * base - 0.0001,
-                  'C':  x * base} for x in range(0, datalen)]}
+                  'O': x * base,        # But replace O,H,L,C
+                  'H': x * base + 0.0001,
+                  'L': x * base - 0.0001,
+                  'C': x * base} for x in range(0, datalen)]}
     if what == 'lower':
         return {'BTC_UNITEST':
                 [{'T': pair[x]['T'],  # Keep old dates
@@ -98,10 +101,11 @@ def load_data_test(what):
                 [{'T': pair[x]['T'],  # Keep old dates
                   'V': pair[x]['V'],  # Keep old volume
                   'BV': pair[x]['BV'],  # keep too
-                  'O': math.sin(x*hz) / 1000 + base,        # But replace O,H,L,C
-                  'H': math.sin(x*hz) / 1000 + base + 0.0001,
-                  'L': math.sin(x*hz) / 1000 + base - 0.0001,
-                  'C': math.sin(x*hz) / 1000 + base} for x in range(0, datalen)]}
+                  # But replace O,H,L,C
+                  'O': math.sin(x * hz) / 1000 + base,
+                  'H': math.sin(x * hz) / 1000 + base + 0.0001,
+                  'L': math.sin(x * hz) / 1000 + base - 0.0001,
+                  'C': math.sin(x * hz) / 1000 + base} for x in range(0, datalen)]}
     return data
 
 
@@ -121,7 +125,8 @@ def simple_backtest(config, contour, num_results):
 def test_backtest2(default_conf, mocker):
     mocker.patch.dict('freqtrade.main._CONF', default_conf)
     data = optimize.load_data(ticker_interval=5, pairs=['BTC_ETH'])
-    results = backtest(default_conf['stake_amount'], optimize.preprocess(data), 10, True)
+    results = backtest(default_conf['stake_amount'],
+                       optimize.preprocess(data), 10, True)
     assert not results.empty
 
 


### PR DESCRIPTION
## Summary

This PR aims at taking into account various parameters from the config file : 

- use_sell_signal (which was by default always activated)
- sell_profit_only
- stoploss

## Quick changelog

    - add a profit/loss counter
    - adding the sell_signal in backtest function
    - adding sell_profit_only and stoploss in backtest function

## What's new?
*Explain in details what this PR solve or improve. You can include visuals.* 

  