### PR TITLE
Remove useless USDT_BTC filename conversion

### DIFF
--- a/freqtrade/optimize/__init__.py
+++ b/freqtrade/optimize/__init__.py
@@ -127,7 +127,6 @@ def download_backtesting_testdata(datadir: str, pair: str, interval: int = 5) ->
         pair=filepair,
         interval=interval,
     ))
-    filename = filename.replace('USDT_BTC', 'BTC_FAKEBULL')
 
     if os.path.isfile(filename):
         with open(filename, "rt") as fp:


### PR DESCRIPTION
## Summary
Remove the filename conversion `filename.replace('USDT_BTC', 'BTC_FAKEBULL')`. This is useless, and add trouble when users are backtesting with USDT

Solve the issue: #397 

## Quick changelog

- Remove the filename conversion `filename.replace('USDT_BTC', 'BTC_FAKEBULL')` when backtesting is downloading USDT_BTC pair.
