### PR TITLE
Add number of trades in /daily command

### DIFF
--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -241,20 +241,27 @@ def _daily(bot: Bot, update: Update) -> None:
             .order_by(Trade.close_date)\
             .all()
         curdayprofit = sum(trade.calc_profit() for trade in trades)
-        profit_days[profitday] = format(curdayprofit, '.8f')
+        profit_days[profitday] = {
+            'amount': format(curdayprofit, '.8f'),
+            'trades': len(trades)
+        }
 
     stats = [
         [
             key,
-            '{value:.8f} {symbol}'.format(value=float(value), symbol=_CONF['stake_currency']),
+            '{value:.8f} {symbol}'.format(
+                value=float(value['amount']),
+                symbol=_CONF['stake_currency']
+            ),
             '{value:.3f} {symbol}'.format(
                 value=_FIAT_CONVERT.convert_amount(
-                    value,
+                    value['amount'],
                     _CONF['stake_currency'],
                     _CONF['fiat_display_currency']
                 ),
                 symbol=_CONF['fiat_display_currency']
-            )
+            ),
+            '{value} trade{s}'.format(value=value['trades'], s='' if value['trades'] < 2 else 's'),
         ]
         for key, value in profit_days.items()
     ]
@@ -262,7 +269,8 @@ def _daily(bot: Bot, update: Update) -> None:
                      headers=[
                          'Day',
                          'Profit {}'.format(_CONF['stake_currency']),
-                         'Profit {}'.format(_CONF['fiat_display_currency'])
+                         'Profit {}'.format(_CONF['fiat_display_currency']),
+                         '# Trades'
                      ],
                      tablefmt='simple')
 

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -448,6 +448,28 @@ def test_daily_handle(
     assert str(datetime.utcnow().date()) in msg_mock.call_args_list[0][0][0]
     assert str('  0.00006217 BTC') in msg_mock.call_args_list[0][0][0]
     assert str('  0.933 USD') in msg_mock.call_args_list[0][0][0]
+    assert str('  1 trade') in msg_mock.call_args_list[0][0][0]
+    assert str('  0 trade') in msg_mock.call_args_list[0][0][0]
+
+    # Reset msg_mock
+    msg_mock.reset_mock()
+    # Add two other trades
+    create_trade(0.001)
+    create_trade(0.001)
+
+    trades = Trade.query.all()
+    for trade in trades:
+        trade.update(limit_buy_order)
+        trade.update(limit_sell_order)
+        trade.close_date = datetime.utcnow()
+        trade.is_open = False
+
+    update.message.text = '/daily 1'
+
+    _daily(bot=MagicMock(), update=update)
+    assert str('  0.00018651 BTC') in msg_mock.call_args_list[0][0][0]
+    assert str('  2.798 USD') in msg_mock.call_args_list[0][0][0]
+    assert str('  3 trades') in msg_mock.call_args_list[0][0][0]
 
     # Try invalid data
     msg_mock.reset_mock()


### PR DESCRIPTION
## Summary
Very simple PR that add the number of trades in /daily report.

![num-of-trades](https://user-images.githubusercontent.com/1137839/35180470-e016e2ac-fd65-11e7-9b98-c2ddf8931738.png)

Solve the issue: #408 

## Quick changelog

- Add number of trades made during the day when using `/daily` command
