### PR TITLE
Fix dry_run db issue when open_order_id already exist

### DIFF
--- a/freqtrade/persistence.py
+++ b/freqtrade/persistence.py
@@ -47,6 +47,10 @@ def init(config: dict, engine: Optional[Engine] = None) -> None:
     Trade.query = session.query_property()
     _DECL_BASE.metadata.create_all(engine)
 
+    # Clean dry_run DB
+    if _CONF.get('dry_run', False) and _CONF.get('dry_run_db', False):
+        clean_dry_run_db()
+
 
 def cleanup() -> None:
     """
@@ -54,6 +58,17 @@ def cleanup() -> None:
     :return: None
     """
     Trade.session.flush()
+
+
+def clean_dry_run_db() -> None:
+    """
+    Remove open_order_id from a Dry_run DB
+    :return: None
+    """
+    for trade in Trade.query.filter(Trade.open_order_id.isnot(None)).all():
+        # Check we are updating only a dry_run order not a prod one
+        if 'dry_run' in trade.open_order_id:
+            trade.open_order_id = None
 
 
 class Trade(_DECL_BASE):

--- a/freqtrade/tests/test_persistence.py
+++ b/freqtrade/tests/test_persistence.py
@@ -4,7 +4,7 @@ import os
 import pytest
 
 from freqtrade.exchange import Exchanges
-from freqtrade.persistence import Trade, init
+from freqtrade.persistence import Trade, init, clean_dry_run_db
 
 
 def test_init_create_session(default_conf, mocker):
@@ -310,3 +310,50 @@ def test_calc_profit_percent(limit_buy_order, limit_sell_order):
 
     # Test with a custom fee rate on the close trade
     assert trade.calc_profit_percent(fee=0.003) == 0.0614782
+
+
+def test_clean_dry_run_db(default_conf, mocker):
+    init(default_conf)
+
+    # Simulate dry_run entries
+    trade = Trade(
+        pair='BTC_ETH',
+        stake_amount=0.001,
+        amount=123.0,
+        fee=0.0025,
+        open_rate=0.123,
+        exchange='BITTREX',
+        open_order_id='dry_run_buy_12345'
+    )
+    Trade.session.add(trade)
+
+    trade = Trade(
+        pair='BTC_ETC',
+        stake_amount=0.001,
+        amount=123.0,
+        fee=0.0025,
+        open_rate=0.123,
+        exchange='BITTREX',
+        open_order_id='dry_run_sell_12345'
+    )
+    Trade.session.add(trade)
+
+    # Simulate prod entry
+    trade = Trade(
+        pair='BTC_ETC',
+        stake_amount=0.001,
+        amount=123.0,
+        fee=0.0025,
+        open_rate=0.123,
+        exchange='BITTREX',
+        open_order_id='prod_buy_12345'
+    )
+    Trade.session.add(trade)
+
+    # We have 3 entries: 2 dry_run, 1 prod
+    assert len(Trade.query.filter(Trade.open_order_id.isnot(None)).all()) == 3
+
+    clean_dry_run_db()
+
+    # We have now only the prod
+    assert len(Trade.query.filter(Trade.open_order_id.isnot(None)).all()) == 1


### PR DESCRIPTION
## Summary
Solve the issue: #385

This issue happens when we start a dry_run with a DB that contains `open_order_id`.
This PR clean up the dry run DB from `open_order_id` generated by a previous dry_run session (Change the value to NULL).
It does not clean `open_order_id` from a prod session.

## Quick changelog
- Remove previous dry_run `open_order_id`
