### PR TITLE
Remove delisted to-be coins from sanitized arr (dont buy)

### DIFF
--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -48,13 +48,15 @@ def refresh_whitelist(whitelist: List[str]) -> List[str]:
                 'Ignoring %s from whitelist (reason: %s).',
                 pair, status.get('Notice') or 'wallet is not active'
             )
-        # Wallet will be delisted soon (and cause a loss)
-        if "delisted" in status['Notice']:
+        # Wallet is going to be delisted (and cause a loss)
+        delisted = 'delisted'
+        if delisted in str(status['Notice']):
             sanitized_whitelist.remove(pair)
             logger.info(
                 'Ignoring %s from whitelist (reason: %s).',
                 pair, status.get('Notice') or 'wallet will be delisted soon'
             )
+
             
     # We need to remove pairs that are unknown
     final_list = [x for x in sanitized_whitelist if x in known_pairs]

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -48,15 +48,13 @@ def refresh_whitelist(whitelist: List[str]) -> List[str]:
                 'Ignoring %s from whitelist (reason: %s).',
                 pair, status.get('Notice') or 'wallet is not active'
             )
-        # Wallet is going to be delisted (and cause a loss)
-        delisted = 'delisted'
-        if delisted in str(status['Notice']):
+        # Wallet will be delisted soon (and cause a loss)
+        if 'delisted' in str(status['Notice']).lower():
             sanitized_whitelist.remove(pair)
             logger.info(
                 'Ignoring %s from whitelist (reason: %s).',
                 pair, status.get('Notice') or 'wallet will be delisted soon'
             )
-
             
     # We need to remove pairs that are unknown
     final_list = [x for x in sanitized_whitelist if x in known_pairs]

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -48,7 +48,14 @@ def refresh_whitelist(whitelist: List[str]) -> List[str]:
                 'Ignoring %s from whitelist (reason: %s).',
                 pair, status.get('Notice') or 'wallet is not active'
             )
-
+        # Wallet will be delisted soon (and cause a loss)
+        if "delisted" in status['Notice']:
+            sanitized_whitelist.remove(pair)
+            logger.info(
+                'Ignoring %s from whitelist (reason: %s).',
+                pair, status.get('Notice') or 'wallet will be delisted soon'
+            )
+            
     # We need to remove pairs that are unknown
     final_list = [x for x in sanitized_whitelist if x in known_pairs]
     return final_list


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/gcarq/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary
Remove delisted to-be coins from sanitized arr (dont buy)
Solve the issue: #382 

## Quick changelog

- Remove delisted to-be coins from sanitized arr (dont buy): Solve the issue: #382 
