### PR TITLE
Feat/telegram sell msg

### DIFF
--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -193,7 +193,7 @@ def execute_sell(trade: Trade, limit: float) -> None:
     profit_trade = trade.calc_profit(rate=limit)
     current_rate = exchange.get_ticker(trade.pair, False)['bid']
     current_profit = trade.calc_profit_percent(current_rate)
-    
+
     message = """*{exchange}:* Selling
 *Current Pair:* [{pair}]({pair_url})
 *Limit:* `{limit}`

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -191,12 +191,25 @@ def execute_sell(trade: Trade, limit: float) -> None:
 
     fmt_exp_profit = round(trade.calc_profit_percent(rate=limit) * 100, 2)
     profit_trade = trade.calc_profit(rate=limit)
-
-    message = '*{exchange}:* Selling [{pair}]({pair_url}) with limit `{limit:.8f}`'.format(
+    current_rate = exchange.get_ticker(trade.pair, False)['bid']
+    current_profit = trade.calc_profit_percent(current_rate)
+    
+    message = """*{exchange}:* Selling
+*Current Pair:* [{pair}]({pair_url})
+*Limit:* `{limit}`
+*Amount:* `{amount}`
+*Open Rate:* `{open_rate:.8f}`
+*Current Rate:* `{current_rate:.8f}`
+*Current Profit:* `{current_profit:.2f}%`
+    """.format(
         exchange=trade.exchange,
         pair=trade.pair.replace('_', '/'),
         pair_url=exchange.get_pair_detail_url(trade.pair),
-        limit=limit
+        limit=limit,
+        open_rate=trade.open_rate,
+        current_rate=current_rate,
+        amount=round(trade.amount, 8),
+        current_profit=round(current_profit * 100, 2),
     )
 
     # For regular case, when the configuration exists

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -156,6 +156,7 @@ def _status(bot: Bot, update: Update) -> None:
 *Close Profit:* `{close_profit}`
 *Current Profit:* `{current_profit:.2f}%`
 *Open Order:* `{open_order}`
+*Total Open Trades:* `{total_trades}`
             """.format(
                 trade_id=trade.id,
                 pair=trade.pair.replace('_', '/'),
@@ -170,6 +171,7 @@ def _status(bot: Bot, update: Update) -> None:
                 open_order='({} rem={:.8f})'.format(
                     order['type'], order['remaining']
                 ) if order else None,
+                total_trades=len(trades)
             )
             send_msg(message, bot=bot)
 

