### PR TITLE
Fix _coinmarketcap that fails backtesting and Hyperopt when no network

### DIFF
--- a/freqtrade/fiat_convert.py
+++ b/freqtrade/fiat_convert.py
@@ -57,7 +57,11 @@ class CryptoToFiatConverter():
     ]
 
     def __init__(self) -> None:
-        self._coinmarketcap = Pymarketcap()
+        try:
+            self._coinmarketcap = Pymarketcap()
+        except BaseException:
+            self._coinmarketcap = None
+
         self._pairs = []
 
     def convert_amount(self, crypto_amount: float, crypto_symbol: str, fiat_symbol: str) -> float:
@@ -147,10 +151,12 @@ class CryptoToFiatConverter():
         # Check if the fiat convertion you want is supported
         if not self._is_supported_fiat(fiat=fiat_symbol):
             raise ValueError('The fiat {} is not supported.'.format(fiat_symbol))
-
-        return float(
-            self._coinmarketcap.ticker(
-                currency=crypto_symbol,
-                convert=fiat_symbol
-            )['price_' + fiat_symbol.lower()]
-        )
+        try:
+            return float(
+                self._coinmarketcap.ticker(
+                    currency=crypto_symbol,
+                    convert=fiat_symbol
+                )['price_' + fiat_symbol.lower()]
+            )
+        except BaseException:
+            return 0.0

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -167,6 +167,7 @@ def test_profit_handle(
     mocker.patch.multiple('freqtrade.fiat_convert.Pymarketcap',
                           ticker=MagicMock(return_value={'price_usd': 15000.0}),
                           _cache_symbols=MagicMock(return_value={'BTC': 1}))
+    mocker.patch('freqtrade.fiat_convert.CryptoToFiatConverter._find_price', return_value=15000.0)
     init(default_conf, create_engine('sqlite://'))
 
     _profit(bot=MagicMock(), update=update)
@@ -422,6 +423,7 @@ def test_daily_handle(
     mocker.patch.multiple('freqtrade.fiat_convert.Pymarketcap',
                           ticker=MagicMock(return_value={'price_usd': 15000.0}),
                           _cache_symbols=MagicMock(return_value={'BTC': 1}))
+    mocker.patch('freqtrade.fiat_convert.CryptoToFiatConverter._find_price', return_value=15000.0)
     init(default_conf, create_engine('sqlite://'))
 
     # Create some test data


### PR DESCRIPTION
## Summary
This PR fix the issue caused by Pymarketcap when you use the bot without network connections (Hyperopt, Backtesting).

Solve the issue: #322

## Quick changelog
- Solve the exception raised when the bot is used without network connection
