### PR TITLE
Upgrade flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
 install:
 - ./install_ta-lib.sh
 - export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-- pip install flake8 coveralls
+- pip install --upgrade flake8 coveralls
 - pip install -r requirements.txt
 - pip install -e .
 jobs:

--- a/freqtrade/analyze.py
+++ b/freqtrade/analyze.py
@@ -11,7 +11,7 @@ import talib.abstract as ta
 from pandas import DataFrame, to_datetime
 
 from freqtrade.exchange import get_ticker_history
-from freqtrade.vendor.qtpylib.indicators import awesome_oscillator, PandasObject as qtpylib
+import freqtrade.vendor.qtpylib.indicators as qtpylib
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +53,7 @@ def populate_indicators(dataframe: DataFrame) -> DataFrame:
     dataframe['adx'] = ta.ADX(dataframe)
 
     # Awesome oscillator
-    dataframe['ao'] = awesome_oscillator(dataframe)
+    dataframe['ao'] = qtpylib.awesome_oscillator(dataframe)
     """
     # Commodity Channel Index: values Oversold:<-100, Overbought:>100
     dataframe['cci'] = ta.CCI(dataframe)

--- a/freqtrade/tests/test_fiat_convert.py
+++ b/freqtrade/tests/test_fiat_convert.py
@@ -116,8 +116,8 @@ def test_fiat_convert_get_price(mocker):
 
 
 def test_fiat_convert_without_network(mocker):
-    Pymarketcap = MagicMock(side_effect=ImportError('Oh boy, you have no network!'))
-    mocker.patch('freqtrade.fiat_convert.Pymarketcap', Pymarketcap)
+    pymarketcap = MagicMock(side_effect=ImportError('Oh boy, you have no network!'))
+    mocker.patch('freqtrade.fiat_convert.Pymarketcap', pymarketcap)
 
     fiat_convert = CryptoToFiatConverter()
     assert fiat_convert._coinmarketcap is None


### PR DESCRIPTION
## Summary

We were stuck in an old version of `flake8`. This PR makes the build always use the latest.

## Quick changelog

Due to pip dependency caching we use in Travis, we would always get the same version of flake8 and coveralls. Using the `--upgrade` switch for pip, we force it to check for newer versions available.