### PR TITLE
Fix hypeopt issue when no result found

### DIFF
--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -235,13 +235,26 @@ def start(args):
     else:
         trials = Trials()
 
-    best = fmin(fn=optimizer, space=SPACE, algo=tpe.suggest, max_evals=TOTAL_TRIES, trials=trials)
+    try:
+        best_parameters = fmin(
+            fn=optimizer,
+            space=SPACE,
+            algo=tpe.suggest,
+            max_evals=TOTAL_TRIES,
+            trials=trials
+        )
+
+        results = sorted(trials.results, key=itemgetter('loss'))
+        best_result = results[0]['result']
+
+    except ValueError:
+        best_parameters = {}
+        best_result = 'Sorry, Hyperopt was not able to find good parameters. Please ' \
+                      'try with more epochs (param: -e).'
 
     # Improve best parameter logging display
-    if best:
-        best = space_eval(SPACE, best)
+    if best_parameters:
+        best_parameters = space_eval(SPACE, best_parameters)
 
-    logger.info('Best parameters:\n%s', json.dumps(best, indent=4))
-
-    results = sorted(trials.results, key=itemgetter('loss'))
-    logger.info('Best Result:\n%s', results[0]['result'])
+    logger.info('Best parameters:\n%s', json.dumps(best_parameters, indent=4))
+    logger.info('Best Result:\n%s', best_result)

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -114,3 +114,22 @@ def test_fmin_best_results(mocker, caplog):
 
     for line in exists:
         assert line in caplog.text
+
+
+def test_fmin_throw_value_error(mocker, caplog):
+    mocker.patch('freqtrade.optimize.hyperopt.MongoTrials', return_value=create_trials(mocker))
+    mocker.patch('freqtrade.optimize.preprocess')
+    mocker.patch('freqtrade.optimize.load_data')
+    mocker.patch('freqtrade.optimize.hyperopt.fmin', side_effect=ValueError())
+
+    args = mocker.Mock(epochs=1, config='config.json.example')
+    start(args)
+
+    exists = [
+        'Best Result:',
+        'Sorry, Hyperopt was not able to find good parameters. Please try with more epochs '
+        '(param: -e).',
+    ]
+
+    for line in exists:
+        assert line in caplog.text


### PR DESCRIPTION
## Summary
This PR aims to fix the issue with Hyperopt that throw an error when no parameter was found. It happens when we execute Hyperopt with too few epochs. 

Solve the issue: #337 

## Quick changelog
- Try/catch the `fmin()`, and return a message to the user

## What's new?
All issue details in the issue #337.

**Error message returned to the user**
```
Using config: config.json ...

Validating configuration ...

Best parameters:
{}

Best Result:
Sorry, Hyperopt was not able to find good parameters. Please try with more epochs (param: -e).
```