### PR TITLE
Speed up unittest from 60s to 6s

### DIFF
--- a/freqtrade/fiat_convert.py
+++ b/freqtrade/fiat_convert.py
@@ -87,7 +87,7 @@ class CryptoToFiatConverter():
         fiat_symbol = fiat_symbol.upper()
 
         # Check if the fiat convertion you want is supported
-        if not self._is_supported_fiat(fiat=fiat_symbol):
+        if not CryptoToFiatConverter.is_supported_fiat(fiat=fiat_symbol):
             raise ValueError('The fiat {} is not supported.'.format(fiat_symbol))
 
         # Get the pair that interest us and return the price in fiat
@@ -131,7 +131,7 @@ class CryptoToFiatConverter():
 
         return price
 
-    def _is_supported_fiat(self, fiat: str) -> bool:
+    def is_supported_fiat(fiat: str) -> bool:
         """
         Check if the FIAT your want to convert to is supported
         :param fiat: FIAT to check (e.g USD)
@@ -140,7 +140,7 @@ class CryptoToFiatConverter():
 
         fiat = fiat.upper()
 
-        return fiat in self.SUPPORTED_FIAT
+        return fiat in CryptoToFiatConverter.SUPPORTED_FIAT
 
     def _find_price(self, crypto_symbol: str, fiat_symbol: str) -> float:
         """
