### PR TITLE
--datadir <path> argument

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -46,6 +46,11 @@ python3 ./freqtrade/main.py backtesting --realistic-simulation --refresh-pairs-c
 python3 ./freqtrade/main.py backtesting --realistic-simulation --live
 ```
 
+**Using a different on-disk ticker-data source**
+```bash
+python3 ./freqtrade/main.py backtesting --datadir freqtrade/tests/testdata-20180101
+```
+
 For help about backtesting usage, please refer to 
 [Backtesting commands](#backtesting-commands).
 

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -26,6 +26,9 @@ optional arguments:
                         specify configuration file (default: config.json)
   -v, --verbose         be verbose
   --version             show program's version number and exit
+  -dd PATH, --datadir PATH
+                        Path is from where backtesting and hyperopt will load the
+                        ticker data files (default freqdata/tests/testdata).
   --dynamic-whitelist [INT]
                         dynamically generate and update whitelist based on 24h
                         BaseVolume (Default 20 currencies)

--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -163,6 +163,11 @@ We strongly recommend to use `screen` to prevent any connection loss.
 python3 ./freqtrade/main.py -c config.json hyperopt
 ```
 
+### Execute hyperopt with different ticker-data source
+If you would like to learn parameters using an alternate ticke-data that
+you have on-disk, use the --datadir PATH option. Default hyperopt will
+use data from directory freqtrade/tests/testdata.
+
 ### Hyperopt with MongoDB
 Hyperopt with MongoDB, is like Hyperopt under steroids. As you saw by
 executing the previous command is the execution takes a long time. 

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -126,6 +126,15 @@ def parse_args(args: List[str]):
         action='store_true',
         dest='dry_run_db',
     )
+    parser.add_argument(
+        '-dd', '--datadir',
+        help='path to backtest data (default freqdata/tests/testdata',
+        dest='datadir',
+        default='freqtrade/tests/testdata',
+        type=str,
+        metavar='PATH',
+    )
+
     build_subcommands(parser)
     parsed_args = parser.parse_args(args)
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -162,7 +162,7 @@ def start(args):
             data[pair] = exchange.get_ticker_history(pair, args.ticker_interval)
     else:
         logger.info('Using local backtesting data (using whitelist in given config) ...')
-        data = optimize.load_data(pairs=pairs, ticker_interval=args.ticker_interval,
+        data = optimize.load_data(args.datadir, pairs=pairs, ticker_interval=args.ticker_interval,
                                   refresh_pairs=args.refresh_pairs)
 
         logger.info('Using stake_currency: %s ...', config['stake_currency'])

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -36,7 +36,7 @@ CURRENT_BEST_LOSS = 100
 EXPECTED_MAX_PROFIT = 3.85
 
 # Configuration and data used by hyperopt
-PROCESSED = optimize.preprocess(optimize.load_data())
+PROCESSED = None  # optimize.preprocess(optimize.load_data())
 OPTIMIZE_CONFIG = hyperopt_optimize_conf()
 
 # Monkey patch config
@@ -224,7 +224,7 @@ def start(args):
     config = load_config(args.config)
     pairs = config['exchange']['pair_whitelist']
     PROCESSED = optimize.preprocess(optimize.load_data(
-        pairs=pairs, ticker_interval=args.ticker_interval))
+        args.datadir, pairs=pairs, ticker_interval=args.ticker_interval))
 
     if args.mongodb:
         logger.info('Using mongodb ...')

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -32,7 +32,7 @@ def test_generate_text_table():
 
 def test_get_timeframe():
     data = preprocess(optimize.load_data(
-        ticker_interval=1, pairs=['BTC_UNITEST']))
+        None, ticker_interval=1, pairs=['BTC_UNITEST']))
     min_date, max_date = get_timeframe(data)
     assert min_date.isoformat() == '2017-11-04T23:02:00+00:00'
     assert max_date.isoformat() == '2017-11-14T22:59:00+00:00'
@@ -42,7 +42,7 @@ def test_backtest(default_conf, mocker):
     mocker.patch.dict('freqtrade.main._CONF', default_conf)
     exchange._API = Bittrex({'key': '', 'secret': ''})
 
