### PR TITLE
Fix markdown mistakes in backtesting doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ to understand the requirements before sending your pull-requests.
 ### Bot commands
 
 ```bash
-usage: main.py [-h] [-c PATH] [-v] [--version] [--dynamic-whitelist [INT]]
-               [--dry-run-db]
+usage: main.py [-h] [-v] [--version] [-c PATH] [--dry-run-db] [--datadir PATH]
+               [--dynamic-whitelist [INT]]
                {backtesting,hyperopt} ...
 
 Simple High Frequency Trading Bot for crypto currencies
@@ -149,16 +149,17 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  -c PATH, --config PATH
-                        specify configuration file (default: config.json)
   -v, --verbose         be verbose
   --version             show program's version number and exit
-  --dynamic-whitelist [INT]
-                        dynamically generate and update whitelist based on 24h
-                        BaseVolume (Default 20 currencies)
+  -c PATH, --config PATH
+                        specify configuration file (default: config.json)
   --dry-run-db          Force dry run to use a local DB
                         "tradesv3.dry_run.sqlite" instead of memory DB. Work
                         only if dry_run is enabled.
+  --datadir PATH        path to backtest data (default freqdata/tests/testdata
+  --dynamic-whitelist [INT]
+                        dynamically generate and update whitelist based on 24h
+                        BaseVolume (Default 20 currencies)
 ```
 More details on:
 - [How to run the bot](https://github.com/gcarq/freqtrade/blob/develop/docs/bot-usage.md#bot-commands)

--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -14,7 +14,7 @@ real data. This is what we call
 
 Backtesting will use the crypto-currencies (pair) from your config file
 and load static tickers located in 
-[/freqtrade/tests/testdata](https://github.com/gcarq/freqtrade/tree/develop/freqtrade/tests/testdata).
+[/freqtrade/tests/testdata](https://github.com/gcarq/freqtrade/tree/develop/freqtrade/tests/testdata).  
 If the 5 min and 1 min ticker for the crypto-currencies to test is not 
 already in the `testdata` folder, backtesting will download them 
 automatically. Testdata files will not be updated until you specify it.
@@ -51,38 +51,44 @@ python3 ./freqtrade/main.py backtesting --realistic-simulation --live
 python3 ./freqtrade/main.py backtesting --datadir freqtrade/tests/testdata-20180101
 ```
 
-**Running backtest with smaller testset**
-Use the --timerange argument to change how much of the testset
+**Running backtest with smaller testset**  
+Use the `--timerange` argument to change how much of the testset
 you want to use. The last N ticks/timeframes will be used.
-Example:
 
+Example:
 ```bash
 python3 ./freqtrade/main.py backtesting --timerange=-200
 ```
 
-***Advanced use of timerange***
-  Doing --timerange=-200 will get the last 200 timeframes
-  from your inputdata. You can also specify specific dates,
-  or a range span indexed by start and stop.
-  The full timerange specification:
-  Not implemented yet! --timerange=-20180131
-  Not implemented yet! --timerange=20180101-
-  Not implemented yet! --timerange=20180101-20181231
-  Last 123 tickframes of data:  --timerange=-123
-  First 123 tickframes of data: --timerange=123-
-  Tickframes from line 123 through 456: --timerange=123-456
+***Advanced use of timerange***  
+Doing `--timerange=-200` will get the last 200 timeframes
+from your inputdata. You can also specify specific dates,
+or a range span indexed by start and stop.
+
+The full timerange specification:
+- Use last 123 tickframes of data: `--timerange=-123`
+- Use first 123 tickframes of data: `--timerange=123-`
+- Use tickframes from line 123 through 456: `--timerange=123-456`
 
 
-**Update testdata directory
+Incoming feature, not implemented yet:
+- `--timerange=-20180131`
+-  `--timerange=20180101-`
+- `--timerange=20180101-20181231`
+
+
+**Update testdata directory**
 To update your testdata directory, or download into another testdata directory:
 ```bash
-mkdir freqtrade/tests/testdata-20180113
-cp freqtrade/tests/testdata/pairs.json freqtrade/tests/testdata-20180113
-cd freqtrade/tests/testdata-20180113
+mkdir -p user_data/data/testdata-20180113
+cp freqtrade/tests/testdata/pairs.json user_data/data-20180113
+cd user_data/data-20180113
+```
 
 Possibly edit pairs.json file to include/exclude pairs
 
-python download_backtest_data.py -p pairs.json
+```bash
+python freqtrade/tests/testdata/download_backtest_data.py -p pairs.json
 ```
 
 The script will read your pairs.json file, and download ticker data


### PR DESCRIPTION
## Summary
PR #357 and #328 has introduced markdown render mistakes in the `backtesting.md`
This PR fix the formatting of `backtesting.md`

## Quick changelog

- Fix formatting issue on `backtesting.md`