### PR TITLE
Make readable hyperopt best parameters result

### DIFF
--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -204,19 +204,39 @@ signal. Given following result from hyperopt:
 ```
 Best parameters:
 {
-  "adx": 1,
-  "adx-value": 15.0,
-  "fastd": 1,
-  "fastd-value": 40.0,
-  "green_candle": 1,
-  "mfi": 0,
-  "over_sar": 0,
-  "rsi": 1,
-  "rsi-value": 37.0,
-  "trigger": 0,
-  "uptrend_long_ema": 1,
-  "uptrend_short_ema": 0,
-  "uptrend_sma": 0
+    "adx": {
+        "enabled": true,
+        "value": 15.0
+    },
+    "fastd": {
+        "enabled": true,
+        "value": 40.0
+    },
+    "green_candle": {
+        "enabled": true
+    },
+    "mfi": {
+        "enabled": false
+    },
+    "over_sar": {
+        "enabled": false
+    },
+    "rsi": {
+        "enabled": true,
+        "value": 37.0
+    },
+    "trigger": {
+        "type": "lower_bb"
+    },
+    "uptrend_long_ema": {
+        "enabled": true
+    },
+    "uptrend_short_ema": {
+        "enabled": false
+    },
+    "uptrend_sma": {
+        "enabled": false
+    }
 }
 
 Best Result:
@@ -224,14 +244,14 @@ Best Result:
 ```
 
 You should understand this result like:
-- You should **consider** the guard "adx" (`"adx": 1,` = `adx` is true) 
-and the best value is `15.0` (`"adx-value": 15.0,`)
-- You should **consider** the guard "fastd" (`"fastd": 1,` = `fastd` 
-is true) and the best value is `40.0` (`"fastd-value": 40.0,`)
+- You should **consider** the guard "adx" (`"adx"` is `"enabled": true`) 
+and the best value is `15.0` (`"value": 15.0,`)
+- You should **consider** the guard "fastd" (`"fastd"` is `"enabled": 
+true`) and the best value is `40.0` (`"value": 40.0,`)
 - You should **consider** to enable the guard "green_candle" 
-(`"green_candle": 1,` = `candle` is true) but this guards as no 
+(`"green_candle"` is `"enabled": true`) but this guards as no 
 customizable value.
-- You should **ignore** the guard "mfi" (`"mfi": 0,` = `mfi` is false)
+- You should **ignore** the guard "mfi" (`"mfi"` is `"enabled": false`)
 - and so on...
 
 
@@ -239,8 +259,8 @@ You have to look from
 [freqtrade/optimize/hyperopt.py](https://github.com/gcarq/freqtrade/blob/develop/freqtrade/optimize/hyperopt.py#L170-L200) 
 what those values match to.   
   
-So for example you had `adx-value: 15.0` (and `adx: 1` was true) so we 
-would look at `adx`-block from 
+So for example you had `adx:` with the `value: 15.0` so we would look 
+at `adx`-block from 
 [freqtrade/optimize/hyperopt.py](https://github.com/gcarq/freqtrade/blob/develop/freqtrade/optimize/hyperopt.py#L178-L179). 
 That translates to the following code block to 
 [analyze.populate_buy_trend()](https://github.com/gcarq/freqtrade/blob/develop/freqtrade/analyze.py#L73)

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -8,7 +8,7 @@ from functools import reduce
 from math import exp
 from operator import itemgetter
 
-from hyperopt import fmin, tpe, hp, Trials, STATUS_OK, STATUS_FAIL
+from hyperopt import fmin, tpe, hp, Trials, STATUS_OK, STATUS_FAIL, space_eval
 from hyperopt.mongoexp import MongoTrials
 from pandas import DataFrame
 
@@ -209,7 +209,7 @@ def buy_strategy_generator(params):
 
 
 def start(args):
-    global TOTAL_TRIES, PROCESSED
+    global TOTAL_TRIES, PROCESSED, SPACE
     TOTAL_TRIES = args.epochs
 
     exchange._API = Bittrex({'key': '', 'secret': ''})
@@ -236,6 +236,11 @@ def start(args):
         trials = Trials()
 
     best = fmin(fn=optimizer, space=SPACE, algo=tpe.suggest, max_evals=TOTAL_TRIES, trials=trials)
+
+    # Improve best parameter logging display
+    if best:
+        best = space_eval(SPACE, best)
+
     logger.info('Best parameters:\n%s', json.dumps(best, indent=4))
 
     results = sorted(trials.results, key=itemgetter('loss'))

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -77,3 +77,40 @@ def test_no_log_if_loss_does_not_improve(mocker):
     })
 
     assert not logger.called
+
+
+def test_fmin_best_results(mocker, caplog):
+    fmin_result = {
+      "adx": 1,
+      "adx-value": 15.0,
+      "fastd": 1,
+      "fastd-value": 40.0,
+      "green_candle": 1,
+      "mfi": 0,
+      "over_sar": 0,
+      "rsi": 1,
+      "rsi-value": 37.0,
+      "trigger": 2,
+      "uptrend_long_ema": 1,
+      "uptrend_short_ema": 0,
+      "uptrend_sma": 0
+    }
+
+    mocker.patch('freqtrade.optimize.hyperopt.MongoTrials', return_value=create_trials(mocker))
+    mocker.patch('freqtrade.optimize.preprocess')
+    mocker.patch('freqtrade.optimize.load_data')
+    mocker.patch('freqtrade.optimize.hyperopt.fmin', return_value=fmin_result)
+
+    args = mocker.Mock(epochs=1, config='config.json.example')
+    start(args)
+
+    exists = [
+        'Best parameters',
+        '"adx": {\n        "enabled": true,\n        "value": 15.0\n    },',
+        '"green_candle": {\n        "enabled": true\n    },',
+        '"mfi": {\n        "enabled": false\n    },',
+        '"trigger": {\n        "type": "ao_cross_zero"\n    },'
+    ]
+
+    for line in exists:
+        assert line in caplog.text


### PR DESCRIPTION
## Summary
This PR improve how Hyperopt display best parameters results.
We saw on Slack and also on Github, users do not understand clearly the result provided by hyperopt. With this PR why try to make it clearer.

Solve the issue: #162; #304, #309

## Quick changelog
- Improve the display of best parameter. Instead of displaying Raw Json, we display the name of the guards and triggers.

## What's new?
**Before**
```python
Best parameters:
{
  "adx": 1,
  "adx-value": 15.0,
  "fastd": 1,
  "fastd-value": 40.0,
  "green_candle": 1,
  "mfi": 0,
  "over_sar": 0,
  "rsi": 1,
  "rsi-value": 37.0,
  "trigger": 0,
  "uptrend_long_ema": 1,
  "uptrend_short_ema": 0,
  "uptrend_sma": 0
}
```

**After**
```python
Best parameters:
{
    "adx": {
        "enabled": false
    },
    "fastd": {
        "enabled": false
    },
    "green_candle": {
        "enabled": false
    },
    "mfi": {
        "enabled": false
    },
    "over_sar": {
        "enabled": false
    },
    "rsi": {
        "enabled": true,
        "value": 39.0
    },
    "trigger": {
        "type": "faststoch10"
    },
    "uptrend_long_ema": {
        "enabled": true
    },
    "uptrend_short_ema": {
        "enabled": false
    },
    "uptrend_sma": {
        "enabled": true
    }
}
```