### PR TITLE
Set timeout for bittrex only

### DIFF
--- a/freqtrade/exchange/bittrex.py
+++ b/freqtrade/exchange/bittrex.py
@@ -22,7 +22,6 @@ def custom_requests(request_url, apisign):
     """
     Set timeout for requests
     """
-    print("Dispatch", request_url, apisign)
     return requests.get(
         request_url,
         headers={"apisign": apisign},

--- a/freqtrade/exchange/bittrex.py
+++ b/freqtrade/exchange/bittrex.py
@@ -1,4 +1,5 @@
 import logging
+import requests
 from typing import List, Dict, Optional
 
 from bittrex.bittrex import Bittrex as _Bittrex, API_V2_0, API_V1_1
@@ -12,6 +13,21 @@ logger = logging.getLogger(__name__)
 _API: _Bittrex = None
 _API_V2: _Bittrex = None
 _EXCHANGE_CONF: dict = {}
+
+# API socket timeout
+API_TIMEOUT = 60
+
+
+def custom_requests(request_url, apisign):
+    """
+    Set timeout for requests
+    """
+    print("Dispatch", request_url, apisign)
+    return requests.get(
+        request_url,
+        headers={"apisign": apisign},
+        timeout=API_TIMEOUT
+    ).json()
 
 
 class Bittrex(Exchange):
@@ -31,12 +47,14 @@ class Bittrex(Exchange):
             api_secret=_EXCHANGE_CONF['secret'],
             calls_per_second=1,
             api_version=API_V1_1,
+            dispatch=custom_requests
         )
         _API_V2 = _Bittrex(
             api_key=_EXCHANGE_CONF['key'],
             api_secret=_EXCHANGE_CONF['secret'],
             calls_per_second=1,
             api_version=API_V2_0,
+            dispatch=custom_requests
         )
         self.cached_ticker = {}
 

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -10,7 +10,6 @@ from datetime import datetime
 from typing import Dict, Optional, List
 
 import requests
-from requests.adapters import TimeoutSauce
 from cachetools import cached, TTLCache
 
 from freqtrade import __version__, exchange, persistence, rpc, DependencyException, \
@@ -24,23 +23,6 @@ from freqtrade.fiat_convert import CryptoToFiatConverter
 logger = logging.getLogger('freqtrade')
 
 _CONF = {}
-
-DEFAULT_TIMEOUT = 120
-
-
-# Set requests default timeout (fix for #127)
-class DefaultTimeout(TimeoutSauce):
-    def __init__(self, *args, **kwargs):
-        connect = kwargs.get('connect', DEFAULT_TIMEOUT)
-        read = kwargs.get('read', connect)
-        if connect is None:
-            connect = DEFAULT_TIMEOUT
-        if read is None:
-            read = connect
-        super(DefaultTimeout, self).__init__(connect=connect, read=read)
-
-
-requests.adapters.TimeoutSauce = DefaultTimeout
 
 
 def refresh_whitelist(whitelist: List[str]) -> List[str]:


### PR DESCRIPTION
## Summary
Set timeout only for bittrex API to avoid side effects

Solve the issue: #127 

## What's new?
Correct way to set timeout, use python-bittrex hook instead of monkey-patching
Based on this comment https://github.com/gcarq/freqtrade/issues/127#issuecomment-356599037
