### PR TITLE
Revert "Added order timeout handling"

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -11,7 +11,6 @@
         "0":  0.04
     },
     "stoploss": -0.10,
-    "unfilledtimeout": 600,
     "bid_strategy": {
         "ask_last_balance": 0.0
     },

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,6 @@ The table below will list all configuration parameters.
 | `dry_run` | true | Yes | Define if the bot must be in Dry-run or production mode. 
 | `minimal_roi` | See below | Yes | Set the threshold in percent the bot will use to sell a trade. More information below. 
 | `stoploss` | -0.10 | No | Value of the stoploss in percent used by the bot. More information below. 
-| `unfilledtimeout` | 0 | No | How long (in minutes) the bot will wait for an unfilled order to complete, after which the order will be cancelled.
 | `bid_strategy.ask_last_balance` | 0.0 | Yes | Set the bidding price. More information below.
 | `exchange.name` | bittrex | Yes | Name of the exchange class to use.
 | `exchange.key` | key | No | API key to use for the exchange. Only required when you are in production mode.

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -5,7 +5,7 @@ import logging
 import sys
 import time
 import traceback
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Dict, Optional, List
 
 import requests
@@ -98,10 +98,6 @@ def _process(nb_assets: Optional[int] = 0) -> bool:
                 # Check if we can sell our current pair
                 state_changed = handle_trade(trade) or state_changed
 
