### PR TITLE
Convert CryptoToFiatConverter into a Singleton

### DIFF
--- a/freqtrade/fiat_convert.py
+++ b/freqtrade/fiat_convert.py
@@ -48,7 +48,10 @@ class CryptoFiat():
         return self._expiration - time.time() <= 0
 
 
-class CryptoToFiatConverter():
+class CryptoToFiatConverter(object):
+    __instance = None
+    _coinmarketcap = None
+
     # Constants
     SUPPORTED_FIAT = [
         "AUD", "BRL", "CAD", "CHF", "CLP", "CNY", "CZK", "DKK",
@@ -57,12 +60,16 @@ class CryptoToFiatConverter():
         "RUB", "SEK", "SGD", "THB", "TRY", "TWD", "ZAR", "USD"
     ]
 
-    def __init__(self) -> None:
-        try:
-            self._coinmarketcap = Pymarketcap()
-        except BaseException:
-            self._coinmarketcap = None
+    def __new__(cls):
+        if CryptoToFiatConverter.__instance is None:
+            CryptoToFiatConverter.__instance = object.__new__(cls)
+            try:
+                CryptoToFiatConverter._coinmarketcap = Pymarketcap()
+            except BaseException:
+                CryptoToFiatConverter._coinmarketcap = None
+        return CryptoToFiatConverter.__instance
 
+    def __init__(self) -> None:
         self._pairs = []
 
     def convert_amount(self, crypto_amount: float, crypto_symbol: str, fiat_symbol: str) -> float:

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -219,9 +219,7 @@ def test_forcesell_handle(default_conf, update, ticker, ticker_sell_up, mocker):
     mocker.patch.multiple('freqtrade.main.exchange',
                           validate_pairs=MagicMock(),
                           get_ticker=ticker)
-    mocker.patch.multiple('freqtrade.fiat_convert.Pymarketcap',
-                          ticker=MagicMock(return_value={'price_usd': 15000.0}),
-                          _cache_symbols=MagicMock(return_value={'BTC': 1}))
+    mocker.patch('freqtrade.fiat_convert.CryptoToFiatConverter._find_price', return_value=15000.0)
     init(default_conf, create_engine('sqlite://'))
 
     # Create some test data
