### PR TITLE
Unfilled order timeouts - now using timestamps from exchange

### DIFF
--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -5,7 +5,8 @@ import logging
 import sys
 import time
 import traceback
-from datetime import datetime, timedelta
+import arrow
+from datetime import datetime
 from typing import Dict, Optional, List
 
 import requests
@@ -98,9 +99,9 @@ def _process(nb_assets: Optional[int] = 0) -> bool:
                 # Check if we can sell our current pair
                 state_changed = handle_trade(trade) or state_changed
 
-            if 'unfilledtimeout' in _CONF and trade.open_order_id:
-                # Check and handle any timed out trades
-                check_handle_timedout(trade)
+        if 'unfilledtimeout' in _CONF:
+            # Check and handle any timed out open orders
+            check_handle_timedout(_CONF['unfilledtimeout'])
 
             Trade.session.flush()
     except (requests.exceptions.RequestException, json.JSONDecodeError) as error:
@@ -119,48 +120,46 @@ def _process(nb_assets: Optional[int] = 0) -> bool:
     return state_changed
 
 
-def check_handle_timedout(trade: Trade) -> bool:
+def check_handle_timedout(timeoutvalue: int) -> None:
     """
-    Check if a trade is timed out and cancel if neccessary
-    :param trade: Trade instance
-    :return: True if the trade is timed out, false otherwise
+    Check if any orders are timed out and cancel if neccessary
+    :param timeoutvalue: Number of minutes until order is considered timed out
+    :return: None
     """
-    timeoutthreashold = datetime.utcnow() - timedelta(minutes=_CONF['unfilledtimeout'])
-    order = exchange.get_order(trade.open_order_id)
+    timeoutthreashold = arrow.utcnow().shift(minutes=-timeoutvalue).datetime
 
-    if trade.open_date < timeoutthreashold:
-        # Buy timeout - cancel order
-        exchange.cancel_order(trade.open_order_id)
-        if order['remaining'] == order['amount']:
-            # if trade is not partially completed, just delete the trade
-            Trade.session.delete(trade)
-            Trade.session.flush()
-            logger.info('Buy order timeout for %s.', trade)
-        else:
-            # if trade is partially complete, edit the stake details for the trade
-            # and close the order
-            trade.amount = order['amount'] - order['remaining']
-            trade.stake_amount = trade.amount * trade.open_rate
-            trade.open_order_id = None
-            logger.info('Partial buy order timeout for %s.', trade)
-        return True
-    elif trade.close_date is not None and trade.close_date < timeoutthreashold:
-        # Sell timeout - cancel order and update trade
-        if order['remaining'] == order['amount']:
-            # if trade is not partially completed, just cancel the trade
+    for trade in Trade.query.filter(Trade.open_order_id.isnot(None)).all():
+        order = exchange.get_order(trade.open_order_id)
+        if order['type'] == "LIMIT_BUY" and order['opened'] < timeoutthreashold:
+            # Buy timeout - cancel order
             exchange.cancel_order(trade.open_order_id)
-            trade.close_rate = None
-            trade.close_profit = None
-            trade.close_date = None
-            trade.is_open = True
-            trade.open_order_id = None
-            logger.info('Sell order timeout for %s.', trade)
-            return True
-        else:
-            # TODO: figure out how to handle partially complete sell orders
-            return False
-    else:
-        return False
+            if order['remaining'] == order['amount']:
+                # if trade is not partially completed, just delete the trade
+                Trade.session.delete(trade)
+                Trade.session.flush()
+                logger.info('Buy order timeout for %s.', trade)
+            else:
+                # if trade is partially complete, edit the stake details for the trade
+                # and close the order
+                trade.amount = order['amount'] - order['remaining']
+                trade.stake_amount = trade.amount * trade.open_rate
+                trade.open_order_id = None
+                logger.info('Partial buy order timeout for %s.', trade)
+        elif order['type'] == "LIMIT_SELL" and order['opened'] < timeoutthreashold:
+            # Sell timeout - cancel order and update trade
+            if order['remaining'] == order['amount']:
+                # if trade is not partially completed, just cancel the trade
+                exchange.cancel_order(trade.open_order_id)
+                trade.close_rate = None
+                trade.close_profit = None
+                trade.close_date = None
+                trade.is_open = True
+                trade.open_order_id = None
+                logger.info('Sell order timeout for %s.', trade)
+                return True
+            else:
+                # TODO: figure out how to handle partially complete sell orders
+                pass
 
 
 def execute_sell(trade: Trade, limit: float) -> None:

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -130,7 +130,9 @@ def check_handle_timedout(timeoutvalue: int) -> None:
 
     for trade in Trade.query.filter(Trade.open_order_id.isnot(None)).all():
         order = exchange.get_order(trade.open_order_id)
-        if order['type'] == "LIMIT_BUY" and order['opened'] < timeoutthreashold:
+        ordertime = arrow.get(order['opened'])
+
+        if order['type'] == "LIMIT_BUY" and ordertime < timeoutthreashold:
             # Buy timeout - cancel order
             exchange.cancel_order(trade.open_order_id)
             if order['remaining'] == order['amount']:
@@ -145,7 +147,7 @@ def check_handle_timedout(timeoutvalue: int) -> None:
                 trade.stake_amount = trade.amount * trade.open_rate
                 trade.open_order_id = None
                 logger.info('Partial buy order timeout for %s.', trade)