-    data = optimize.load_data(ticker_interval=5, pairs=['BTC_ETH'])
+    data = optimize.load_data(None, ticker_interval=5, pairs=['BTC_ETH'])
     results = backtest(default_conf['stake_amount'],
                        optimize.preprocess(data), 10, True)
     assert not results.empty
@@ -53,7 +53,7 @@ def test_backtest_1min_ticker_interval(default_conf, mocker):
     exchange._API = Bittrex({'key': '', 'secret': ''})
 
     # Run a backtesting for an exiting 5min ticker_interval
-    data = optimize.load_data(ticker_interval=1, pairs=['BTC_UNITEST'])
+    data = optimize.load_data(None, ticker_interval=1, pairs=['BTC_UNITEST'])
     results = backtest(default_conf['stake_amount'],
                        optimize.preprocess(data), 1, True)
     assert not results.empty
@@ -67,7 +67,7 @@ def trim_dictlist(dl, num):
 
 
 def load_data_test(what):
-    data = optimize.load_data(ticker_interval=1, pairs=['BTC_UNITEST'])
+    data = optimize.load_data(None, ticker_interval=1, pairs=['BTC_UNITEST'])
     data = trim_dictlist(data, -100)
     pair = data['BTC_UNITEST']
     datalen = len(pair)
@@ -124,7 +124,7 @@ def simple_backtest(config, contour, num_results):
 
 def test_backtest2(default_conf, mocker):
     mocker.patch.dict('freqtrade.main._CONF', default_conf)
-    data = optimize.load_data(ticker_interval=5, pairs=['BTC_ETH'])
+    data = optimize.load_data(None, ticker_interval=5, pairs=['BTC_ETH'])
     results = backtest(default_conf['stake_amount'],
                        optimize.preprocess(data), 10, True)
     assert not results.empty
@@ -149,8 +149,8 @@ def test_backtest_pricecontours(default_conf, mocker):
         simple_backtest(default_conf, contour, numres)
 
 
-def mocked_load_data(pairs=[], ticker_interval=0, refresh_pairs=False):
-    tickerdata = optimize.load_tickerdata_file('BTC_UNITEST', 1)
+def mocked_load_data(datadir, pairs=[], ticker_interval=0, refresh_pairs=False):
+    tickerdata = optimize.load_tickerdata_file(datadir, 'BTC_UNITEST', 1)
     pairdata = {'BTC_UNITEST': tickerdata}
     return trim_dictlist(pairdata, -100)
 
@@ -165,6 +165,7 @@ def test_backtest_start(default_conf, mocker, caplog):
     args.ticker_interval = 1
     args.level = 10
     args.live = False