@@ -256,9 +254,7 @@ def test_forcesell_down_handle(default_conf, update, ticker, ticker_sell_down, m
     mocker.patch.multiple('freqtrade.main.exchange',
                           validate_pairs=MagicMock(),
                           get_ticker=ticker)
-    mocker.patch.multiple('freqtrade.fiat_convert.Pymarketcap',
-                          ticker=MagicMock(return_value={'price_usd': 15000.0}),
-                          _cache_symbols=MagicMock(return_value={'BTC': 1}))
+    mocker.patch('freqtrade.fiat_convert.CryptoToFiatConverter._find_price', return_value=15000.0)
     init(default_conf, create_engine('sqlite://'))
 
     # Create some test data
@@ -317,9 +313,7 @@ def test_forcesell_all_handle(default_conf, update, ticker, mocker):
     mocker.patch.multiple('freqtrade.main.exchange',
                           validate_pairs=MagicMock(),
                           get_ticker=ticker)
-    mocker.patch.multiple('freqtrade.fiat_convert.Pymarketcap',
-                          ticker=MagicMock(return_value={'price_usd': 15000.0}),
-                          _cache_symbols=MagicMock(return_value={'BTC': 1}))
+    mocker.patch('freqtrade.fiat_convert.CryptoToFiatConverter._find_price', return_value=15000.0)
     init(default_conf, create_engine('sqlite://'))
 
     # Create some test data

--- a/freqtrade/tests/test_fiat_convert.py
+++ b/freqtrade/tests/test_fiat_convert.py
@@ -116,9 +116,9 @@ def test_fiat_convert_get_price(mocker):
     assert fiat_convert._pairs[0]._expiration is not expiration
 
 
-def test_fiat_convert_without_network(mocker):
-    pymarketcap = MagicMock(side_effect=ImportError('Oh boy, you have no network!'))
-    mocker.patch('freqtrade.fiat_convert.Pymarketcap', pymarketcap)
+def test_fiat_convert_without_network():
+    # Because CryptoToFiatConverter is a Singleton we reset the value of _coinmarketcap
+    CryptoToFiatConverter._coinmarketcap = None
 
     fiat_convert = CryptoToFiatConverter()
     assert fiat_convert._coinmarketcap is None

--- a/freqtrade/tests/test_main.py
+++ b/freqtrade/tests/test_main.py
@@ -525,9 +525,7 @@ def test_execute_sell_up(default_conf, ticker, ticker_sell_up, mocker):
     mocker.patch.multiple('freqtrade.main.exchange',
                           validate_pairs=MagicMock(),
                           get_ticker=ticker)
-    mocker.patch.multiple('freqtrade.fiat_convert.Pymarketcap',
-                          ticker=MagicMock(return_value={'price_usd': 15000.0}),
-                          _cache_symbols=MagicMock(return_value={'BTC': 1}))
+    mocker.patch('freqtrade.fiat_convert.CryptoToFiatConverter._find_price', return_value=15000.0)
     init(default_conf, create_engine('sqlite://'))
 
     # Create some test data
@@ -562,9 +560,7 @@ def test_execute_sell_down(default_conf, ticker, ticker_sell_down, mocker):
     mocker.patch.multiple('freqtrade.main.exchange',
                           validate_pairs=MagicMock(),
                           get_ticker=ticker)
-    mocker.patch.multiple('freqtrade.fiat_convert.Pymarketcap',
-                          ticker=MagicMock(return_value={'price_usd': 15000.0}),
-                          _cache_symbols=MagicMock(return_value={'BTC': 1}))
+    mocker.patch('freqtrade.fiat_convert.CryptoToFiatConverter._find_price', return_value=15000.0)
     init(default_conf, create_engine('sqlite://'))
 
     # Create some test data


### PR DESCRIPTION
## Summary
Speed up unit test from 60s to 6s by Change `CryptoToFiatConverter()` to a Singleton. 

The issue is `CryptoToFiatConverter()` call `Pymarketcap()` lib at the `__init__`. When `Pymarketcap()` get instanced, it calls some other services. It results in a latency of 2 sec.

By changing `CryptoToFiatConverter()` to a Singleton, we avoid to init `Pymarketcap()` every time.

Solve the issue: #420

## Quick changelog

- Change `CryptoToFiatConverter()` to a Singleton. The bot will instance `Pymarketcap()` only once.
- Accelerate Unit test
- Accelerate every time the bot calls `CryptoToFiatConverter()`

## What's new?
Faster unit tests, Faster bot.
Below the new performance of the tests.

|    |   Test  | Original duration | New duration |
|----|---------|-------------------|--------------|
| [x] | freqtrade/tests/test_main.py::test_handle_trade_roi | 6.70s | 0.02s |
| [x] | freqtrade/tests/test_main.py::test_handle_overlpapping_signals | 4.23s | 0.02s |
| [x] | freqtrade/tests/test_main.py::test_sell_profit_only_enable_profit | 4.15s | 0.01s |
| [x] | freqtrade/tests/test_main.py::test_handle_trade_experimental | 4.12s | 0.01s |
| [x] | freqtrade/tests/test_main.py::test_sell_profit_only_disable_loss | 4.10s | 0.01s |
| [x] | freqtrade/tests/test_main.py::test_sell_profit_only_disable_profit | 4.10s | 0.02s |
| [x] | freqtrade/tests/test_main.py::test_process_trade_creation | 2.92s | 0.04s |
| [x] | freqtrade/tests/test_main.py::test_process_trade_handling | 2.36s | 0.02s |
| [x] | freqtrade/tests/test_main.py::test_sell_profit_only_enable_loss | 2.29s | 0.06s |
| [x] | freqtrade/tests/test_main.py::test_execute_sell_without_conf_sell_up | 2.25s | 0.01s |
| [x] | freqtrade/tests/test_main.py::test_close_trade | 2.13s | 0.02s |
| [x] | freqtrade/tests/rpc/test_rpc_telegram.py::test_status_handle | 2.10s | 0.01s |
| [x] | freqtrade/tests/rpc/test_rpc_telegram.py::test_count_handle | 2.09s | 0.01s |
| [x] | freqtrade/tests/rpc/test_rpc_telegram.py::test_status_table_handle | 2.09s | 0.01s |
| [x] | freqtrade/tests/test_main.py::test_execute_sell_without_conf_sell_down | 2.07s | 0.01s |
| [x] | freqtrade/tests/test_main.py::test_create_trade_minimal_amount | 2.06s | 0.01s |
| [x] | freqtrade/tests/rpc/test_rpc_telegram.py::test_performance_handle | 2.03s | 0.02s |
| [x] | freqtrade/tests/test_main.py::test_create_trade | 2.02s | 0.01s |
| [x] | freqtrade/tests/test_fiat_convert.py::test_fiat_convert_is_supported | 1.25s | 0.08s |
| [x] | freqtrade/tests/test_fiat_convert.py::test_fiat_convert_get_price | 1.23s | 0.08s |
| [x] | freqtrade/tests/test_fiat_convert.py::test_fiat_convert_find_price | 1.23s | 0.08s |
| [x] | freqtrade/tests/test_fiat_convert.py::test_fiat_convert_add_pair | 1.19s | 0.08s |