-        elif order['type'] == "LIMIT_SELL" and order['opened'] < timeoutthreashold:
+        elif order['type'] == "LIMIT_SELL" and ordertime < timeoutthreashold:
             # Sell timeout - cancel order and update trade
             if order['remaining'] == order['amount']:
                 # if trade is not partially completed, just cancel the trade

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from unittest.mock import MagicMock
 
 import pytest
+import arrow
 from jsonschema import validate
 from telegram import Message, Chat, Update
 
@@ -123,11 +124,50 @@ def limit_buy_order():
         'id': 'mocked_limit_buy',
         'type': 'LIMIT_BUY',
         'pair': 'mocked',
-        'opened': datetime.utcnow(),
+        'opened': arrow.utcnow().datetime,
         'rate': 0.00001099,
         'amount': 90.99181073,
         'remaining': 0.0,
-        'closed': datetime.utcnow(),
+        'closed': arrow.utcnow().datetime,
+    }
+
+
+@pytest.fixture
+def limit_buy_order_old():
+    return {
+        'id': 'mocked_limit_buy_old',
+        'type': 'LIMIT_BUY',
+        'pair': 'BTC_ETH',
+        'opened': arrow.utcnow().shift(minutes=-601).datetime,
+        'rate': 0.00001099,
+        'amount': 90.99181073,
+        'remaining': 90.99181073,
+    }
+
+
+@pytest.fixture
+def limit_sell_order_old():
+    return {
+        'id': 'mocked_limit_sell_old',
+        'type': 'LIMIT_SELL',
+        'pair': 'BTC_ETH',
+        'opened': arrow.utcnow().shift(minutes=-601).datetime,
+        'rate': 0.00001099,
+        'amount': 90.99181073,
+        'remaining': 90.99181073,
+    }
+
+
+@pytest.fixture
+def limit_buy_order_old_partial():
+    return {
+        'id': 'mocked_limit_buy_old_partial',
+        'type': 'LIMIT_BUY',
+        'pair': 'BTC_ETH',
+        'opened': arrow.utcnow().shift(minutes=-601).datetime,
+        'rate': 0.00001099,
+        'amount': 90.99181073,
+        'remaining': 67.99181073,
     }
 
 
@@ -137,11 +177,11 @@ def limit_sell_order():
         'id': 'mocked_limit_sell',
         'type': 'LIMIT_SELL',
         'pair': 'mocked',
-        'opened': datetime.utcnow(),
+        'opened': arrow.utcnow().datetime,
         'rate': 0.00001173,
         'amount': 90.99181073,
         'remaining': 0.0,
-        'closed': datetime.utcnow(),
+        'closed': arrow.utcnow().datetime,
     }
 
 

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -124,11 +124,11 @@ def limit_buy_order():
         'id': 'mocked_limit_buy',
         'type': 'LIMIT_BUY',
         'pair': 'mocked',
-        'opened': arrow.utcnow().datetime,
+        'opened': str(arrow.utcnow().datetime),
         'rate': 0.00001099,
         'amount': 90.99181073,
         'remaining': 0.0,
-        'closed': arrow.utcnow().datetime,
+        'closed': str(arrow.utcnow().datetime),
     }
 
 
@@ -138,7 +138,7 @@ def limit_buy_order_old():
         'id': 'mocked_limit_buy_old',
         'type': 'LIMIT_BUY',
         'pair': 'BTC_ETH',
-        'opened': arrow.utcnow().shift(minutes=-601).datetime,
+        'opened': str(arrow.utcnow().shift(minutes=-601).datetime),
         'rate': 0.00001099,
         'amount': 90.99181073,
         'remaining': 90.99181073,
@@ -151,7 +151,7 @@ def limit_sell_order_old():
         'id': 'mocked_limit_sell_old',
         'type': 'LIMIT_SELL',
         'pair': 'BTC_ETH',
-        'opened': arrow.utcnow().shift(minutes=-601).datetime,
+        'opened': str(arrow.utcnow().shift(minutes=-601).datetime),
         'rate': 0.00001099,
         'amount': 90.99181073,
         'remaining': 90.99181073,
@@ -164,7 +164,7 @@ def limit_buy_order_old_partial():
         'id': 'mocked_limit_buy_old_partial',
         'type': 'LIMIT_BUY',
         'pair': 'BTC_ETH',
-        'opened': arrow.utcnow().shift(minutes=-601).datetime,
+        'opened': str(arrow.utcnow().shift(minutes=-601).datetime),
         'rate': 0.00001099,
         'amount': 90.99181073,
         'remaining': 67.99181073,
@@ -177,11 +177,11 @@ def limit_sell_order():
         'id': 'mocked_limit_sell',
         'type': 'LIMIT_SELL',
         'pair': 'mocked',
-        'opened': arrow.utcnow().datetime,
+        'opened': str(arrow.utcnow().datetime),
         'rate': 0.00001173,
         'amount': 90.99181073,
         'remaining': 0.0,
-        'closed': arrow.utcnow().datetime,
+        'closed': str(arrow.utcnow().datetime),
     }
 
 


### PR DESCRIPTION
## Summary
In detecting unfilled order timeouts, the order time from the exchange is now used. Also a bit of re-factoring. Had to re-write some unit tests as a result.

Solve the issue: Comments in pull requrest #295 by @ermakus. Using a seperate pull request to avoid any git-merging issues. 

## Quick changelog

- In detecting unfilled order timeouts, the order open time from the exchange is used.

  