### PR TITLE
Refactoring backtesting sell conditions eval

### DIFF
--- a/docs/plotting.md
+++ b/docs/plotting.md
@@ -17,6 +17,19 @@ python script/plot_dataframe.py -p BTC_ETH,BTC_LTC
 The -p pair argument, can be used to specify what
 pair you would like to plot.
 
+**Advanced use**
+
+To plot the current live price use the --live flag:
+```
+python scripts/plot_dataframe.py -p BTC_ETH --live
+```
+
+To plot a timerange (to zoom in):
+```
+python scripts/plot_dataframe.py -p BTC_ETH --timerange=100-200
+```
+Timerange doesn't work with live data.
+
 
 ## Plot profit
 
@@ -46,3 +59,11 @@ Example
 ```
 python python scripts/plot_profit.py --datadir ../freqtrade/freqtrade/tests/testdata-20171221/ -p BTC_LTC
 ```
+
+**When it goes wrong**
+
+*** Linux: Can't display**
+
+If you are inside an python environment, you might want to set the
+DISPLAY variable as so:
+$ DISPLAY=:0 python scripts/plot_dataframe.py

--- a/docs/plotting.md
+++ b/docs/plotting.md
@@ -5,21 +5,34 @@ This page explains how to plot prices, indicator, profits.
 - [Plot price and indicators](#plot-price-and-indicators)
 - [Plot profit](#plot-profit)
 
+## Installation
+
+Plotting scripts use Plotly library. Install/upgrade it with:
+
+```
+pip install --upgrade plotly
+```
+
+At least version 2.3.0 is required.
+
 ## Plot price and indicators
 Usage for the price plotter:
-script/plot_dataframe.py [-h] [-p pair]
+
+```
+script/plot_dataframe.py [-h] [-p pair] [--live]
+```
 
 Example
 ```
-python script/plot_dataframe.py -p BTC_ETH,BTC_LTC
+python script/plot_dataframe.py -p BTC_ETH
 ```
 
-The -p pair argument, can be used to specify what
+The `-p` pair argument, can be used to specify what
 pair you would like to plot.
 
 **Advanced use**
 
-To plot the current live price use the --live flag:
+To plot the current live price use the `--live` flag:
 ```
 python scripts/plot_dataframe.py -p BTC_ETH --live
 ```
@@ -51,19 +64,14 @@ The third graph can be useful to spot outliers, events in pairs
 that makes profit spikes.
 
 Usage for the profit plotter:
-script/plot_profit.py [-h] [-p pair] [--datadir directory] [--ticker_interval num]
 
-The -p pair argument, can be used to plot a single pair
+```
+script/plot_profit.py [-h] [-p pair] [--datadir directory] [--ticker_interval num]
+```
+
+The `-p` pair argument, can be used to plot a single pair
 
 Example
 ```
 python python scripts/plot_profit.py --datadir ../freqtrade/freqtrade/tests/testdata-20171221/ -p BTC_LTC
 ```
-
-**When it goes wrong**
-
-*** Linux: Can't display**
-
-If you are inside an python environment, you might want to set the
-DISPLAY variable as so:
-$ DISPLAY=:0 python scripts/plot_dataframe.py

--- a/freqtrade/exchange/bittrex.py
+++ b/freqtrade/exchange/bittrex.py
@@ -1,5 +1,4 @@
 import logging
-import requests
 from typing import Dict, List, Optional
 
 from bittrex.bittrex import Bittrex as _Bittrex
@@ -14,20 +13,6 @@ logger = logging.getLogger(__name__)
 _API: _Bittrex = None
 _API_V2: _Bittrex = None
 _EXCHANGE_CONF: dict = {}
-
-# API socket timeout
-API_TIMEOUT = 60
-
-
-def custom_requests(request_url, apisign):
-    """
-    Set timeout for requests
-    """
-    return requests.get(
-        request_url,
-        headers={"apisign": apisign},
-        timeout=API_TIMEOUT
-    ).json()
 
 
 class Bittrex(Exchange):
@@ -47,14 +32,12 @@ class Bittrex(Exchange):
             api_secret=_EXCHANGE_CONF['secret'],
             calls_per_second=1,
             api_version=API_V1_1,
-            dispatch=custom_requests
         )
         _API_V2 = _Bittrex(
             api_key=_EXCHANGE_CONF['key'],
             api_secret=_EXCHANGE_CONF['secret'],
             calls_per_second=1,
             api_version=API_V2_0,
-            dispatch=custom_requests
         )
         self.cached_ticker = {}
 

--- a/freqtrade/fiat_convert.py
+++ b/freqtrade/fiat_convert.py
@@ -1,12 +1,19 @@
+"""
+Module that define classes to convert Crypto-currency to FIAT
+e.g BTC to USD
+"""
+
 import logging
 import time
-
 from pymarketcap import Pymarketcap
 
 logger = logging.getLogger(__name__)
 
 
 class CryptoFiat():
+    """
+    Object to describe what is the price of Crypto-currency in a FIAT
+    """
     # Constants
     CACHE_DURATION = 6 * 60 * 60  # 6 hours
 
@@ -49,6 +56,11 @@ class CryptoFiat():
 
 
 class CryptoToFiatConverter(object):
+    """
+    Main class to initiate Crypto to FIAT.
+    This object contains a list of pair Crypto, FIAT
+    This object is also a Singleton
+    """
     __instance = None
     _coinmarketcap = None
 

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -309,11 +309,12 @@ def min_roi_reached(trade: Trade, current_rate: float, current_time: datetime) -
 
 def should_sell(trade: Trade, rate: float, date: datetime, buy: bool, sell: bool) -> bool:
     """
-    Sells the current pair if the threshold is reached and updates the trade record.
-    :return: True if trade has been sold, False otherwise
+    This function evaluate if on the condition required to trigger a sell has been reached
+    if the threshold is reached and updates the trade record.
+    :return: True if trade should be sold, False otherwise
     """
     # Check if minimal roi has been reached and no longer in buy conditions (avoiding a fee)
-    if not buy and min_roi_reached(trade, rate, date):
+    if min_roi_reached(trade, rate, date):
         logger.debug('Executing sell due to ROI ...')
         return True
 

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -307,6 +307,29 @@ def min_roi_reached(trade: Trade, current_rate: float, current_time: datetime) -
     return False
 
 
+def should_sell(trade: Trade, rate: float, date: datetime, buy: bool, sell: bool) -> bool:
+    """
+    Sells the current pair if the threshold is reached and updates the trade record.
+    :return: True if trade has been sold, False otherwise
+    """
+    # Check if minimal roi has been reached and no longer in buy conditions (avoiding a fee)
+    if not buy and min_roi_reached(trade, rate, date):
+        logger.debug('Executing sell due to ROI ...')
+        return True
+
+    # Experimental: Check if the trade is profitable before selling it (avoid selling at loss)
+    if _CONF.get('experimental', {}).get('sell_profit_only', False):
+        logger.debug('Checking if trade is profitable ...')
+        if not buy and trade.calc_profit(rate=rate) <= 0:
+            return False
+
+    if sell and not buy and _CONF.get('experimental', {}).get('use_sell_signal', False):
+        logger.debug('Executing sell due to sell signal ...')
+        return True
+
+    return False
+
+
 def handle_trade(trade: Trade, interval: int) -> bool:
     """
     Sells the current pair if the threshold is reached and updates the trade record.
@@ -323,20 +346,7 @@ def handle_trade(trade: Trade, interval: int) -> bool:
     if _CONF.get('experimental', {}).get('use_sell_signal'):
         (buy, sell) = get_signal(trade.pair, interval)
 
-    # Check if minimal roi has been reached and no longer in buy conditions (avoiding a fee)
-    if not buy and min_roi_reached(trade, current_rate, datetime.utcnow()):
-        logger.debug('Executing sell due to ROI ...')
-        execute_sell(trade, current_rate)
-        return True
-
-    # Experimental: Check if the trade is profitable before selling it (avoid selling at loss)
-    if _CONF.get('experimental', {}).get('sell_profit_only', False):
-        logger.debug('Checking if trade is profitable ...')
-        if not buy and trade.calc_profit(rate=current_rate) <= 0:
-            return False
-
-    if sell and not buy:
-        logger.debug('Executing sell due to sell signal ...')
+    if should_sell(trade, current_rate, datetime.utcnow(), buy, sell):
         execute_sell(trade, current_rate)
         return True
 

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -5,8 +5,10 @@ import logging
 import time
 import os
 import re
+from datetime import datetime
 from typing import Any, Callable, Dict, List
 
+import numpy as np
 from jsonschema import Draft4Validator, validate
 from jsonschema.exceptions import ValidationError, best_match
 from wrapt import synchronized
@@ -16,11 +18,6 @@ from freqtrade import __version__
 logger = logging.getLogger(__name__)
 
 
-def file_dump_json(filename, data):
-    with open(filename, 'w') as fp:
-        json.dump(data, fp)
-
-
 class State(enum.Enum):
     RUNNING = 0
     STOPPED = 1
@@ -28,6 +25,44 @@ class State(enum.Enum):
 
 # Current application state
 _STATE = State.STOPPED
+
+
+############################################
+# Used by scripts                          #
+# Matplotlib doesn't support ::datetime64, #
+# so we need to convert it into ::datetime #
+############################################
+
+def datesarray_to_datetimearray(dates):
+    """
+    Convert an pandas-array of timestamps into
+    An numpy-array of datetimes
+    :return: numpy-array of datetime
+    """
+    times = []
+    dates = dates.astype(datetime)
+    for i in range(0, dates.size):
+        date = dates[i].to_pydatetime()
+        times.append(date)
+    return np.array(times)
+
+
+def common_datearray(dfs):
+    alldates = {}
+    for pair, pair_data in dfs.items():
+        dates = datesarray_to_datetimearray(pair_data['date'])
+        for date in dates:
+            alldates[date] = 1
+    lst = []
+    for date, _ in alldates.items():
+        lst.append(date)
+    arr = np.array(lst)
+    return np.sort(arr, axis=0)
+
+
+def file_dump_json(filename, data):
+    with open(filename, 'w') as fp:
+        json.dump(data, fp)
 
 
 @synchronized
@@ -161,6 +196,15 @@ def parse_args(args: List[str], description: str):
 
     build_subcommands(parser)
     return parser.parse_args(args)
+
+
+def scripts_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        '-p', '--pair',
+        help='Show profits for only this pairs. Pairs are comma-separated.',
+        dest='pair',
+        default=None
+    )
 
 
 def backtesting_options(parser: argparse.ArgumentParser) -> None:

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -12,7 +12,7 @@ import freqtrade.optimize as optimize
 from freqtrade import exchange
 from freqtrade.analyze import populate_buy_trend, populate_sell_trend
 from freqtrade.exchange import Bittrex
-from freqtrade.main import min_roi_reached
+from freqtrade.main import should_sell
 from freqtrade.persistence import Trade
 from freqtrade.strategy.strategy import Strategy
 
@@ -50,8 +50,8 @@ def generate_text_table(
             result.profit_percent.mean() * 100.0,
             result.profit_BTC.sum(),
             result.duration.mean() * ticker_interval,
-            result.profit.sum(),
-            result.loss.sum()
+            len(result[result.profit_BTC > 0]),
+            len(result[result.profit_BTC < 0])
         ])
 
     # Append Total
@@ -61,18 +61,15 @@ def generate_text_table(
         results.profit_percent.mean() * 100.0,
         results.profit_BTC.sum(),
         results.duration.mean() * ticker_interval,
-        results.profit.sum(),
-        results.loss.sum()
+        len(results[results.profit_BTC > 0]),
+        len(results[results.profit_BTC < 0])
     ])
     return tabulate(tabular_data, headers=headers, floatfmt=floatfmt)
 
 
-def get_trade_entry(pair, row, ticker, trade_count_lock, args):
+def get_sell_trade_entry(pair, row, rows, ticker, trade_count_lock, args):
     stake_amount = args['stake_amount']
     max_open_trades = args.get('max_open_trades', 0)
-    sell_profit_only = args.get('sell_profit_only', False)
-    stoploss = args.get('stoploss', -1)
-    use_sell_signal = args.get('use_sell_signal', False)
     trade = Trade(open_rate=row.close,
                   open_date=row.date,
                   stake_amount=stake_amount,
@@ -81,26 +78,20 @@ def get_trade_entry(pair, row, ticker, trade_count_lock, args):
                   )
 
     # calculate win/lose forwards from buy point
-    sell_subset = ticker[row.Index + 1:][['close', 'date', 'sell']]
+    sell_subset = ticker[ticker.date > row.date][['close', 'date', 'sell']]
     for row2 in sell_subset.itertuples(index=True):
         if max_open_trades > 0:
             # Increase trade_count_lock for every iteration
             trade_count_lock[row2.date] = trade_count_lock.get(row2.date, 0) + 1
 
-        current_profit_percent = trade.calc_profit_percent(rate=row2.close)
-        if (sell_profit_only and current_profit_percent < 0):
-            continue
-        if min_roi_reached(trade, row2.close, row2.date) or \
-            (row2.sell == 1 and use_sell_signal) or \
-                current_profit_percent <= stoploss:
-            current_profit_btc = trade.calc_profit(rate=row2.close)
+        buy_signal = rows[rows.date == row2.date].empty
+        if(should_sell(trade, row2.close, row2.date, buy_signal, row2.sell)):
             return row2, (pair,
-                          current_profit_percent,
-                          current_profit_btc,
-                          row2.Index - row.Index,
-                          current_profit_btc > 0,
-                          current_profit_btc < 0
-                          )
+                          trade.calc_profit_percent(rate=row2.close),
+                          trade.calc_profit(rate=row2.close),
+                          row2.Index - row.Index
+                          ), row2.date
+    return False
 
 
 def backtest(args) -> DataFrame:
@@ -129,10 +120,10 @@ def backtest(args) -> DataFrame:
         ticker = populate_sell_trend(populate_buy_trend(pair_data))
         # for each buy point
         lock_pair_until = None
-        buy_subset = ticker[ticker.buy == 1][['buy', 'open', 'close', 'date', 'sell']]
+        buy_subset = ticker[(ticker.buy == 1) & (ticker.sell == 0)][['buy', 'open', 'close', 'date', 'sell']]
         for row in buy_subset.itertuples(index=True):
             if realistic:
-                if lock_pair_until is not None and row.Index <= lock_pair_until:
+                if lock_pair_until is not None and row.date <= lock_pair_until:
                     continue
             if max_open_trades > 0:
                 # Check if max_open_trades has already been reached for the given date
@@ -143,11 +134,11 @@ def backtest(args) -> DataFrame:
                 # Increase lock
                 trade_count_lock[row.date] = trade_count_lock.get(row.date, 0) + 1
 
-            ret = get_trade_entry(pair, row, ticker,
-                                  trade_count_lock, args)
+            ret = get_sell_trade_entry(pair, row, buy_subset, ticker,
+                                       trade_count_lock, args)
             if ret:
-                row2, trade_entry = ret
-                lock_pair_until = row2.Index
+                row2, trade_entry, next_date = ret
+                lock_pair_until = next_date
                 trades.append(trade_entry)
                 if record:
                     # Note, need to be json.dump friendly
@@ -162,7 +153,7 @@ def backtest(args) -> DataFrame:
     if record and record.find('trades') >= 0:
         logger.info('Dumping backtest results')
         misc.file_dump_json('backtest-result.json', records)
-    labels = ['currency', 'profit_percent', 'profit_BTC', 'duration', 'profit', 'loss']
+    labels = ['currency', 'profit_percent', 'profit_BTC', 'duration']
     return DataFrame.from_records(trades, columns=labels)
 
 

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -221,7 +221,7 @@ def calculate_loss(total_profit: float, trade_count: int, trade_duration: float)
     """ objective function, returns smaller number for more optimal results """
     trade_loss = 1 - 0.25 * exp(-(trade_count - TARGET_TRADES) ** 2 / 10 ** 5.8)
     profit_loss = max(0, 1 - total_profit / EXPECTED_MAX_PROFIT)
-    duration_loss = 0.7 + 0.3 * min(trade_duration / MAX_ACCEPTED_TRADE_DURATION, 1)
+    duration_loss = 0.4 * min(trade_duration / MAX_ACCEPTED_TRADE_DURATION, 1)
     return trade_loss + profit_loss + duration_loss
 
 
@@ -237,12 +237,12 @@ def generate_roi_table(params) -> Dict[str, float]:
 
 def roi_space() -> Dict[str, Any]:
     return {
-        'roi_t1': hp.quniform('roi_t1', 10, 220, 20),
-        'roi_t2': hp.quniform('roi_t2', 10, 120, 15),
-        'roi_t3': hp.quniform('roi_t3', 10, 120, 10),
-        'roi_p1': hp.quniform('roi_p1', 0.01, 0.05, 0.01),
-        'roi_p2': hp.quniform('roi_p2', 0.01, 0.10, 0.01),
-        'roi_p3': hp.quniform('roi_p3', 0.01, 0.30, 0.01),
+        'roi_t1': hp.quniform('roi_t1', 10, 120, 20),
+        'roi_t2': hp.quniform('roi_t2', 10, 60, 15),
+        'roi_t3': hp.quniform('roi_t3', 10, 40, 10),
+        'roi_p1': hp.quniform('roi_p1', 0.01, 0.04, 0.01),
+        'roi_p2': hp.quniform('roi_p2', 0.01, 0.07, 0.01),
+        'roi_p3': hp.quniform('roi_p3', 0.01, 0.20, 0.01),
     }
 
 

--- a/freqtrade/strategy/default_strategy.py
+++ b/freqtrade/strategy/default_strategy.py
@@ -1,7 +1,9 @@
+# pragma pylint: disable=missing-docstring, invalid-name, pointless-string-statement
+
 import talib.abstract as ta
+from pandas import DataFrame
 import freqtrade.vendor.qtpylib.indicators as qtpylib
 from freqtrade.strategy.interface import IStrategy
-from pandas import DataFrame
 
 
 class_name = 'DefaultStrategy'

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -1,8 +1,22 @@
+"""
+IStrategy interface
+This module defines the interface to apply for strategies
+"""
+
 from abc import ABC, abstractmethod
 from pandas import DataFrame
 
 
 class IStrategy(ABC):
+    """
+    Interface for freqtrade strategies
+    Defines the mandatory structure must follow any custom strategies
+
+    Attributes you can use:
+        minimal_roi -> Dict: Minimal ROI designed for the strategy
+        stoploss -> float: optimal stoploss designed for the strategy
+        ticker_interval -> int: value of the ticker interval to use for the strategy
+    """
     @property
     def name(self) -> str:
         """
@@ -10,13 +24,6 @@ class IStrategy(ABC):
         :return: str representation of the class name
         """
         return self.__class__.__name__
-
-    """
-    Attributes you can use:
-        minimal_roi -> Dict: Minimal ROI designed for the strategy
-        stoploss -> float: optimal stoploss designed for the strategy
-        ticker_interval -> int: value of the ticker interval to use for the strategy
-    """
 
     @abstractmethod
     def populate_indicators(self, dataframe: DataFrame) -> DataFrame:

--- a/freqtrade/strategy/strategy.py
+++ b/freqtrade/strategy/strategy.py
@@ -50,7 +50,6 @@ class Strategy(object):
         if 'strategy' in config:
             strategy = config['strategy']
         else:
-            print(config)
             strategy = self.DEFAULT_STRATEGY
 
         # Load the strategy

--- a/freqtrade/strategy/strategy.py
+++ b/freqtrade/strategy/strategy.py
@@ -50,6 +50,7 @@ class Strategy(object):
         if 'strategy' in config:
             strategy = config['strategy']
         else:
+            print(config)
             strategy = self.DEFAULT_STRATEGY
 
         # Load the strategy

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -3,10 +3,13 @@ from datetime import datetime
 from unittest.mock import MagicMock
 from functools import reduce
 
+import json
 import arrow
 import pytest
 from jsonschema import validate
 from telegram import Chat, Message, Update
+from freqtrade.analyze import parse_ticker_dataframe
+from freqtrade.strategy.strategy import Strategy
 
 from freqtrade.misc import CONF_SCHEMA
 
@@ -256,3 +259,16 @@ def ticker_history_without_bv():
             "T": "2017-11-26T09:00:00"
         }
     ]
+
+
+@pytest.fixture
+def result():
+    with open('freqtrade/tests/testdata/BTC_ETH-1.json') as data_file:
+        return parse_ticker_dataframe(json.load(data_file))
+
+
+@pytest.fixture
+def default_strategy():
+    strategy = Strategy()
+    strategy.init({'strategy': 'default_strategy'})
+    return strategy

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -1,8 +1,9 @@
-# pragma pylint: disable=missing-docstring,C0103
+# pragma pylint: disable=missing-docstring, C0103, bad-continuation, global-statement
+# pragma pylint: disable=protected-access
 from unittest.mock import MagicMock
-from requests.exceptions import RequestException
 from random import randint
 import logging
+from requests.exceptions import RequestException
 import pytest
 
 from freqtrade import OperationalException
@@ -30,7 +31,7 @@ def test_init(default_conf, mocker, caplog):
             ) in caplog.record_tuples
 
 
-def test_init_exception(default_conf, mocker):
+def test_init_exception(default_conf):
     default_conf['exchange']['name'] = 'wrong_exchange_name'
 
     with pytest.raises(
@@ -171,7 +172,7 @@ def test_get_balances_prod(default_conf, mocker):
 
 # This test is somewhat redundant with
 # test_exchange_bittrex.py::test_exchange_bittrex_get_ticker
-def test_get_ticker(default_conf, mocker, ticker):
+def test_get_ticker(default_conf, mocker):
     maybe_init_api(default_conf, mocker)
     api_mock = MagicMock()
     tick = {"success": True, 'result': {'Bid': 0.00001098, 'Ask': 0.00001099, 'Last': 0.0001}}
@@ -200,7 +201,7 @@ def test_get_ticker(default_conf, mocker, ticker):
     assert ticker['ask'] == 1
 
 
-def test_get_ticker_history(default_conf, mocker, ticker):
+def test_get_ticker_history(default_conf, mocker):
     api_mock = MagicMock()
     tick = 123
     api_mock.get_ticker_history = MagicMock(return_value=tick)
@@ -251,7 +252,7 @@ def test_get_order(default_conf, mocker):
     api_mock = MagicMock()
     api_mock.get_order = MagicMock(return_value=456)
     mocker.patch('freqtrade.exchange._API', api_mock)
-    assert 456 == exchange.get_order('X')
+    assert exchange.get_order('X') == 456
 
 
 def test_get_name(default_conf, mocker):
@@ -271,16 +272,16 @@ def test_get_fee(default_conf, mocker):
     assert get_fee() == 0.0025
 
 
-def test_exchange_misc(default_conf, mocker):
+def test_exchange_misc(mocker):
     api_mock = MagicMock()
     mocker.patch('freqtrade.exchange._API', api_mock)
     exchange.get_markets()
-    assert 1 == api_mock.get_markets.call_count
+    assert api_mock.get_markets.call_count == 1
     exchange.get_market_summaries()
-    assert 1 == api_mock.get_market_summaries.call_count
+    assert api_mock.get_market_summaries.call_count == 1
     api_mock.name = 123
-    assert 123 == exchange.get_name()
+    assert exchange.get_name() == 123
     api_mock.fee = 456
-    assert 456 == exchange.get_fee()
+    assert exchange.get_fee() == 456
     exchange.get_wallet_health()
-    assert 1 == api_mock.get_wallet_health.call_count
+    assert api_mock.get_wallet_health.call_count == 1

--- a/freqtrade/tests/exchange/test_exchange_bittrex.py
+++ b/freqtrade/tests/exchange/test_exchange_bittrex.py
@@ -345,8 +345,3 @@ def test_validate_response_min_trade_requirement_not_met():
     }
     with pytest.raises(ContentDecodingError, match=r'.*MIN_TRADE_REQUIREMENT_NOT_MET.*'):
         Bittrex._validate_response(response)
-
-
-def test_custom_requests(mocker):
-    mocker.patch('freqtrade.exchange.bittrex.requests', MagicMock())
-    btx.custom_requests('http://', '')

--- a/freqtrade/tests/exchange/test_exchange_bittrex.py
+++ b/freqtrade/tests/exchange/test_exchange_bittrex.py
@@ -1,9 +1,8 @@
-# pragma pylint: disable=missing-docstring,C0103
+# pragma pylint: disable=missing-docstring, C0103, protected-access, unused-argument
 
-import pytest
 from unittest.mock import MagicMock
+import pytest
 from requests.exceptions import ContentDecodingError
-
 from freqtrade.exchange.bittrex import Bittrex
 import freqtrade.exchange.bittrex as btx
 
@@ -88,8 +87,7 @@ class FakeBittrex():
                            'PricePerUnit': 1,
                            'Quantity': 1,
                            'QuantityRemaining': 1,
-                           'Closed': True
-                           },
+                           'Closed': True},
                 'message': 'lost'}
 
     def fake_cancel_order(self, uuid):
@@ -211,24 +209,18 @@ def test_exchange_bittrex_get_ticker():
 def test_exchange_bittrex_get_ticker_bad():
     wb = make_wrap_bittrex()
     fb = FakeBittrex()
-    fb.result = {'success': True,
-                 'result': {'Bid': 1, 'Ask': 0}}  # incomplete result
+    fb.result = {'success': True, 'result': {'Bid': 1, 'Ask': 0}}  # incomplete result
 
     with pytest.raises(ContentDecodingError, match=r'.*Got invalid response from bittrex params.*'):
         wb.get_ticker('BTC_ETH')
-    fb.result = {'success': False,
-                 'message': 'gone bad'
-                 }
+    fb.result = {'success': False, 'message': 'gone bad'}
     with pytest.raises(btx.OperationalException, match=r'.*gone bad.*'):
         wb.get_ticker('BTC_ETH')
 
-    fb.result = {'success': True,
-                 'result': {}}  # incomplete result
+    fb.result = {'success': True, 'result': {}}  # incomplete result
     with pytest.raises(ContentDecodingError, match=r'.*Got invalid response from bittrex params.*'):
         wb.get_ticker('BTC_ETH')
-    fb.result = {'success': False,
-                 'message': 'gone bad'
-                 }
+    fb.result = {'success': False, 'message': 'gone bad'}
     with pytest.raises(btx.OperationalException, match=r'.*gone bad.*'):
         wb.get_ticker('BTC_ETH')
 

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -1,28 +1,19 @@
-# pragma pylint: disable=missing-docstring,W0212
+# pragma pylint: disable=missing-docstring, W0212, line-too-long, C0103
 
 import logging
 import math
-import pandas as pd
-import pytest
 from unittest.mock import MagicMock
+import pandas as pd
 from freqtrade import exchange, optimize
 from freqtrade.exchange import Bittrex
 from freqtrade.optimize import preprocess
 from freqtrade.optimize.backtesting import backtest, generate_text_table, get_timeframe
 import freqtrade.optimize.backtesting as backtesting
-from freqtrade.strategy.strategy import Strategy
 
 
-@pytest.fixture
-def default_strategy():
-    strategy = Strategy()
-    strategy.init({'strategy': 'default_strategy'})
-    return strategy
-
-
-def trim_dictlist(dl, num):
+def trim_dictlist(dict_list, num):
     new = {}
-    for pair, pair_data in dl.items():
+    for pair, pair_data in dict_list.items():
         new[pair] = pair_data[num:]
     return new
 

--- a/freqtrade/tests/optimize/test_optimize.py
+++ b/freqtrade/tests/optimize/test_optimize.py
@@ -1,4 +1,4 @@
-# pragma pylint: disable=missing-docstring,W0212
+# pragma pylint: disable=missing-docstring, protected-access, C0103
 
 import os
 import logging
@@ -55,8 +55,7 @@ def test_load_data_30min_ticker(default_conf, ticker_history, mocker, caplog):
     assert os.path.isfile(file) is True
     assert ('freqtrade.optimize',
             logging.INFO,
-            'Download the pair: "BTC_ETH", Interval: 30 min'
-            ) not in caplog.record_tuples
+            'Download the pair: "BTC_ETH", Interval: 30 min') not in caplog.record_tuples
     _clean_test_file(file)
 
 
@@ -72,8 +71,7 @@ def test_load_data_5min_ticker(default_conf, ticker_history, mocker, caplog):
     assert os.path.isfile(file) is True
     assert ('freqtrade.optimize',
             logging.INFO,
-            'Download the pair: "BTC_ETH", Interval: 5 min'
-            ) not in caplog.record_tuples
+            'Download the pair: "BTC_ETH", Interval: 5 min') not in caplog.record_tuples
     _clean_test_file(file)
 
 
@@ -89,8 +87,7 @@ def test_load_data_1min_ticker(default_conf, ticker_history, mocker, caplog):
     assert os.path.isfile(file) is True
     assert ('freqtrade.optimize',
             logging.INFO,
-            'Download the pair: "BTC_ETH", Interval: 1 min'
-            ) not in caplog.record_tuples
+            'Download the pair: "BTC_ETH", Interval: 1 min') not in caplog.record_tuples
     _clean_test_file(file)
 
 
@@ -106,8 +103,7 @@ def test_load_data_with_new_pair_1min(default_conf, ticker_history, mocker, capl
     assert os.path.isfile(file) is True
     assert ('freqtrade.optimize',
             logging.INFO,
-            'Download the pair: "BTC_MEME", Interval: 1 min'
-            ) in caplog.record_tuples
+            'Download the pair: "BTC_MEME", Interval: 1 min') in caplog.record_tuples
     _clean_test_file(file)
 
 
@@ -173,8 +169,7 @@ def test_download_pairs_exception(default_conf, ticker_history, mocker, caplog):
     _clean_test_file(file1_5)
     assert ('freqtrade.optimize.__init__',
             logging.INFO,
-            'Failed to download the pair: "BTC-MEME", Interval: 1 min'
-            ) in caplog.record_tuples
+            'Failed to download the pair: "BTC-MEME", Interval: 1 min') in caplog.record_tuples
 
 
 def test_download_backtesting_testdata(default_conf, ticker_history, mocker):

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -1,4 +1,5 @@
 # pragma pylint: disable=missing-docstring, too-many-arguments, too-many-ancestors, C0103
+# pragma pylint: disable=unused-argument
 import re
 from datetime import datetime
 from random import randint

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -1,14 +1,7 @@
-import json
+# pragma pylint: disable=missing-docstring, protected-access, C0103
+
 import logging
-import pytest
 from freqtrade.strategy.strategy import Strategy
-from freqtrade.analyze import parse_ticker_dataframe
-
-
-@pytest.fixture
-def result():
-    with open('freqtrade/tests/testdata/BTC_ETH-1.json') as data_file:
-        return parse_ticker_dataframe(json.load(data_file))
 
 
 def test_sanitize_module_name():
@@ -28,8 +21,6 @@ def test_search_strategy():
 
 def test_strategy_structure():
     assert hasattr(Strategy, 'init')
-    assert hasattr(Strategy, 'minimal_roi')
-    assert hasattr(Strategy, 'stoploss')
     assert hasattr(Strategy, 'populate_indicators')
     assert hasattr(Strategy, 'populate_buy_trend')
     assert hasattr(Strategy, 'populate_sell_trend')

--- a/freqtrade/tests/test_acl_pair.py
+++ b/freqtrade/tests/test_acl_pair.py
@@ -1,3 +1,5 @@
+# pragma pylint: disable=missing-docstring,C0103
+
 from freqtrade.main import refresh_whitelist, gen_pair_whitelist
 
 # whitelist, blacklist, filtering, all of that will
@@ -73,16 +75,9 @@ def get_market_summaries():
 
 
 def get_health():
-    return [{'Currency': 'ETH',
-             'IsActive': True
-             },
-            {'Currency': 'TKN',
-             'IsActive': True
-             },
-            {'Currency': 'BLK',
-             'IsActive': True
-             }
-            ]
+    return [{'Currency': 'ETH', 'IsActive': True},
+            {'Currency': 'TKN', 'IsActive': True},
+            {'Currency': 'BLK', 'IsActive': True}]
 
 
 def get_health_empty():

--- a/freqtrade/tests/test_analyze.py
+++ b/freqtrade/tests/test_analyze.py
@@ -1,10 +1,8 @@
-# pragma pylint: disable=missing-docstring,W0621
+# pragma pylint: disable=missing-docstring, C0103
 import datetime
-import json
 from unittest.mock import MagicMock
 
 import arrow
-import pytest
 from pandas import DataFrame
 
 import freqtrade.tests.conftest as tt  # test tools
@@ -12,12 +10,6 @@ from freqtrade.analyze import (get_signal, parse_ticker_dataframe,
                                populate_buy_trend, populate_indicators,
                                populate_sell_trend)
 from freqtrade.strategy.strategy import Strategy
-
-
-@pytest.fixture
-def result():
-    with open('freqtrade/tests/testdata/BTC_ETH-1.json') as data_file:
-        return parse_ticker_dataframe(json.load(data_file))
 
 
 def test_dataframe_correct_columns(result):

--- a/freqtrade/tests/test_dataframe.py
+++ b/freqtrade/tests/test_dataframe.py
@@ -1,5 +1,6 @@
-import pandas
+# pragma pylint: disable=missing-docstring, C0103
 
+import pandas
 import freqtrade.optimize
 from freqtrade import analyze
 

--- a/freqtrade/tests/test_fiat_convert.py
+++ b/freqtrade/tests/test_fiat_convert.py
@@ -1,4 +1,5 @@
-# pragma pylint: disable=missing-docstring, too-many-arguments, too-many-ancestors, C0103
+# pragma pylint: disable=missing-docstring, too-many-arguments, too-many-ancestors,
+# pragma pylint: disable=protected-access, C0103
 
 import time
 from unittest.mock import MagicMock
@@ -47,16 +48,19 @@ def test_fiat_convert_is_supported():
 def test_fiat_convert_add_pair():
     fiat_convert = CryptoToFiatConverter()
 
-    assert len(fiat_convert._pairs) == 0
+    pair_len = len(fiat_convert._pairs)
+    assert pair_len == 0
 
     fiat_convert._add_pair(crypto_symbol='btc', fiat_symbol='usd', price=12345.0)
-    assert len(fiat_convert._pairs) == 1
+    pair_len = len(fiat_convert._pairs)
+    assert pair_len == 1
     assert fiat_convert._pairs[0].crypto_symbol == 'BTC'
     assert fiat_convert._pairs[0].fiat_symbol == 'USD'
     assert fiat_convert._pairs[0].price == 12345.0
 
     fiat_convert._add_pair(crypto_symbol='btc', fiat_symbol='Eur', price=13000.2)
-    assert len(fiat_convert._pairs) == 2
+    pair_len = len(fiat_convert._pairs)
+    assert pair_len == 2
     assert fiat_convert._pairs[1].crypto_symbol == 'BTC'
     assert fiat_convert._pairs[1].fiat_symbol == 'EUR'
     assert fiat_convert._pairs[1].price == 13000.2
@@ -95,7 +99,8 @@ def test_fiat_convert_get_price(mocker):
         fiat_convert.get_price(crypto_symbol='BTC', fiat_symbol='US Dollar')
 
     # Check the value return by the method
-    assert len(fiat_convert._pairs) == 0
+    pair_len = len(fiat_convert._pairs)
+    assert pair_len == 0
     assert fiat_convert.get_price(crypto_symbol='BTC', fiat_symbol='USD') == 28000.0
     assert fiat_convert._pairs[0].crypto_symbol == 'BTC'
     assert fiat_convert._pairs[0].fiat_symbol == 'USD'

--- a/freqtrade/tests/test_main.py
+++ b/freqtrade/tests/test_main.py
@@ -1,4 +1,4 @@
-# pragma pylint: disable=missing-docstring,C0103
+# pragma pylint: disable=missing-docstring, C0103
 import copy
 import logging
 from unittest.mock import MagicMock
@@ -325,27 +325,31 @@ def test_handle_overlpapping_signals(default_conf, ticker, mocker):
 
     # Buy and Sell triggering, so doing nothing ...
     trades = Trade.query.all()
-    assert len(trades) == 0
+    nb_trades = len(trades)
+    assert nb_trades == 0
 
     # Buy is triggering, so buying ...
     mocker.patch('freqtrade.main.get_signal', side_effect=lambda s, t: (True, False))
     create_trade(0.001, int(default_conf['ticker_interval']))
     trades = Trade.query.all()
-    assert len(trades) == 1
+    nb_trades = len(trades)
+    assert nb_trades == 1
     assert trades[0].is_open is True
 
     # Buy and Sell are not triggering, so doing nothing ...
     mocker.patch('freqtrade.main.get_signal', side_effect=lambda s, t: (False, False))
     assert handle_trade(trades[0], int(default_conf['ticker_interval'])) is False
     trades = Trade.query.all()
-    assert len(trades) == 1
+    nb_trades = len(trades)
+    assert nb_trades == 1
     assert trades[0].is_open is True
 
     # Buy and Sell are triggering, so doing nothing ...
     mocker.patch('freqtrade.main.get_signal', side_effect=lambda s, t: (True, True))
     assert handle_trade(trades[0], int(default_conf['ticker_interval'])) is False
     trades = Trade.query.all()
-    assert len(trades) == 1
+    nb_trades = len(trades)
+    assert nb_trades == 1
     assert trades[0].is_open is True
 
     # Sell is triggering, guess what : we are Selling!
@@ -468,7 +472,8 @@ def test_check_handle_timedout_buy(default_conf, ticker, limit_buy_order_old, mo
     assert cancel_order_mock.call_count == 1
     assert rpc_mock.call_count == 1
     trades = Trade.query.filter(Trade.open_order_id.is_(trade_buy.open_order_id)).all()
-    assert len(trades) == 0
+    nb_trades = len(trades)
+    assert nb_trades == 0
 
 
 def test_handle_timedout_limit_buy(mocker):

--- a/freqtrade/tests/test_persistence.py
+++ b/freqtrade/tests/test_persistence.py
@@ -1,4 +1,4 @@
-# pragma pylint: disable=missing-docstring
+# pragma pylint: disable=missing-docstring, C0103
 import os
 import pytest
 from sqlalchemy import create_engine
@@ -12,7 +12,7 @@ def test_init_create_session(default_conf, mocker):
     # Check if init create a session
     init(default_conf)
     assert hasattr(Trade, 'session')
-    assert type(Trade.session).__name__ is 'Session'
+    assert 'Session' in type(Trade.session).__name__
 
 
 def test_init_dry_run_db(default_conf, mocker):

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,4 @@ tabulate==0.8.2
 pymarketcap==3.3.153
 
 # Required for plotting data
-#matplotlib==2.1.0
-#PYQT5==5.9
+#plotly==2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-bittrex==0.2.2
+python-bittrex==0.3.0
 SQLAlchemy==1.2.2
 python-telegram-bot==9.0.0
 arrow==0.12.1

--- a/scripts/plot_profit.py
+++ b/scripts/plot_profit.py
@@ -3,23 +3,20 @@
 import sys
 import json
 import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
 import numpy as np
 
 import freqtrade.optimize as optimize
 import freqtrade.misc as misc
+import freqtrade.exchange as exchange
 from freqtrade.strategy.strategy import Strategy
 
 
 def plot_parse_args(args):
-    parser = misc.common_args_parser('Graph utility')
+    parser = misc.common_args_parser('Graph profits')
     # FIX: perhaps delete those backtesting options that are not feasible (shows up in -h)
     misc.backtesting_options(parser)
-    parser.add_argument(
-        '-p', '--pair',
-        help='Show profits for only this pairs. Pairs are comma-separated.',
-        dest='pair',
-        default=None
-    )
+    misc.scripts_options(parser)
     return parser.parse_args(args)
 
 
@@ -39,7 +36,9 @@ def make_profit_array(data, px, filter_pairs=[]):
         profit = trade[1]
         tim = trade[4]
         dur = trade[5]
-        pg[tim+dur-1] += profit
+        ix = tim + dur - 1
+        if ix < px:
+            pg[ix] += profit
 
     # rewrite the pg array to go from
     # total profits at each timeframe
@@ -81,28 +80,21 @@ def plot_profit(args) -> None:
         pairs = list(set(pairs) & set(filter_pairs))
         print('Filter, keep pairs %s' % pairs)
 
+    timerange = misc.parse_timerange(args.timerange)
     tickers = optimize.load_data(args.datadir, pairs=pairs,
                                  ticker_interval=strategy.ticker_interval,
-                                 refresh_pairs=False)
+                                 refresh_pairs=False,
+                                 timerange=timerange)
     dataframes = optimize.preprocess(tickers)
+
+    # NOTE: the dataframes are of unequal length,
+    # 'dates' is an merged date array of them all.
+
+    dates = misc.common_datearray(dataframes)
+    max_x = dates.size
 
     # Make an average close price of all the pairs that was involved.
     # this could be useful to gauge the overall market trend
-
-    # FIX: since the dataframes are of unequal length,
-    # andor has different dates, we need to merge them
-    # But we dont have the date information in the
-    # backtesting results, this is needed to match the dates
-    # For now, assume the dataframes are aligned.
-    max_x = 0
-    for pair, pair_data in dataframes.items():
-        n = len(pair_data['close'])
-        max_x = max(max_x, n)
-    #    if max_x != n:
-    #        raise Exception('Please rerun script. Input data has different lengths %s'
-    #                         %('Different pair length: %s <=> %s' %(max_x, n)))
-    print('max_x: %s' % (max_x))
-
     # We are essentially saying:
     #  array <- sum dataframes[*]['close'] / num_items dataframes
     #  FIX: there should be some onliner numpy/panda for this
@@ -132,8 +124,9 @@ def plot_profit(args) -> None:
 
     fig, (ax1, ax2, ax3) = plt.subplots(3, sharex=True)
     fig.suptitle('total profit')
-    ax1.plot(avgclose, label='avgclose')
-    ax2.plot(pg, label='profit')
+
+    ax1.plot(dates, avgclose, label='avgclose')
+    ax2.plot(dates, pg, label='profit')
     ax1.legend(loc='upper left')
     ax2.legend(loc='upper left')
 
@@ -143,15 +136,15 @@ def plot_profit(args) -> None:
     # In third graph, we plot each profit separately
     for pair in pairs:
         pg = make_profit_array(data, max_x, pair)
-        ax3.plot(pg, label=pair)
+        ax3.plot(dates, pg, label=pair)
     ax3.legend(loc='upper left')
     # black background to easier see multiple colors
     ax3.set_facecolor('black')
+    xfmt = mdates.DateFormatter('%d-%m-%y %H:%M')  # Dont let matplotlib autoformat date
+    ax3.xaxis.set_major_formatter(xfmt)
 
-    # Fine-tune figure; make subplots close to each other and hide x ticks for
-    # all but bottom plot.
     fig.subplots_adjust(hspace=0)
-    plt.setp([a.get_xticklabels() for a in fig.axes[:-1]], visible=False)
+    fig.autofmt_xdate()  # Rotate the dates
     plt.show()
 
 

--- a/scripts/plot_profit.py
+++ b/scripts/plot_profit.py
@@ -2,9 +2,12 @@
 
 import sys
 import json
-import matplotlib.pyplot as plt
-import matplotlib.dates as mdates
 import numpy as np
+
+import plotly
+from plotly import tools
+from plotly.offline import plot
+import plotly.graph_objs as go
 
 import freqtrade.optimize as optimize
 import freqtrade.misc as misc
@@ -122,30 +125,32 @@ def plot_profit(args) -> None:
     # Plot the pairs average close prices, and total profit growth
     #
 
-    fig, (ax1, ax2, ax3) = plt.subplots(3, sharex=True)
-    fig.suptitle('total profit')
+    avgclose = go.Scattergl(
+        x=dates,
+        y=avgclose,
+        name='Avg close price',
+    )
+    profit = go.Scattergl(
+        x=dates,
+        y=pg,
+        name='Profit',
+    )
 
-    ax1.plot(dates, avgclose, label='avgclose')
-    ax2.plot(dates, pg, label='profit')
-    ax1.legend(loc='upper left')
-    ax2.legend(loc='upper left')
+    fig = tools.make_subplots(rows=3, cols=1, shared_xaxes=True, row_width=[1, 1, 1])
 
-    # FIX if we have one line pair in paris
-    #     then skip the plotting of the third graph,
-    #     or change what we plot
-    # In third graph, we plot each profit separately
+    fig.append_trace(avgclose, 1, 1)
+    fig.append_trace(profit, 2, 1)
+
     for pair in pairs:
         pg = make_profit_array(data, max_x, pair)
-        ax3.plot(dates, pg, label=pair)
-    ax3.legend(loc='upper left')
-    # black background to easier see multiple colors
-    ax3.set_facecolor('black')
-    xfmt = mdates.DateFormatter('%d-%m-%y %H:%M')  # Dont let matplotlib autoformat date
-    ax3.xaxis.set_major_formatter(xfmt)
+        pair_profit = go.Scattergl(
+            x=dates,
+            y=pg,
+            name=pair,
+        )
+        fig.append_trace(pair_profit, 3, 1)
 
-    fig.subplots_adjust(hspace=0)
-    fig.autofmt_xdate()  # Rotate the dates
-    plt.show()
+    plot(fig, filename='freqtrade-profit-plot.html')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

This PR aims is to share the same sell evaluation function among backtesting and the bot, so that when modifications are made to the bot, they get automagicaly in the bactesting  environnement. This PR also takes into account the fact that BUY cannot occur if SELL is on at the same time and that SELL cannot occur if BUY is on at the same time.

## Quick changelog

- refactoring bot to have a function returning True of False to indicate that the trade should be cloed
- refactoring backtesting to use this function
- refactoring backtesting to use dates instead of index

## Help required

Four unit tests are failing, but before modifying them I would like to have your point of view on what is failing and what is the best fix. The tests seems not very deterministic.