### PR TITLE
Fix Backtesting header alignment

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -192,6 +192,6 @@ def start(args):
         use_sell_signal=config.get('experimental', {}).get('use_sell_signal', False)
     )
     logger.info(
-        '\n====================== BACKTESTING REPORT ================================\n%s',
+        '\n==================================== BACKTESTING REPORT ====================================\n%s', # noqa
         generate_text_table(data, results, config['stake_currency'], args.ticker_interval)
     )


### PR DESCRIPTION
## Summary
Since backtesting has now 2 more columns `profit` and `loss`, the backtesting header is not aligned anymore. 

Solve the issue: None

## Quick changelog
- Update the backtesting result header (Because UI matter :) )

## What's new?
A very cool backtesting result header with equal '=' from both sides.

**Before :(**
```
2018-01-04 23:09:37,811 - freqtrade.optimize.backtesting - INFO -
====================== BACKTESTING REPORT ================================
pair         buy count    avg profit %    total profit BTC    avg duration    profit    loss
---------  -----------  --------------  ------------------  --------------  --------  ------
BTC_ADA              6            2.56          0.00030613          2497.5         6       0
BTC_NEO              8            2.52          0.00039928          2564.4         8       0
BTC_NXT              2            4.17          0.00016817           425.0         2       0
BTC_MCO             10            2.63          0.00052232           725.0        10       0
```

**After :)**
```
2018-01-04 23:11:04,318 - freqtrade.optimize.backtesting - INFO -
==================================== BACKTESTING REPORT ====================================
pair         buy count    avg profit %    total profit BTC    avg duration    profit    loss
---------  -----------  --------------  ------------------  --------------  --------  ------
BTC_ADA              6            2.56          0.00030613          2497.5         6       0
BTC_NEO              8            2.52          0.00039928          2564.4         8       0
BTC_NXT              2            4.17          0.00016817           425.0         2       0
BTC_MCO             10            2.63          0.00052232           725.0        10       0
```