@@ -150,7 +150,7 @@ class CryptoToFiatConverter():
         :return: float, price of the crypto-currency in Fiat
         """
         # Check if the fiat convertion you want is supported
-        if not self._is_supported_fiat(fiat=fiat_symbol):
+        if not CryptoToFiatConverter.is_supported_fiat(fiat=fiat_symbol):
             raise ValueError('The fiat {} is not supported.'.format(fiat_symbol))
         try:
             return float(

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -87,6 +87,7 @@ def test_status_handle(default_conf, update, ticker, mocker):
     mocker.patch.multiple('freqtrade.main.exchange',
                           validate_pairs=MagicMock(),
                           get_ticker=ticker)
+    mocker.patch('freqtrade.fiat_convert.Pymarketcap', MagicMock())
     init(default_conf, create_engine('sqlite://'))
 
     update_state(State.STOPPED)
@@ -124,6 +125,7 @@ def test_status_table_handle(default_conf, update, ticker, mocker):
                           validate_pairs=MagicMock(),
                           get_ticker=ticker,
                           buy=MagicMock(return_value='mocked_order_id'))
+    mocker.patch('freqtrade.fiat_convert.Pymarketcap', MagicMock())
     init(default_conf, create_engine('sqlite://'))
     update_state(State.STOPPED)
     _status_table(bot=MagicMock(), update=update)
@@ -386,6 +388,7 @@ def test_performance_handle(
     mocker.patch.multiple('freqtrade.main.exchange',
                           validate_pairs=MagicMock(),
                           get_ticker=ticker)
+    mocker.patch('freqtrade.fiat_convert.Pymarketcap', MagicMock())
     init(default_conf, create_engine('sqlite://'))
 
     # Create some test data
@@ -493,6 +496,7 @@ def test_count_handle(default_conf, update, ticker, mocker):
                           validate_pairs=MagicMock(),
                           get_ticker=ticker,
                           buy=MagicMock(return_value='mocked_order_id'))
+    mocker.patch('freqtrade.fiat_convert.Pymarketcap', MagicMock())
     init(default_conf, create_engine('sqlite://'))
     update_state(State.STOPPED)
     _count(bot=MagicMock(), update=update)

--- a/freqtrade/tests/test_fiat_convert.py
+++ b/freqtrade/tests/test_fiat_convert.py
@@ -36,12 +36,11 @@ def test_pair_convertion_object():
     assert pair_convertion.price == 30000.123
 
 
-def test_fiat_convert_is_supported():
-    fiat_convert = CryptoToFiatConverter()
-    assert fiat_convert._is_supported_fiat(fiat='USD') is True
-    assert fiat_convert._is_supported_fiat(fiat='usd') is True
-    assert fiat_convert._is_supported_fiat(fiat='abc') is False
-    assert fiat_convert._is_supported_fiat(fiat='ABC') is False
+def test_fiat_convert_is_supported(mocker):
+    assert CryptoToFiatConverter.is_supported_fiat(fiat='USD') is True
+    assert CryptoToFiatConverter.is_supported_fiat(fiat='usd') is True
+    assert CryptoToFiatConverter.is_supported_fiat(fiat='abc') is False
+    assert CryptoToFiatConverter.is_supported_fiat(fiat='ABC') is False
 
 
 def test_fiat_convert_add_pair():

--- a/freqtrade/tests/test_fiat_convert.py
+++ b/freqtrade/tests/test_fiat_convert.py
@@ -43,7 +43,9 @@ def test_fiat_convert_is_supported(mocker):
     assert CryptoToFiatConverter.is_supported_fiat(fiat='ABC') is False
 
 
-def test_fiat_convert_add_pair():
+def test_fiat_convert_add_pair(mocker):
+    api_mock = MagicMock(return_value={})
+    mocker.patch('freqtrade.fiat_convert.Pymarketcap', api_mock)
     fiat_convert = CryptoToFiatConverter()
 
     assert len(fiat_convert._pairs) == 0

--- a/freqtrade/tests/test_fiat_convert.py
+++ b/freqtrade/tests/test_fiat_convert.py
@@ -67,7 +67,7 @@ def test_fiat_convert_find_price(mocker):
     api_mock = MagicMock(return_value={
         'ticker': MagicMock(return_value={
             'price_usd': 12345.0,
-        'price_eur': 13000.2
+            'price_eur': 13000.2
         })
     })
     mocker.patch('freqtrade.fiat_convert.Pymarketcap', api_mock)

--- a/freqtrade/tests/test_fiat_convert.py
+++ b/freqtrade/tests/test_fiat_convert.py
@@ -63,10 +63,12 @@ def test_fiat_convert_add_pair():
 
 def test_fiat_convert_find_price(mocker):
     api_mock = MagicMock(return_value={
-        'price_usd': 12345.0,
+        'ticker': MagicMock(return_value={
+            'price_usd': 12345.0,
         'price_eur': 13000.2
+        })
     })
-    mocker.patch('freqtrade.fiat_convert.Pymarketcap.ticker', api_mock)
+    mocker.patch('freqtrade.fiat_convert.Pymarketcap', api_mock)
     fiat_convert = CryptoToFiatConverter()
 
     with pytest.raises(ValueError, match=r'The fiat ABC is not supported.'):
@@ -82,10 +84,12 @@ def test_fiat_convert_find_price(mocker):
 
 def test_fiat_convert_get_price(mocker):
     api_mock = MagicMock(return_value={
-        'price_usd': 28000.0,
-        'price_eur': 15000.0
+        'ticker': MagicMock(return_value={
+            'price_usd': 28000.0,
+            'price_eur': 15000.0
+        })
     })
-    mocker.patch('freqtrade.fiat_convert.Pymarketcap.ticker', api_mock)
+    mocker.patch('freqtrade.fiat_convert.Pymarketcap', api_mock)
     mocker.patch('freqtrade.fiat_convert.CryptoToFiatConverter._find_price', return_value=28000.0)
 
     fiat_convert = CryptoToFiatConverter()

--- a/freqtrade/tests/test_main.py
+++ b/freqtrade/tests/test_main.py
@@ -58,6 +58,7 @@ def test_process_trade_creation(default_conf, ticker, limit_buy_order, health, m
                           get_wallet_health=health,
                           buy=MagicMock(return_value='mocked_limit_buy'),
                           get_order=MagicMock(return_value=limit_buy_order))
+    mocker.patch('freqtrade.fiat_convert.Pymarketcap', MagicMock())
     init(default_conf, create_engine('sqlite://'))
 
     trades = Trade.query.filter(Trade.is_open.is_(True)).all()
@@ -123,6 +124,7 @@ def test_process_trade_handling(default_conf, ticker, limit_buy_order, health, m
                           get_wallet_health=health,
                           buy=MagicMock(return_value='mocked_limit_buy'),
                           get_order=MagicMock(return_value=limit_buy_order))
+    mocker.patch('freqtrade.fiat_convert.Pymarketcap', MagicMock())
     init(default_conf, create_engine('sqlite://'))
 
     trades = Trade.query.filter(Trade.is_open.is_(True)).all()
@@ -144,6 +146,8 @@ def test_create_trade(default_conf, ticker, limit_buy_order, mocker):
                           validate_pairs=MagicMock(),
                           get_ticker=ticker,
                           buy=MagicMock(return_value='mocked_limit_buy'))
+    mocker.patch('freqtrade.fiat_convert.Pymarketcap', MagicMock())
+
     # Save state of current whitelist
     whitelist = copy.deepcopy(default_conf['exchange']['pair_whitelist'])
 
@@ -165,7 +169,6 @@ def test_create_trade(default_conf, ticker, limit_buy_order, mocker):
 
     assert whitelist == default_conf['exchange']['pair_whitelist']
 
-
 def test_create_trade_minimal_amount(default_conf, ticker, mocker):
     mocker.patch.dict('freqtrade.main._CONF', default_conf)
     mocker.patch.multiple('freqtrade.rpc', init=MagicMock(), send_msg=MagicMock())
@@ -176,6 +179,7 @@ def test_create_trade_minimal_amount(default_conf, ticker, mocker):
     mocker.patch.multiple('freqtrade.main.exchange',
                           validate_pairs=MagicMock(),
                           get_ticker=ticker)
+    mocker.patch('freqtrade.fiat_convert.Pymarketcap', MagicMock())
     init(default_conf, create_engine('sqlite://'))
     min_stake_amount = 0.0005
     create_trade(min_stake_amount, int(default_conf['ticker_interval']))
@@ -278,6 +282,7 @@ def test_handle_overlpapping_signals(default_conf, ticker, mocker, caplog):
                           get_ticker=ticker,
                           buy=MagicMock(return_value='mocked_limit_buy'))
     mocker.patch('freqtrade.main.min_roi_reached', return_value=False)
+    mocker.patch('freqtrade.fiat_convert.Pymarketcap', MagicMock())
 
     init(default_conf, create_engine('sqlite://'))
     create_trade(0.001, int(default_conf['ticker_interval']))
@@ -324,6 +329,7 @@ def test_handle_trade_roi(default_conf, ticker, mocker, caplog):
                           get_ticker=ticker,
                           buy=MagicMock(return_value='mocked_limit_buy'))
     mocker.patch('freqtrade.main.min_roi_reached', return_value=True)
+    mocker.patch('freqtrade.fiat_convert.Pymarketcap', MagicMock())
 
     init(default_conf, create_engine('sqlite://'))
     create_trade(0.001, int(default_conf['ticker_interval']))
@@ -356,6 +362,7 @@ def test_handle_trade_experimental(default_conf, ticker, mocker, caplog):
                           get_ticker=ticker,
                           buy=MagicMock(return_value='mocked_limit_buy'))
     mocker.patch('freqtrade.main.min_roi_reached', return_value=False)
+    mocker.patch('freqtrade.fiat_convert.Pymarketcap', MagicMock())
 
     init(default_conf, create_engine('sqlite://'))
     create_trade(0.001, int(default_conf['ticker_interval']))
@@ -380,6 +387,7 @@ def test_close_trade(default_conf, ticker, limit_buy_order, limit_sell_order, mo
                           validate_pairs=MagicMock(),
                           get_ticker=ticker,
                           buy=MagicMock(return_value='mocked_limit_buy'))
+    mocker.patch('freqtrade.fiat_convert.Pymarketcap', MagicMock())
 
     # Create trade and sell it
     init(default_conf, create_engine('sqlite://'))
@@ -595,6 +603,7 @@ def test_execute_sell_without_conf_sell_down(default_conf, ticker, ticker_sell_d
     mocker.patch.multiple('freqtrade.main.exchange',
                           validate_pairs=MagicMock(),
                           get_ticker=ticker)
+    mocker.patch('freqtrade.fiat_convert.Pymarketcap', MagicMock())
     init(default_conf, create_engine('sqlite://'))
 
     # Create some test data
@@ -627,6 +636,7 @@ def test_execute_sell_without_conf_sell_up(default_conf, ticker, ticker_sell_up,
     mocker.patch.multiple('freqtrade.main.exchange',
                           validate_pairs=MagicMock(),
                           get_ticker=ticker)
+    mocker.patch('freqtrade.fiat_convert.Pymarketcap', MagicMock())
     init(default_conf, create_engine('sqlite://'))
 
     # Create some test data
@@ -668,6 +678,7 @@ def test_sell_profit_only_enable_profit(default_conf, limit_buy_order, mocker):
                               'last': 0.00002172
                           }),
                           buy=MagicMock(return_value='mocked_limit_buy'))
+    mocker.patch('freqtrade.fiat_convert.Pymarketcap', MagicMock())
 
     init(default_conf, create_engine('sqlite://'))
     create_trade(0.001, int(default_conf['ticker_interval']))
@@ -696,6 +707,7 @@ def test_sell_profit_only_disable_profit(default_conf, limit_buy_order, mocker):
                               'last': 0.00002172
                           }),
                           buy=MagicMock(return_value='mocked_limit_buy'))
+    mocker.patch('freqtrade.fiat_convert.Pymarketcap', MagicMock())
 
     init(default_conf, create_engine('sqlite://'))
     create_trade(0.001, int(default_conf['ticker_interval']))
@@ -724,6 +736,7 @@ def test_sell_profit_only_enable_loss(default_conf, limit_buy_order, mocker):
                               'last': 0.00000172
                           }),
                           buy=MagicMock(return_value='mocked_limit_buy'))
+    mocker.patch('freqtrade.fiat_convert.Pymarketcap', MagicMock())
 
     init(default_conf, create_engine('sqlite://'))
     create_trade(0.001, int(default_conf['ticker_interval']))
@@ -752,6 +765,7 @@ def test_sell_profit_only_disable_loss(default_conf, limit_buy_order, mocker):
                               'last': 0.00000172
                           }),
                           buy=MagicMock(return_value='mocked_limit_buy'))
+    mocker.patch('freqtrade.fiat_convert.Pymarketcap', MagicMock())
 
     init(default_conf, create_engine('sqlite://'))
     create_trade(0.001, int(default_conf['ticker_interval']))

--- a/freqtrade/tests/test_main.py
+++ b/freqtrade/tests/test_main.py
@@ -169,6 +169,7 @@ def test_create_trade(default_conf, ticker, limit_buy_order, mocker):
 
     assert whitelist == default_conf['exchange']['pair_whitelist']
 
+
 def test_create_trade_minimal_amount(default_conf, ticker, mocker):
     mocker.patch.dict('freqtrade.main._CONF', default_conf)
     mocker.patch.multiple('freqtrade.rpc', init=MagicMock(), send_msg=MagicMock())


### PR DESCRIPTION
## Summary
Speed up unit test from 60s to 6s by only mocking Pymarketcap() lib.

Solve the issue: #420

## Quick changelog

- Mock `freqtrade.fiat_convert.Pymarketcap` every time we create a trade
- In `main.create_trade()` move `fiat_converter = CryptoToFiatConverter()` after we saved the the trade into the DB. Today this logic is before we save the trade into the DB. Any failure of Pymarketcap() we fail the saving of the trade in the DB.

## What's new?
Faster unit tests.
Below the new performance of the tests.

|    |   Test  | Original duration | New duration |
|----|---------|-------------------|--------------|
| [x] | freqtrade/tests/test_main.py::test_handle_trade_roi | 6.70s | 0.02s |
| [x] | freqtrade/tests/test_main.py::test_handle_overlpapping_signals | 4.23s | 0.02s |
| [x] | freqtrade/tests/test_main.py::test_sell_profit_only_enable_profit | 4.15s | 0.01s |
| [x] | freqtrade/tests/test_main.py::test_handle_trade_experimental | 4.12s | 0.01s |
| [x] | freqtrade/tests/test_main.py::test_sell_profit_only_disable_loss | 4.10s | 0.01s |
| [x] | freqtrade/tests/test_main.py::test_sell_profit_only_disable_profit | 4.10s | 0.02s |
| [x] | freqtrade/tests/test_main.py::test_process_trade_creation | 2.92s | 0.04s |
| [x] | freqtrade/tests/test_main.py::test_process_trade_handling | 2.36s | 0.02s |
| [x] | freqtrade/tests/test_main.py::test_sell_profit_only_enable_loss | 2.29s | 0.06s |
| [x] | freqtrade/tests/test_main.py::test_execute_sell_without_conf_sell_up | 2.25s | 0.01s |
| [x] | freqtrade/tests/test_main.py::test_close_trade | 2.13s | 0.02s |
| [x] | freqtrade/tests/rpc/test_rpc_telegram.py::test_status_handle | 2.10s | 0.01s |
| [x] | freqtrade/tests/rpc/test_rpc_telegram.py::test_count_handle | 2.09s | 0.01s |
| [x] | freqtrade/tests/rpc/test_rpc_telegram.py::test_status_table_handle | 2.09s | 0.01s |
| [x] | freqtrade/tests/test_main.py::test_execute_sell_without_conf_sell_down | 2.07s | 0.01s |
| [x] | freqtrade/tests/test_main.py::test_create_trade_minimal_amount | 2.06s | 0.01s |
| [x] | freqtrade/tests/rpc/test_rpc_telegram.py::test_performance_handle | 2.03s | 0.02s |
| [x] | freqtrade/tests/test_main.py::test_create_trade | 2.02s | 0.01s |
| [x] | freqtrade/tests/test_fiat_convert.py::test_fiat_convert_is_supported | 1.25s | 0.08s |
| [x] | freqtrade/tests/test_fiat_convert.py::test_fiat_convert_get_price | 1.23s | 0.08s |
| [x] | freqtrade/tests/test_fiat_convert.py::test_fiat_convert_find_price | 1.23s | 0.08s |
| [x] | freqtrade/tests/test_fiat_convert.py::test_fiat_convert_add_pair | 1.19s | 0.08s |
