### PR TITLE
fixing handling of data fetched from Bittrex server with bad content in the ticker

### DIFF
--- a/freqtrade/exchange/bittrex.py
+++ b/freqtrade/exchange/bittrex.py
@@ -122,9 +122,10 @@ class Bittrex(Exchange):
                 raise OperationalException('{message} params=({pair})'.format(
                     message=data['message'],
                     pair=pair))
-
+            keys = ['Bid', 'Ask', 'Last']
             if not data.get('result') or\
-                    not all(key in data.get('result', {}) for key in ['Bid', 'Ask', 'Last']):
+                    not all(key in data.get('result', {}) for key in keys) or\
+                    not all(data.get('result', {})[key] is not None for key in keys):
                 raise ContentDecodingError('{message} params=({pair})'.format(
                     message='Got invalid response from bittrex',
                     pair=pair))

--- a/freqtrade/tests/exchange/test_exchange_bittrex.py
+++ b/freqtrade/tests/exchange/test_exchange_bittrex.py
@@ -232,6 +232,11 @@ def test_exchange_bittrex_get_ticker_bad():
     with pytest.raises(btx.OperationalException, match=r'.*gone bad.*'):
         wb.get_ticker('BTC_ETH')
 
+    fb.result = {'success': True,
+                 'result': {'Bid': 1, 'Ask': 0, 'Last': None}}  # incomplete result
+    with pytest.raises(ContentDecodingError, match=r'.*Got invalid response from bittrex params.*'):
+        wb.get_ticker('BTC_ETH')
+
 
 def test_exchange_bittrex_get_ticker_history_one():
     wb = make_wrap_bittrex()


### PR DESCRIPTION
## Summary
This PR fixes handling of data fetched from Bittrex sever with bad content in the ticker

Solve the issue: #406 

## Quick changelog

- analyze the ticker and throw a ContentDecodingError is one of Bid, Ask, Last is incoherent
- add a unit test