+    args.datadir = None
     backtesting.start(args)
     # check the logs, that will contain the backtest result
     exists = ['Using max_open_trades: 1 ...',

--- a/freqtrade/tests/optimize/test_optimize.py
+++ b/freqtrade/tests/optimize/test_optimize.py
@@ -5,7 +5,7 @@ import logging
 from shutil import copyfile
 from freqtrade import exchange, optimize
 from freqtrade.exchange import Bittrex
-from freqtrade.optimize.__init__ import testdata_path, download_pairs,\
+from freqtrade.optimize.__init__ import make_testdata_path, download_pairs,\
      download_backtesting_testdata, load_tickerdata_file
 
 # Change this if modifying BTC_UNITEST testdatafile
@@ -51,7 +51,7 @@ def test_load_data_5min_ticker(default_conf, ticker_history, mocker, caplog):
 
     file = 'freqtrade/tests/testdata/BTC_ETH-5.json'
     _backup_file(file, copy_file=True)
-    optimize.load_data(pairs=['BTC_ETH'])
+    optimize.load_data(None, pairs=['BTC_ETH'])
     assert os.path.isfile(file) is True
     assert ('freqtrade.optimize',
             logging.INFO,
@@ -68,7 +68,7 @@ def test_load_data_1min_ticker(default_conf, ticker_history, mocker, caplog):
 
     file = 'freqtrade/tests/testdata/BTC_ETH-1.json'
     _backup_file(file, copy_file=True)
-    optimize.load_data(ticker_interval=1, pairs=['BTC_ETH'])
+    optimize.load_data(None, ticker_interval=1, pairs=['BTC_ETH'])
     assert os.path.isfile(file) is True
     assert ('freqtrade.optimize',
             logging.INFO,
@@ -85,7 +85,7 @@ def test_load_data_with_new_pair_1min(default_conf, ticker_history, mocker, capl
 
     file = 'freqtrade/tests/testdata/BTC_MEME-1.json'
     _backup_file(file)
-    optimize.load_data(ticker_interval=1, pairs=['BTC_MEME'])
+    optimize.load_data(None, ticker_interval=1, pairs=['BTC_MEME'])
     assert os.path.isfile(file) is True
     assert ('freqtrade.optimize',
             logging.INFO,
@@ -95,7 +95,7 @@ def test_load_data_with_new_pair_1min(default_conf, ticker_history, mocker, capl
 
 
 def test_testdata_path():
-    assert os.path.join('freqtrade', 'tests', 'testdata') in testdata_path()
+    assert os.path.join('freqtrade', 'tests', 'testdata') in make_testdata_path(None)
 
 
 def test_download_pairs(default_conf, ticker_history, mocker):
@@ -113,7 +113,7 @@ def test_download_pairs(default_conf, ticker_history, mocker):
     _backup_file(file2_1)
     _backup_file(file2_5)
 
-    assert download_pairs(pairs=['BTC-MEME', 'BTC-CFI']) is True
+    assert download_pairs(None, pairs=['BTC-MEME', 'BTC-CFI']) is True
 
     assert os.path.isfile(file1_1) is True
     assert os.path.isfile(file1_5) is True
@@ -139,7 +139,7 @@ def test_download_pairs_exception(default_conf, ticker_history, mocker, caplog):
     _backup_file(file1_1)
     _backup_file(file1_5)
 
-    download_pairs(pairs=['BTC-MEME'])
+    download_pairs(None, pairs=['BTC-MEME'])
     # clean files freshly downloaded
     _clean_test_file(file1_1)
     _clean_test_file(file1_5)
@@ -157,7 +157,7 @@ def test_download_backtesting_testdata(default_conf, ticker_history, mocker):
     # Download a 1 min ticker file
     file1 = 'freqtrade/tests/testdata/BTC_XEL-1.json'
     _backup_file(file1)
-    download_backtesting_testdata(pair="BTC-XEL", interval=1)
+    download_backtesting_testdata(None, pair="BTC-XEL", interval=1)
     assert os.path.isfile(file1) is True
     _clean_test_file(file1)
 
@@ -165,12 +165,12 @@ def test_download_backtesting_testdata(default_conf, ticker_history, mocker):
     file2 = 'freqtrade/tests/testdata/BTC_STORJ-5.json'
     _backup_file(file2)
 
-    download_backtesting_testdata(pair="BTC-STORJ", interval=5)
+    download_backtesting_testdata(None, pair="BTC-STORJ", interval=5)
     assert os.path.isfile(file2) is True
     _clean_test_file(file2)
 
 
 def test_load_tickerdata_file():
-    assert not load_tickerdata_file('BTC_UNITEST', 7)
-    tickerdata = load_tickerdata_file('BTC_UNITEST', 1)
+    assert not load_tickerdata_file(None, 'BTC_UNITEST', 7)
+    tickerdata = load_tickerdata_file(None, 'BTC_UNITEST', 1)
     assert _btc_unittest_length == len(tickerdata)

--- a/freqtrade/tests/test_dataframe.py
+++ b/freqtrade/tests/test_dataframe.py
@@ -7,7 +7,7 @@ _pairs = ['BTC_ETH']
 
 
 def load_dataframe_pair(pairs):
-    ld = freqtrade.optimize.load_data(ticker_interval=5, pairs=pairs)
+    ld = freqtrade.optimize.load_data(None, ticker_interval=5, pairs=pairs)
     assert isinstance(ld, dict)
     assert isinstance(pairs[0], str)
     dataframe = ld[pairs[0]]


### PR DESCRIPTION
This argument enables usage of different backtesting directories.
Useful if one wants compare backtesting performance over time.