--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -147,7 +147,7 @@ def _status(bot: Bot, update: Update) -> None:
             ) if trade.close_profit else None
             message = """
 *Trade ID:* `{trade_id}`
-*Current Pair:* [{pair}]({market_url})
+*Current Pair:* [{pair}]({pair_url})
 *Open Since:* `{date}`
 *Amount:* `{amount}`
 *Open Rate:* `{open_rate:.8f}`
@@ -158,8 +158,8 @@ def _status(bot: Bot, update: Update) -> None:
 *Open Order:* `{open_order}`
             """.format(
                 trade_id=trade.id,
-                pair=trade.pair,
-                market_url=exchange.get_pair_detail_url(trade.pair),
+                pair=trade.pair.replace('_', '/'),
+                pair_url=exchange.get_pair_detail_url(trade.pair),
                 date=arrow.get(trade.open_date).humanize(),
                 open_rate=trade.open_rate,
                 close_rate=trade.close_rate,

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -107,7 +107,7 @@ def test_status_handle(default_conf, update, ticker, mocker):
     _status(bot=MagicMock(), update=update)
 
     assert msg_mock.call_count == 1
-    assert '[BTC_ETH]' in msg_mock.call_args_list[0][0][0]
+    assert '[BTC/ETH]' in msg_mock.call_args_list[0][0][0]
 
 
 def test_status_table_handle(default_conf, update, ticker, mocker):
@@ -239,7 +239,9 @@ def test_forcesell_handle(default_conf, update, ticker, ticker_sell_up, mocker):
     _forcesell(bot=MagicMock(), update=update)
 
     assert rpc_mock.call_count == 2
-    assert 'Selling [BTC/ETH]' in rpc_mock.call_args_list[-1][0][0]
+    assert 'Selling' in rpc_mock.call_args_list[-1][0][0]
+    assert '[BTC/ETH]' in rpc_mock.call_args_list[-1][0][0]
+    assert 'Amount' in rpc_mock.call_args_list[-1][0][0]
     assert '0.00001172' in rpc_mock.call_args_list[-1][0][0]
     assert 'profit: 6.11%, 0.00006126' in rpc_mock.call_args_list[-1][0][0]
     assert '0.919 USD' in rpc_mock.call_args_list[-1][0][0]
@@ -276,7 +278,9 @@ def test_forcesell_down_handle(default_conf, update, ticker, ticker_sell_down, m
     _forcesell(bot=MagicMock(), update=update)
 
     assert rpc_mock.call_count == 2
-    assert 'Selling [BTC/ETH]' in rpc_mock.call_args_list[-1][0][0]
+    assert 'Selling' in rpc_mock.call_args_list[-1][0][0]
+    assert '[BTC/ETH]' in rpc_mock.call_args_list[-1][0][0]
+    assert 'Amount' in rpc_mock.call_args_list[-1][0][0]
     assert '0.00001044' in rpc_mock.call_args_list[-1][0][0]
     assert 'loss: -5.48%, -0.00005492' in rpc_mock.call_args_list[-1][0][0]
     assert '-0.824 USD' in rpc_mock.call_args_list[-1][0][0]

--- a/freqtrade/tests/test_main.py
+++ b/freqtrade/tests/test_main.py
@@ -544,7 +544,10 @@ def test_execute_sell_up(default_conf, ticker, ticker_sell_up, mocker):
     execute_sell(trade=trade, limit=ticker_sell_up()['bid'])
 
     assert rpc_mock.call_count == 2
-    assert 'Selling [BTC/ETH]' in rpc_mock.call_args_list[-1][0][0]
+    assert 'Selling' in rpc_mock.call_args_list[-1][0][0]
+    assert '[BTC/ETH]' in rpc_mock.call_args_list[-1][0][0]
+    assert 'Amount' in rpc_mock.call_args_list[-1][0][0]
+    assert 'Current Profit' in rpc_mock.call_args_list[-1][0][0]
     assert '0.00001172' in rpc_mock.call_args_list[-1][0][0]
     assert 'profit: 6.11%, 0.00006126' in rpc_mock.call_args_list[-1][0][0]
     assert '0.919 USD' in rpc_mock.call_args_list[-1][0][0]
@@ -581,7 +584,9 @@ def test_execute_sell_down(default_conf, ticker, ticker_sell_down, mocker):
     execute_sell(trade=trade, limit=ticker_sell_down()['bid'])
 
     assert rpc_mock.call_count == 2
-    assert 'Selling [BTC/ETH]' in rpc_mock.call_args_list[-1][0][0]
+    assert 'Selling' in rpc_mock.call_args_list[-1][0][0]
+    assert '[BTC/ETH]' in rpc_mock.call_args_list[-1][0][0]
+    assert 'Amount' in rpc_mock.call_args_list[-1][0][0]
     assert '0.00001044' in rpc_mock.call_args_list[-1][0][0]
     assert 'loss: -5.48%, -0.00005492' in rpc_mock.call_args_list[-1][0][0]
     assert '-0.824 USD' in rpc_mock.call_args_list[-1][0][0]
@@ -612,7 +617,9 @@ def test_execute_sell_without_conf(default_conf, ticker, ticker_sell_up, mocker)
     execute_sell(trade=trade, limit=ticker_sell_up()['bid'])
 
     assert rpc_mock.call_count == 2
-    assert 'Selling [BTC/ETH]' in rpc_mock.call_args_list[-1][0][0]
+    assert 'Selling' in rpc_mock.call_args_list[-1][0][0]
+    assert '[BTC/ETH]' in rpc_mock.call_args_list[-1][0][0]
+    assert 'Amount' in rpc_mock.call_args_list[-1][0][0]
     assert '0.00001172' in rpc_mock.call_args_list[-1][0][0]
     assert '(profit: 6.11%, 0.00006126)' in rpc_mock.call_args_list[-1][0][0]
     assert 'USD' not in rpc_mock.call_args_list[-1][0][0]


### PR DESCRIPTION
## Summary
Add more info about the trade on the sell message we send through telegram. Also total number of trades is now included in `/status`


Relates to #410 

See attached screenshot
<img width="531" alt="selling_msg" src="https://user-images.githubusercontent.com/590002/35197251-751bb0a0-fee5-11e7-9058-f76199ce279c.png">



