### PR TITLE
ROI table Hyperopting

### DIFF
--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -225,11 +225,22 @@ def calculate_loss(total_profit: float, trade_count: int, trade_duration: float)
     return trade_loss + profit_loss + duration_loss
 
 
-def hyperopt_space() -> List[Dict]:
+def roi_space() -> List[Dict]:
+    return {
+        'roi_t1': hp.quniform('roi_t1', 10, 220, 10),
+        'roi_t2': hp.quniform('roi_t2', 10, 120, 10),
+        'roi_t3': hp.quniform('roi_t3', 10, 120, 10),
+        'roi_p1': hp.quniform('roi_p1', 1, 5, 1),
+        'roi_p2': hp.quniform('roi_p2', 1, 5, 1),
+        'roi_p3': hp.quniform('roi_p3', 1, 10, 1),
+    }
+
+
+def indicator_space() -> List[Dict]:
     """
     Define your Hyperopt space for searching strategy parameters
     """
-    space = {
+    return {
         'macd_below_zero': hp.choice('macd_below_zero', [
             {'enabled': False},
             {'enabled': True}
@@ -284,7 +295,10 @@ def hyperopt_space() -> List[Dict]:
         ]),
         'stoploss': hp.uniform('stoploss', -0.5, -0.02),
     }
-    return space
+
+
+def hyperopt_space() -> List[Dict]:
+    return {**indicator_space(), **roi_space()}
 
 
 def buy_strategy_generator(params) -> None:

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -225,6 +225,16 @@ def calculate_loss(total_profit: float, trade_count: int, trade_duration: float)
     return trade_loss + profit_loss + duration_loss
 
 
+def generate_roi_table(params):
+    roi_table = {}
+    roi_table["0"] = params['roi_p1'] + params['roi_p2'] + params['roi_p3']
+    roi_table[str(params['roi_t3'])] = params['roi_p1'] + params['roi_p2']
+    roi_table[str(params['roi_t3'] + params['roi_t2'])] = params['roi_p1']
+    roi_table[str(params['roi_t3'] + params['roi_t2'] + params['roi_t1'])] = 0
+
+    return roi_table
+
+
 def roi_space() -> List[Dict]:
     return {
         'roi_t1': hp.quniform('roi_t1', 10, 220, 10),
@@ -233,6 +243,12 @@ def roi_space() -> List[Dict]:
         'roi_p1': hp.quniform('roi_p1', 1, 5, 1),
         'roi_p2': hp.quniform('roi_p2', 1, 5, 1),
         'roi_p3': hp.quniform('roi_p3', 1, 10, 1),
+    }
+
+
+def stoploss_space() -> Dict:
+    return {
+        'stoploss': hp.uniform('stoploss', -0.5, -0.02),
     }
 
 
@@ -293,12 +309,11 @@ def indicator_space() -> List[Dict]:
             {'type': 'heiken_reversal_bull'},
             {'type': 'di_cross'},
         ]),
-        'stoploss': hp.uniform('stoploss', -0.5, -0.02),
     }
 
 
 def hyperopt_space() -> List[Dict]:
-    return {**indicator_space(), **roi_space()}
+    return {**indicator_space(), **roi_space(), **stoploss_space()}
 
 
 def buy_strategy_generator(params) -> None:
@@ -377,6 +392,10 @@ def buy_strategy_generator(params) -> None:
 
 def optimizer(params):
     global _CURRENT_TRIES
+
+    if 'roi_t1' in params:
+        strategy = Strategy()
+        strategy.minimal_roi = generate_roi_table(params)
 
     backtesting.populate_buy_trend = buy_strategy_generator(params)
 
@@ -498,6 +517,8 @@ def start(args):
         )
 
     logger.info('Best parameters:\n%s', json.dumps(best_parameters, indent=4))
+    if 'roi_t1' in best_parameters:
+        logger.info('ROI table:\n%s', generate_roi_table(best_parameters))
     logger.info('Best Result:\n%s', best_result)
 
     # Store trials result to file to resume next time

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -125,6 +125,12 @@ def test_fmin_best_results(mocker, caplog):
         "uptrend_short_ema": 0,
         "uptrend_sma": 0,
         "stoploss": -0.1,
+        "roi_t1": 1,
+        "roi_t2": 2,
+        "roi_t3": 3,
+        "roi_p1": 1,
+        "roi_p2": 2,
+        "roi_p3": 3,
     }
 
     mocker.patch('freqtrade.optimize.hyperopt.MongoTrials', return_value=create_trials(mocker))

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -1,6 +1,6 @@
 # pragma pylint: disable=missing-docstring,W0212,C0103
 from freqtrade.optimize.hyperopt import calculate_loss, TARGET_TRADES, EXPECTED_MAX_PROFIT, start, \
-    log_results, save_trials, read_trials
+    log_results, save_trials, read_trials, generate_roi_table
 
 
 def test_loss_calculation_prefer_correct_trade_count():
@@ -234,3 +234,15 @@ def test_read_trials_returns_trials_file(mocker):
     assert read_trials() == trials
     mock_open.assert_called_once()
     mock_load.assert_called_once()
+
+
+def test_roi_table_generation():
+    params = {
+        'roi_t1': 5,
+        'roi_t2': 10,
+        'roi_t3': 15,
+        'roi_p1': 1,
+        'roi_p2': 2,
+        'roi_p3': 3,
+    }
+    assert generate_roi_table(params) == {'0': 6, '15': 3, '25': 1, '30': 0}


### PR DESCRIPTION
## Summary

First of multiple Hyperopting PR:s coming. This PR makes Hyperopt optimize to find ROI table that maximizes profits.

## What's new?

Tries to find four step ROI table that would maximize protfit. It does this by using 6 new hyperopt variables `roi_t1`, `roi_t2`, `roi_t3`, `roi_p1`, `roi_p2`, `roi_p3` that map to the ROI table like this:

![roi_table](https://user-images.githubusercontent.com/557751/35379887-529842cc-01c0-11e8-8d23-da8133eb047c.jpg)
 
By adjusting the uniform space and step values of these variables you can set the limits for how far and wide will the suitable times and profit percentages be searched by Hyperopt.