### PR TITLE
Update doc: add --upgrade pip

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -297,6 +297,7 @@ cp config.json.example config.json
 ```bash
 python3.6 -m venv .env
 source .env/bin/activate
+pip3.6 install --upgrade pip
 pip3.6 install -r requirements.txt
 pip3.6 install -e .
 ```


### PR DESCRIPTION
## Summary
Add `pip3.6 install --upgrade pip` in the linux installation procedure.
I saw the virtual env can still use an old version of pip and fails the installation of modules.

```bash
python3.6 -m venv .env
source .env/bin/activate
pip3.6 install --upgrade pip
pip3.6 install -r requirements.txt
pip3.6 install -e .
```

Solve the issue: None

## Quick changelog

- Update the install on linux/macOS documentation
