### PR TITLE
Fixing wrong 'old dataframe detection mechanism' for long tickers

### DIFF
--- a/freqtrade/analyze.py
+++ b/freqtrade/analyze.py
@@ -112,7 +112,7 @@ def get_signal(pair: str, interval: int) -> (bool, bool):
 
     # Check if dataframe is out of date
     signal_date = arrow.get(latest['date'])
-    if signal_date < arrow.now() - timedelta(minutes=10):
+    if signal_date < arrow.now() - timedelta(minutes=(interval + 5)):
         logger.warning('Too old dataframe for pair %s', pair)
         return (False, False)  # return False ?
 


### PR DESCRIPTION
## Summary
The PR fixes the bad detection of old dataframe mechanism when using tickers > 5 minutes

## Quick changelog

- A `dataframe` is considered old when it has not been updated after ticker_interval + 5 minutes 

