### PR TITLE
tests cover more backtesting

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -12,8 +12,9 @@ from freqtrade import exchange
 from freqtrade.analyze import populate_buy_trend, populate_sell_trend
 from freqtrade.exchange import Bittrex
 from freqtrade.main import min_roi_reached
-from freqtrade.misc import load_config
-from freqtrade.optimize import load_data, preprocess
+import freqtrade.misc as misc
+from freqtrade.optimize import preprocess
+import freqtrade.optimize as optimize
 from freqtrade.persistence import Trade
 
 logger = logging.getLogger(__name__)
@@ -149,7 +150,7 @@ def start(args):
     exchange._API = Bittrex({'key': '', 'secret': ''})
 
     logger.info('Using config: %s ...', args.config)
-    config = load_config(args.config)
+    config = misc.load_config(args.config)
 
     logger.info('Using ticker_interval: %s ...', args.ticker_interval)
 
@@ -161,8 +162,8 @@ def start(args):
             data[pair] = exchange.get_ticker_history(pair, args.ticker_interval)
     else:
         logger.info('Using local backtesting data (using whitelist in given config) ...')
-        data = load_data(pairs=pairs, ticker_interval=args.ticker_interval,
-                         refresh_pairs=args.refresh_pairs)
+        data = optimize.load_data(pairs=pairs, ticker_interval=args.ticker_interval,
+                                  refresh_pairs=args.refresh_pairs)
 
         logger.info('Using stake_currency: %s ...', config['stake_currency'])
         logger.info('Using stake_amount: %s ...', config['stake_amount'])

--- a/freqtrade/tests/optimize/test_optimize.py
+++ b/freqtrade/tests/optimize/test_optimize.py
@@ -5,7 +5,11 @@ import logging
 from shutil import copyfile
 from freqtrade import exchange, optimize
 from freqtrade.exchange import Bittrex
-from freqtrade.optimize.__init__ import testdata_path, download_pairs, download_backtesting_testdata
+from freqtrade.optimize.__init__ import testdata_path, download_pairs,\
+     download_backtesting_testdata, load_tickerdata_file
+
+# Change this if modifying BTC_UNITEST testdatafile
+_btc_unittest_length = 13681
 
 
 def _backup_file(file: str, copy_file: bool = False) -> None:
@@ -164,3 +168,9 @@ def test_download_backtesting_testdata(default_conf, ticker_history, mocker):
     download_backtesting_testdata(pair="BTC-STORJ", interval=5)
     assert os.path.isfile(file2) is True
     _clean_test_file(file2)
+
+
+def test_load_tickerdata_file():
+    assert not load_tickerdata_file('BTC_UNITEST', 7)
+    tickerdata = load_tickerdata_file('BTC_UNITEST', 1)
+    assert _btc_unittest_length == len(tickerdata)


### PR DESCRIPTION
## COMMIT "split load tickerdata function"

The first commit lifts out the file-load part from optimize.load_data().
The file-load part is put into load_tickerdata_file() function.

By doing so we enable the possibility to test targets that uses load_data().
In where we mock load_data(), replacing it, but still want to use the file-load part in our testcase.
An example of this is found in the next commit.

One small kludge introduced by this commit is in the logic where we do a retry of  load_tickerdata_file() in the function load_data(). The logic is correct, but perhaps not so beautiful stated.

A simple test case is also added, even though it doesn't increase the coverage it is warranted by the one-test-per-function policy.

## COMMIT "tests cover more backtesting"
The second commit is the objective of this commit. The commented-out testcase in tests_backtesting.py is now brought back.
The reason the test case was commented-out was because I couldn't get the mocking of load_config to work. It seems the reason for that has something to do with how backtesting.py imports parts of freqtrade. And that is the reason for the changed made to backtesting.py.

backtesting.py is modified to enable mocking of load_config() and load_data()

Then in the unittest, we have a replacement for load_config that loads a smaller set to fasten up the testtime.

There is a possible future annoyance in these tests, where if everytime the trading algorithm is changed, alot of tests needs to be updated. To fix these, we could use a fixed strategy.
  