### PR TITLE
Remove optimize.load_data() that is called twice

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -187,9 +187,6 @@ def start(args):
             data[pair] = exchange.get_ticker_history(pair, ticker_interval)
     else:
         logger.info('Using local backtesting data (using whitelist in given config) ...')
-        data = optimize.load_data(args.datadir, pairs=pairs, ticker_interval=ticker_interval,
-                                  refresh_pairs=args.refresh_pairs)
-
         logger.info('Using stake_currency: %s ...', config['stake_currency'])
         logger.info('Using stake_amount: %s ...', config['stake_amount'])
 


### PR DESCRIPTION
## Summary
In backtesting.py::start() `optimize.load_data()` is called twice. There is a wrong refactoring here. One call is enough.

## Quick changelog
- Remove duplicate `optimize.load_data()` call in `backtesting.py::start()`

## What's new?
Clean and Optimize backtesting.py


The initial code was:
```python
        logger.info('Using local backtesting data (using whitelist in given config) ...')
        data = optimize.load_data(args.datadir, pairs=pairs, ticker_interval=ticker_interval,
                                  refresh_pairs=args.refresh_pairs)

        logger.info('Using stake_currency: %s ...', config['stake_currency'])
        logger.info('Using stake_amount: %s ...', config['stake_amount'])

        timerange = misc.parse_timerange(args.timerange)
        data = optimize.load_data(args.datadir, pairs=pairs, ticker_interval=args.ticker_interval,
                                  refresh_pairs=args.refresh_pairs,
                                  timerange=timerange)
```

The first load_data is wrong and useless.