### PR TITLE
Show estimated BTC and fiat balance

### DIFF
--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -382,13 +382,31 @@ def _balance(bot: Bot, update: Update) -> None:
     if not balances:
         output = '`All balances are zero.`'
 
+    total = 0.0
     for currency in balances:
-        output += """*Currency*: {Currency}
+        coin = currency['Currency']
+        if coin == 'BTC':
+            currency["Rate"] = 1.0
+        else:
+            currency["Rate"] = exchange.get_ticker('BTC_' + coin, False)['bid']
+        currency['BTC'] = currency["Rate"] * currency["Balance"]
+        total = total + currency['BTC']
+        output += """{Currency}:
 *Available*: {Available}
 *Balance*: {Balance}
 *Pending*: {Pending}
+*Est. BTC*: {BTC: .8f}
 
 """.format(**currency)
+
+    symbol = _CONF['fiat_display_currency']
+    value = _FIAT_CONVERT.convert_amount(
+        total, 'BTC', symbol
+    )
+    output += """*Estimated Value*:
+*BTC*: {0: .8f}
+*{1}*: {2: .2f}
+""".format(total, symbol, value)
     send_msg(output)
 
 

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -391,7 +391,7 @@ def _balance(bot: Bot, update: Update) -> None:
             currency["Rate"] = exchange.get_ticker('BTC_' + coin, False)['bid']
         currency['BTC'] = currency["Rate"] * currency["Balance"]
         total = total + currency['BTC']
-        output += """{Currency}:
+        output += """*Currency*: {Currency}
 *Available*: {Available}
 *Balance*: {Balance}
 *Pending*: {Pending}

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -606,11 +606,15 @@ def test_balance_handle(default_conf, update, mocker):
                           send_msg=msg_mock)
     mocker.patch.multiple('freqtrade.main.exchange',
                           get_balances=MagicMock(return_value=mock_balance))
+    mocker.patch.multiple('freqtrade.fiat_convert.Pymarketcap',
+                          ticker=MagicMock(return_value={'price_usd': 15000.0}),
+                          _cache_symbols=MagicMock(return_value={'BTC': 1}))
 
     _balance(bot=MagicMock(), update=update)
     assert msg_mock.call_count == 1
     assert '*Currency*: BTC' in msg_mock.call_args_list[0][0][0]
     assert 'Balance' in msg_mock.call_args_list[0][0][0]
+    assert 'Est. BTC' in msg_mock.call_args_list[0][0][0]
 
 
 def test_help_handle(default_conf, update, mocker):


### PR DESCRIPTION
## Summary

Show estimated BTC and fiat amount by /balance command (like in bittrex wallets section)

## What's new?
Example:

*Currency*: BTC
*Available*: 12.0
*Balance*: 10.0
*Pending*: 0.0
*Est. BTC*:  10.00000000

*Estimated Value*:
*BTC*:  10.00000000
*USD*:  150000.00
