### PR TITLE
Replace matplotlib with Plotly

### DIFF
--- a/docs/plotting.md
+++ b/docs/plotting.md
@@ -5,21 +5,34 @@ This page explains how to plot prices, indicator, profits.
 - [Plot price and indicators](#plot-price-and-indicators)
 - [Plot profit](#plot-profit)
 
+## Installation
+
+Plotting scripts use Plotly library. Install/upgrade it with:
+
+```
+pip install --upgrade plotly
+```
+
+At least version 2.3.0 is required.
+
 ## Plot price and indicators
 Usage for the price plotter:
-script/plot_dataframe.py [-h] [-p pair]
+
+```
+script/plot_dataframe.py [-h] [-p pair] [--live]
+```
 
 Example
 ```
-python script/plot_dataframe.py -p BTC_ETH,BTC_LTC
+python script/plot_dataframe.py -p BTC_ETH
 ```
 
-The -p pair argument, can be used to specify what
+The `-p` pair argument, can be used to specify what
 pair you would like to plot.
 
 **Advanced use**
 
-To plot the current live price use the --live flag:
+To plot the current live price use the `--live` flag:
 ```
 python scripts/plot_dataframe.py -p BTC_ETH --live
 ```
@@ -51,19 +64,14 @@ The third graph can be useful to spot outliers, events in pairs
 that makes profit spikes.
 
 Usage for the profit plotter:
-script/plot_profit.py [-h] [-p pair] [--datadir directory] [--ticker_interval num]
 
-The -p pair argument, can be used to plot a single pair
+```
+script/plot_profit.py [-h] [-p pair] [--datadir directory] [--ticker_interval num]
+```
+
+The `-p` pair argument, can be used to plot a single pair
 
 Example
 ```
 python python scripts/plot_profit.py --datadir ../freqtrade/freqtrade/tests/testdata-20171221/ -p BTC_LTC
 ```
-
-**When it goes wrong**
-
-*** Linux: Can't display**
-
-If you are inside an python environment, you might want to set the
-DISPLAY variable as so:
-$ DISPLAY=:0 python scripts/plot_dataframe.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,4 @@ tabulate==0.8.2
 pymarketcap==3.3.153
 
 # Required for plotting data
-#matplotlib==2.1.0
-#PYQT5==5.9
+#plotly==2.3.0

--- a/scripts/plot_profit.py
+++ b/scripts/plot_profit.py
@@ -2,9 +2,12 @@
 
 import sys
 import json
-import matplotlib.pyplot as plt
-import matplotlib.dates as mdates
 import numpy as np
+
+import plotly
+from plotly import tools
+from plotly.offline import plot
+import plotly.graph_objs as go
 
 import freqtrade.optimize as optimize
 import freqtrade.misc as misc
@@ -122,30 +125,32 @@ def plot_profit(args) -> None:
     # Plot the pairs average close prices, and total profit growth
     #
 
-    fig, (ax1, ax2, ax3) = plt.subplots(3, sharex=True)
-    fig.suptitle('total profit')
+    avgclose = go.Scattergl(
+        x=dates,
+        y=avgclose,
+        name='Avg close price',
+    )
+    profit = go.Scattergl(
+        x=dates,
+        y=pg,
+        name='Profit',
+    )
 
-    ax1.plot(dates, avgclose, label='avgclose')
-    ax2.plot(dates, pg, label='profit')
-    ax1.legend(loc='upper left')
-    ax2.legend(loc='upper left')
+    fig = tools.make_subplots(rows=3, cols=1, shared_xaxes=True, row_width=[1, 1, 1])
 
-    # FIX if we have one line pair in paris
-    #     then skip the plotting of the third graph,
-    #     or change what we plot
-    # In third graph, we plot each profit separately
+    fig.append_trace(avgclose, 1, 1)
+    fig.append_trace(profit, 2, 1)
+
     for pair in pairs:
         pg = make_profit_array(data, max_x, pair)
-        ax3.plot(dates, pg, label=pair)
-    ax3.legend(loc='upper left')
-    # black background to easier see multiple colors
-    ax3.set_facecolor('black')
-    xfmt = mdates.DateFormatter('%d-%m-%y %H:%M')  # Dont let matplotlib autoformat date
-    ax3.xaxis.set_major_formatter(xfmt)
+        pair_profit = go.Scattergl(
+            x=dates,
+            y=pg,
+            name=pair,
+        )
+        fig.append_trace(pair_profit, 3, 1)
 
-    fig.subplots_adjust(hspace=0)
-    fig.autofmt_xdate()  # Rotate the dates
-    plt.show()
+    plot(fig, filename='freqtrade-profit-plot.html')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Convert both plotting scripts to use Plotly. Results in HTML pages with WebGL optimized graphs.

<img width="1226" alt="screenshot 2018-01-28 11 58 37" src="https://user-images.githubusercontent.com/557751/35480962-c32eb2a0-0422-11e8-91ee-a762d1157cb2.png">

## What's new?

No need for DISPLAY backends for different environments, instead plots are in a html file that is easy to save, transfer or serve from a container.

Users will need to run `pip install plotly` to get the new plotting library. It is by default commented out in the `requirements.txt`.