-            if 'unfilledtimeout' in _CONF and trade.open_order_id:
-                # Check and handle any timed out trades
-                check_handle_timedout(trade)
-
             Trade.session.flush()
     except (requests.exceptions.RequestException, json.JSONDecodeError) as error:
         logger.warning(
@@ -117,50 +113,6 @@ def _process(nb_assets: Optional[int] = 0) -> bool:
         logger.exception('Got OperationalException. Stopping trader ...')
         update_state(State.STOPPED)
     return state_changed
-
-
-def check_handle_timedout(trade: Trade) -> bool:
-    """
-    Check if a trade is timed out and cancel if neccessary
-    :param trade: Trade instance
-    :return: True if the trade is timed out, false otherwise
-    """
-    timeoutthreashold = datetime.utcnow() - timedelta(minutes=_CONF['unfilledtimeout'])
-    order = exchange.get_order(trade.open_order_id)
-
-    if trade.open_date < timeoutthreashold:
-        # Buy timeout - cancel order
-        exchange.cancel_order(trade.open_order_id)
-        if order['remaining'] == order['amount']:
-            # if trade is not partially completed, just delete the trade
-            Trade.session.delete(trade)
-            Trade.session.flush()
-            logger.info('Buy order timeout for %s.', trade)
-        else:
-            # if trade is partially complete, edit the stake details for the trade
-            # and close the order
-            trade.amount = order['amount'] - order['remaining']
-            trade.stake_amount = trade.amount * trade.open_rate
-            trade.open_order_id = None
-            logger.info('Partial buy order timeout for %s.', trade)
-        return True
-    elif trade.close_date is not None and trade.close_date < timeoutthreashold:
-        # Sell timeout - cancel order and update trade
-        if order['remaining'] == order['amount']:
-            # if trade is not partially completed, just cancel the trade
-            exchange.cancel_order(trade.open_order_id)
-            trade.close_rate = None
-            trade.close_profit = None
-            trade.close_date = None
-            trade.is_open = True
-            trade.open_order_id = None
-            logger.info('Sell order timeout for %s.', trade)
-            return True
-        else:
-            # TODO: figure out how to handle partially complete sell orders
-            return False
-    else:
-        return False
 
 
 def execute_sell(trade: Trade, limit: float) -> None:

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -218,7 +218,6 @@ CONF_SCHEMA = {
             'minProperties': 1
         },
         'stoploss': {'type': 'number', 'maximum': 0, 'exclusiveMaximum': True},
-        'unfilledtimeout': {'type': 'integer', 'minimum': 0},
         'bid_strategy': {
             'type': 'object',
             'properties': {

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -25,7 +25,6 @@ def default_conf():
             "0":  0.04
         },
         "stoploss": -0.10,
-        "unfilledtimeout": 600,
         "bid_strategy": {
             "ask_last_balance": 0.0
         },

--- a/freqtrade/tests/test_main.py
+++ b/freqtrade/tests/test_main.py
@@ -5,14 +5,13 @@ from unittest.mock import MagicMock
 import pytest
 import requests
 import logging
-from datetime import timedelta, datetime
 from sqlalchemy import create_engine
 
 from freqtrade import DependencyException, OperationalException
 from freqtrade.analyze import SignalType
 from freqtrade.exchange import Exchanges
 from freqtrade.main import create_trade, handle_trade, init, \
-    get_target_bid, _process, execute_sell, check_handle_timedout
+    get_target_bid, _process, execute_sell
 from freqtrade.misc import get_state, State
 from freqtrade.persistence import Trade
 
@@ -317,163 +316,6 @@ def test_close_trade(default_conf, ticker, limit_buy_order, limit_sell_order, mo
 
     with pytest.raises(ValueError, match=r'.*closed trade.*'):
         handle_trade(trade)
-
-
-def test_check_handle_timedout(default_conf, ticker, health, mocker):
-    mocker.patch.dict('freqtrade.main._CONF', default_conf)
-    cancel_order_mock = MagicMock()
-    mocker.patch.multiple('freqtrade.rpc', init=MagicMock(), send_msg=MagicMock())
-    mocker.patch.multiple('freqtrade.main.exchange',
-                          validate_pairs=MagicMock(),
-                          get_ticker=ticker,
-                          get_order=MagicMock(return_value={
-                              'closed': None,
-                              'type': 'LIMIT_BUY',
-                              'remaining': 1.0,
-                              'amount': 1.0,
-                          }),
-                          cancel_order=cancel_order_mock)
-    init(default_conf, create_engine('sqlite://'))
-
-    tradeBuy = Trade(
-        pair='BTC_ETH',
-        open_rate=1,
-        exchange='BITTREX',
-        open_order_id='123456789',
-        amount=1,
-        fee=0.0,
-        stake_amount=1,
-        open_date=datetime.utcnow(),
-        is_open=True
-    )
-
-    tradeSell = Trade(
-        pair='BTC_BCC',
-        open_rate=1,
-        exchange='BITTREX',
-        open_order_id='678901234',
-        amount=1,
-        fee=0.0,
-        stake_amount=1,
-        open_date=datetime.utcnow(),
-        close_date=datetime.utcnow(),
-        is_open=True
-    )
-
-    Trade.session.add(tradeBuy)
-    Trade.session.add(tradeSell)
-
-    # check it doesn't cancel any buy trades under the time limit
-    ret = check_handle_timedout(tradeBuy)
-    assert ret is False
-    assert cancel_order_mock.call_count == 0
-    trades = Trade.query.filter(Trade.open_order_id.is_(tradeBuy.open_order_id)).all()
-    assert len(trades) == 1
-
-    # change the trade open datetime to 601 minutes in the past
-    tradeBuy.open_date = datetime.utcnow() - timedelta(minutes=601)
-
-    # check it does cancel buy orders over the time limit
-    ret = check_handle_timedout(tradeBuy)
-    assert ret is True
-    assert cancel_order_mock.call_count == 1
-    trades = Trade.query.filter(Trade.open_order_id.is_(tradeBuy.open_order_id)).all()
-    assert len(trades) == 0
-
-    # check it doesn't cancel any sell trades under the time limit
-    ret = check_handle_timedout(tradeSell)
-    assert ret is False
-    assert cancel_order_mock.call_count == 1
-    assert tradeSell.is_open is True
-
-    # change the trade close datetime to 601 minutes in the past
-    tradeSell.close_date = datetime.utcnow() - timedelta(minutes=601)
-
-    # check it does cancel sell orders over the time limit
-    ret = check_handle_timedout(tradeSell)
-    assert ret is True
-    assert cancel_order_mock.call_count == 2
-    assert tradeSell.is_open is True
-
-
-def test_check_handle_timedout_partial(default_conf, ticker, health, mocker):
-    mocker.patch.dict('freqtrade.main._CONF', default_conf)
-    cancel_order_mock = MagicMock()
-    mocker.patch.multiple('freqtrade.rpc', init=MagicMock(), send_msg=MagicMock())
-    mocker.patch.multiple('freqtrade.main.exchange',
-                          validate_pairs=MagicMock(),
-                          get_ticker=ticker,
-                          get_order=MagicMock(return_value={
-                              'closed': None,
-                              'type': 'LIMIT_BUY',
-                              'remaining': 0.5,
-                              'amount': 1.0,
-                          }),
-                          cancel_order=cancel_order_mock)
-    init(default_conf, create_engine('sqlite://'))
-
-    tradeBuy = Trade(
-        pair='BTC_ETH',
-        open_rate=1,
-        exchange='BITTREX',
-        open_order_id='123456789',
-        amount=1,
-        fee=0.0,
-        stake_amount=1,
-        open_date=datetime.utcnow(),
-        is_open=True
-    )
-
-    tradeSell = Trade(
-        pair='BTC_BCC',
-        open_rate=1,
-        exchange='BITTREX',
-        open_order_id='678901234',
-        amount=1,
-        fee=0.0,
-        stake_amount=1,
-        open_date=datetime.utcnow(),
-        close_date=datetime.utcnow(),
-        is_open=True
-    )
-
-    Trade.session.add(tradeBuy)
-    Trade.session.add(tradeSell)
-
-    # check it doesn't cancel any buy trades under the time limit
-    ret = check_handle_timedout(tradeBuy)
-    assert ret is False
-    assert cancel_order_mock.call_count == 0
-    trades = Trade.query.filter(Trade.open_order_id.is_(tradeBuy.open_order_id)).all()
-    assert len(trades) == 1
-
-    # change the trade open datetime to 601 minutes in the past
-    tradeBuy.open_date = datetime.utcnow() - timedelta(minutes=601)
-
-    # check it does cancel buy orders over the time limit
-    # note this is for a partially-complete buy order
-    ret = check_handle_timedout(tradeBuy)
-    assert ret is True
-    assert cancel_order_mock.call_count == 1
-    trades = Trade.query.filter(Trade.open_order_id.is_(tradeBuy.open_order_id)).all()
-    assert len(trades) == 1
-    assert trades[0].amount == 0.5
-    assert trades[0].stake_amount == 0.5
-
-    # check it doesn't cancel any sell trades under the time limit
-    ret = check_handle_timedout(tradeSell)
-    assert ret is False
-    assert cancel_order_mock.call_count == 1
-    assert tradeSell.is_open is True
-
-    # change the trade close datetime to 601 minutes in the past
-    tradeSell.close_date = datetime.utcnow() - timedelta(minutes=601)
-
-    # check it does not cancel partially-complete sell orders over the time limit
-    ret = check_handle_timedout(tradeSell)
-    assert ret is False
-    assert cancel_order_mock.call_count == 1
-    assert tradeSell.open_order_id is not None
 
 
 def test_balance_fully_ask_side(mocker):


### PR DESCRIPTION
Reverts gcarq/freqtrade#295

Reasoning it seems that 
> Looks like now bot tried to immediately cancel orders if age of trade > unfilledtimeout, even if sell order just created

I might have forgotten to add the `unfilledtimeout` to my config.json while testing this PR out