### PR TITLE
Add setup.sh script to install and update the bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ bot in dry-run. We invite you to read the
 [bot documentation](https://github.com/gcarq/freqtrade/blob/develop/docs/index.md) 
 to ensure you understand how the bot is working.
 
+### Easy installation
+The script below will install all dependencies and help you to configure the bot.
+```bash
+./setup.sh --install
+```
+
+### Manual installation
 The following steps are made for Linux/MacOS environment
 
 **1. Clone the repo**

--- a/config_full.json.example
+++ b/config_full.json.example
@@ -4,6 +4,14 @@
     "stake_amount": 0.05,
     "fiat_display_currency": "USD",
     "dry_run": false,
+    "ticker_interval": 5,
+    "minimal_roi": {
+        "40":  0.0,
+        "30":  0.01,
+        "20":  0.02,
+        "0":  0.04
+    },
+    "stoploss": -0.10,
     "unfilledtimeout": 600,
     "bid_strategy": {
         "ask_last_balance": 0.0

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,15 +7,50 @@ To understand how to set up the bot please read the [Bot Configuration](https://
 ## Table of Contents
 
 * [Table of Contents](#table-of-contents)
-* [Automatic Installation - Docker](#automatic-installation-docker)
-* [Custom Installation](#custom-installation)
+* [Easy Installation - Linux Script](#easy-installation---linux-script)
+* [Automatic Installation - Docker](#automatic-installation---docker)
+* [Custom Linux MacOS Installation](#custom-installation)
 	- [Requirements](#requirements)
-	- [Linux - Ubuntu 16.04](#linux-ubuntu-1604)
+	- [Linux - Ubuntu 16.04](#linux---ubuntu-1604)
 	- [MacOS](#macos)
-	- [Windows](#windows)
-* [First Steps](#first-step)
+	- [Setup Config and virtual env](#setup-config-and-virtual-env)
+* [Windows](#windows)
+	
 
 <!-- /TOC -->
+
+------
+
+## Easy Installation - Linux Script
+
+If you are on Debian, Ubuntu or MacOS a freqtrade provides a script to Install, Update, Configure, and Reset your bot.
+
+```bash
+$ ./setup.sh
+usage:
+	-i,--install    Install freqtrade from scratch
+	-u,--update     Command git pull to update.
+	-r,--reset      Hard reset your develop/master branch.
+	-c,--config     Easy config generator (Will override your existing file).
+```
+
+### --install
+This script will install everything you need to run the bot:
+* Mandatory software as: `Python3`, `ta-lib`, `wget`
+* Setup your virtualenv
+* Configure your `config.json` file
+
+This script is a combination of `install script` `--reset`, `--config`
+
+### --update
+Update parameter will pull the last version of your current branch and update your virtualenv.
+
+### --reset
+Reset parameter will hard reset your branch (only if you are on `master` or `develop`) and recreate your virtualenv.
+
+### --config
+Config parameter is a `config.json` configurator. This script will ask you questions to setup your bot and create your `config.json`.
+
 ------
 
 ## Automatic Installation - Docker
@@ -253,12 +288,44 @@ Optionally checkout the develop branch:
 git checkout develop
 ```
 
-### Windows
+
+### Setup Config and virtual env
+
+#### 1. Initialize the configuration
+
+```bash
+cd freqtrade
+cp config.json.example config.json
+```
+
+> *To edit the config please refer to [Bot Configuration](https://github.com/gcarq/freqtrade/blob/develop/docs/configuration.md).*
+
+
+#### 2. Setup your Python virtual environment (virtualenv)
+
+```bash
+python3.6 -m venv .env
+source .env/bin/activate
+pip3.6 install -r requirements.txt
+pip3.6 install -e .
+```
+
+#### 3. Run the Bot
+
+If this is the first time you run the bot, ensure you are running it in Dry-run `"dry_run": true,` otherwise it will start to buy and sell coins.
+
+```bash
+python3.6 ./freqtrade/main.py -c config.json
+```
+
+------
+
+## Windows
 
 We recommend that Windows users use [Docker](#docker) as this will work
 much easier and smoother (also more secure).
 
-#### 1. Install freqtrade
+### Install freqtrade
 
 copy paste `config.json` to ``\path\freqtrade-develop\freqtrade`
 
@@ -276,38 +343,6 @@ copy paste `config.json` to ``\path\freqtrade-develop\freqtrade`
 
 > Thanks [Owdr](https://github.com/Owdr) for the commands. Source: [Issue #222](https://github.com/gcarq/freqtrade/issues/222)
 
-
-------
-
-
-## First Steps
-
-### 1. Initialize the configuration
-
-```bash
-cd freqtrade
-cp config.json.example config.json
-```
-
-> *To edit the config please refer to [Bot Configuration](https://github.com/gcarq/freqtrade/blob/develop/docs/configuration.md).*
-
-
-### 2. Setup your Python virtual environment (virtualenv)
-
-```bash
-python3.6 -m venv .env
-source .env/bin/activate
-pip3.6 install -r requirements.txt
-pip3.6 install -e .
-```
-
-### 3. Run the Bot
-
-If this is the first time you run the bot, ensure you are running it in Dry-run `"dry_run": true,` otherwise it will start to buy and sell coins.
-
-```bash
-python3.6 ./freqtrade/main.py -c config.json
-```
 
 Now you have an environment ready, the next step is
 [Bot Configuration](https://github.com/gcarq/freqtrade/blob/develop/docs/configuration.md)...

--- a/setup.sh
+++ b/setup.sh
@@ -193,12 +193,22 @@ config
 echo "You can now use the bot by executing 'source .env/bin/activate; python3 freqtrade/main.py'."
 }
 
+function plot () {
+echo "
+-----------------------------------------
+Install dependencies for Plotting scripts
+-----------------------------------------
+"
+pip install plotly
+}
+
 function help () {
 echo "usage:"
 echo "	-i,--install    Install freqtrade from scratch"
 echo "	-u,--update     Command git pull to update."
 echo "	-r,--reset      Hard reset your develop/master branch."
 echo "	-c,--config     Easy config generator (Will override your existing file)."
+echo "	-p,--plot       Install dependencies for Plotting scripts."
 }
 
 case $* in
@@ -213,6 +223,9 @@ update
 ;;
 --reset|-r)
 reset
+;;
+--plot|-p)
+plot
 ;;
 *)
 help

--- a/setup.sh
+++ b/setup.sh
@@ -1,196 +1,170 @@
 #!/usr/bin/env bash
 #encoding=utf8
-freqtradepath=$(pwd)
-
-function go_to_folder () {
-cd $freqtradepath
-}
 
 function updateenv () {
-echo "
--------------------------
-Update your virtual env
--------------------------
-"
-source .env/bin/activate
-pip3.6 install --upgrade pip
-pip3 install -r requirements.txt --upgrade
-pip3 install -r requirements.txt
-pip3 install -e .
+    echo "
+    -------------------------
+    Update your virtual env
+    -------------------------
+    "
+    source .env/bin/activate
+    pip3.6 install --upgrade pip
+    pip3 install -r requirements.txt --upgrade
+    pip3 install -r requirements.txt
+    pip3 install -e .
 }
 
 # Install tab lib
 function install_talib () {
-curl -O -L http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz
-tar zxvf ta-lib-0.4.0-src.tar.gz
-cd ta-lib && ./configure --prefix=/usr && make && sudo make install
-cd .. && rm -rf ./ta-lib*
+    curl -O -L http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz
+    tar zxvf ta-lib-0.4.0-src.tar.gz
+    cd ta-lib && ./configure --prefix=/usr && make && sudo make install
+    cd .. && rm -rf ./ta-lib*
 }
 
 # Install bot MacOS
 function install_macos () {
-if [ ! -x "$(command -v brew)" ]
-then
-    echo "-------------------------"
-    echo "Install Brew"
-    echo "-------------------------"
-    echo
-    /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-fi
-brew install python3 wget ta-lib
+    if [ ! -x "$(command -v brew)" ]
+    then
+        echo "-------------------------"
+        echo "Install Brew"
+        echo "-------------------------"
+        echo
+        /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    fi
+    brew install python3 wget ta-lib
 }
 
 # Install bot Debian_ubuntu
 function install_debian () {
-sudo add-apt-repository ppa:jonathonf/python-3.6
-sudo apt-get update
-sudo apt-get install python3.6 python3.6-venv python3.6-dev build-essential autoconf libtool pkg-config make wget git
-install_talib
+    sudo add-apt-repository ppa:jonathonf/python-3.6
+    sudo apt-get update
+    sudo apt-get install python3.6 python3.6-venv python3.6-dev build-essential autoconf libtool pkg-config make wget git
+    install_talib
 }
 
 # Upgrade the bot
 function update () {
-go_to_folder
-git pull
-updateenv
+    git pull
+    updateenv
 }
 
 # Reset Develop or Master branch
 function reset () {
+    echo "----------------------------"
+    echo "Reset branch and virtual env"
+    echo "----------------------------"
+    echo
+    if [ "1" == $(git branch -vv |grep -cE "\* develop|\* master") ]
+    then
+        if [ -d ".env" ]; then
+          echo "- Delete your previous virtual env"
+          rm -rf .env
+        fi
 
-echo "
-----------------------------
-Reset branch and virtual env
-----------------------------
-"
-if [ "1" == $(git branch -vv |grep -cE "\* develop|\* master") ]
-then
-    go_to_folder
+        git fetch -a
 
-    if [ -d ".env" ]; then
-      echo "- Delete your previous virtual env"
-      rm -rf .env
+        if [ "1" == $(git branch -vv |grep -c "* develop") ]
+        then
+          echo "- Hard resetting of 'develop' branch."
+          git reset --hard origin/develop
+        elif [ "1" == $(git branch -vv |grep -c "* master") ]
+        then
+          echo "- Hard resetting of 'master' branch."
+          git reset --hard origin/master
+        fi
+    else
+        echo "Reset ignored because you are not on 'master' or 'develop'."
     fi
 
-    git fetch -a
-
-    if [ "1" == $(git branch -vv |grep -c "* develop") ]
-    then
-      echo "- Hard resetting of 'develop' branch."
-      git reset --hard origin/develop
-    elif [ "1" == $(git branch -vv |grep -c "* master") ]
-    then
-      echo "- Hard resetting of 'master' branch."
-      git reset --hard origin/master
-    fi
-else
-    echo "Reset ignored because you are not on 'master' or 'develop'."
-fi
-
-python3.6 -m venv .env
-updateenv
+    python3.6 -m venv .env
+    updateenv
 }
 
 function config_generator () {
 
-echo "Starting to generate config.json"
+    echo "Starting to generate config.json"
 
-echo "
--------------------------
-General configuration
--------------------------
-"
-read -p "Max open trades: (Default: 3)
-" max_trades
+    echo "-------------------------"
+    echo "General configuration"
+    echo "-------------------------"
+    echo
+    read -p "Max open trades: (Default: 3) " max_trades
 
-read -p "Stake amount: (Default: 0.05)
-" stake_amount
+    read -p "Stake amount: (Default: 0.05) " stake_amount
 
-read -p "Stake currency: (Default: BTC)
-" stake_currency
+    read -p "Stake currency: (Default: BTC) " stake_currency
 
-read -p "Fiat currency: (Default: USD)
-" fiat_currency
+    read -p "Fiat currency: (Default: USD) " fiat_currency
 
-echo "
-------------------------
-Bittrex config generator
-------------------------
-"
-read -p "Exchange API key
-" api_key
-read -p "Exchange API Secret
-" -s api_secret
+    echo "------------------------"
+    echo "Bittrex config generator"
+    echo "------------------------"
+    echo
+    read -p "Exchange API key: " api_key
+    read -p "Exchange API Secret: " api_secret
 
-echo "
--------------------------
-Telegram config generator
--------------------------
-"
-read -p "Telegram Token
-" -s token
-read -p "Telegram Chat_id
-" chat_id
+    echo "-------------------------"
+    echo "Telegram config generator"
+    echo "-------------------------"
+    read -p "Telegram Token: " token
+    read -p "Telegram Chat_id: " chat_id
 
-sed -e "s/\"max_open_trades\": 3,/\"max_open_trades\": $max_trades,/g" \
-    -e "s/\"stake_amount\": 0.05,/\"stake_amount\": $stake_amount,/g" \
-    -e "s/\"stake_currency\": \"BTC\",/\"stake_currency\": \"$stake_currency\",/g" \
-    -e "s/\"fiat_display_currency\": \"USD\",/\"fiat_display_currency\": \"$fiat_currency\",/g" \
-    -e "s/\"your_echange_key\"/\"$api_key\"/g" \
-    -e "s/\"your_echange_secret\"/\"$api_secret\"/g" \
-    -e "s/\"your_instagram_token\"/\"$token\"/g" \
-    -e "s/\"your_instagram_chat_id\"/\"$chat_id\"/g"
-    -e "s/\"dry_run\": false,/\"dry_run\": true,/g" config.json.example > config.json
+    sed -e "s/\"max_open_trades\": 3,/\"max_open_trades\": $max_trades,/g" \
+        -e "s/\"stake_amount\": 0.05,/\"stake_amount\": $stake_amount,/g" \
+        -e "s/\"stake_currency\": \"BTC\",/\"stake_currency\": \"$stake_currency\",/g" \
+        -e "s/\"fiat_display_currency\": \"USD\",/\"fiat_display_currency\": \"$fiat_currency\",/g" \
+        -e "s/\"your_echange_key\"/\"$api_key\"/g" \
+        -e "s/\"your_echange_secret\"/\"$api_secret\"/g" \
+        -e "s/\"your_instagram_token\"/\"$token\"/g" \
+        -e "s/\"your_instagram_chat_id\"/\"$chat_id\"/g"
+        -e "s/\"dry_run\": false,/\"dry_run\": true,/g" config.json.example > config.json
 
 }
 
 function config () {
-go_to_folder
-if [ -f config.json ]
-then
-read -p "A config file already exist, do you want to override it [Y/N]?
-"
-if [[ $REPLY =~ ^[Yy]$ ]]
-then
-    config_generator
-else
-    echo "Configuration of config.json ignored."
-fi
-else
-    config_generator
-fi
+    if [ -f config.json ]
+    then
+    read -p "A config file already exist, do you want to override it [Y/N]? "
+    if [[ $REPLY =~ ^[Yy]$ ]]
+    then
+        config_generator
+    else
+        echo "Configuration of config.json ignored."
+    fi
+    else
+        config_generator
+    fi
 
-echo "Edit ./config.json to modify Pair and other configurations."
+    echo "Edit ./config.json to modify Pair and other configurations."
 }
 
 function install () {
-echo "
--------------------------
-Install mandatory dependencies
--------------------------
-"
+    echo "-------------------------"
+    echo "Install mandatory dependencies"
+    echo "-------------------------"
+    echo
 
-go_to_folder
-if [ "$(uname -s)" == "Darwin" ]
-then
-    echo "- You are on macOS"
-    install_macos
-elif [ -x "$(command -v apt-get)" ]
-then
-    echo "- You are on Debian/Ubuntu"
-    install_debian
-else
-    echo "This script does not support your OS."
-    echo "If you have Python3.6, pip, virtualenv, ta-lib you can continue."
-    echo "Wait 10 seconds to continue the next install steps or use ctrl+c to interrupt this shell."
-    sleep 10
-fi
-reset
-echo "
-- Install complete.
-"
-config
-echo "You can now use the bot by executing 'source .env/bin/activate; python3 freqtrade/main.py'."
+    if [ "$(uname -s)" == "Darwin" ]
+    then
+        echo "- You are on macOS"
+        install_macos
+    elif [ -x "$(command -v apt-get)" ]
+    then
+        echo "- You are on Debian/Ubuntu"
+        install_debian
+    else
+        echo "This script does not support your OS."
+        echo "If you have Python3.6, pip, virtualenv, ta-lib you can continue."
+        echo "Wait 10 seconds to continue the next install steps or use ctrl+c to interrupt this shell."
+        sleep 10
+    fi
+    reset
+    echo "
+    - Install complete.
+    "
+    config
+    echo "You can now use the bot by executing 'source .env/bin/activate; python3 freqtrade/main.py'."
 }
 
 function plot () {
@@ -199,16 +173,16 @@ echo "
 Install dependencies for Plotting scripts
 -----------------------------------------
 "
-pip install plotly
+pip install plotly --upgrade
 }
 
 function help () {
-echo "usage:"
-echo "	-i,--install    Install freqtrade from scratch"
-echo "	-u,--update     Command git pull to update."
-echo "	-r,--reset      Hard reset your develop/master branch."
-echo "	-c,--config     Easy config generator (Will override your existing file)."
-echo "	-p,--plot       Install dependencies for Plotting scripts."
+    echo "usage:"
+    echo "	-i,--install    Install freqtrade from scratch"
+    echo "	-u,--update     Command git pull to update."
+    echo "	-r,--reset      Hard reset your develop/master branch."
+    echo "	-c,--config     Easy config generator (Will override your existing file)."
+    echo "	-p,--plot       Install dependencies for Plotting scripts."
 }
 
 case $* in

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+#encoding=utf8
+freqtradepath=$(pwd)
+
+function go_to_folder () {
+cd $freqtradepath
+}
+
+function updateenv () {
+echo "
+-------------------------
+Update your virtual env
+-------------------------
+"
+source .env/bin/activate
+pip3.6 install --upgrade pip
+pip3 install -r requirements.txt --upgrade
+pip3 install -r requirements.txt
+pip3 install -e .
+}
+
+# Install tab lib
+function install_talib () {
+curl -O -L http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz
+tar zxvf ta-lib-0.4.0-src.tar.gz
+cd ta-lib && ./configure --prefix=/usr && make && sudo make install
+cd .. && rm -rf ./ta-lib*
+}
+
+# Install bot MacOS
+function install_macos () {
+if [ ! -x "$(command -v brew)" ]
+then
+    echo "-------------------------"
+    echo "Install Brew"
+    echo "-------------------------"
+    echo
+    /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+fi
+brew install python3 wget ta-lib
+}
+
+# Install bot Debian_ubuntu
+function install_debian () {
+sudo add-apt-repository ppa:jonathonf/python-3.6
+sudo apt-get update
+sudo apt-get install python3.6 python3.6-venv python3.6-dev build-essential autoconf libtool pkg-config make wget git
+install_talib
+}
+
+# Upgrade the bot
+function update () {
+go_to_folder
+git pull
+updateenv
+}
+
+# Reset Develop or Master branch
+function reset () {
+
+echo "
+----------------------------
+Reset branch and virtual env
+----------------------------
+"
+if [ "1" == $(git branch -vv |grep -cE "\* develop|\* master") ]
+then
+    go_to_folder
+
+    if [ -d ".env" ]; then
+      echo "- Delete your previous virtual env"
+      rm -rf .env
+    fi
+
+    git fetch -a
+
+    if [ "1" == $(git branch -vv |grep -c "* develop") ]
+    then
+      echo "- Hard resetting of 'develop' branch."
+      git reset --hard origin/develop
+    elif [ "1" == $(git branch -vv |grep -c "* master") ]
+    then
+      echo "- Hard resetting of 'master' branch."
+      git reset --hard origin/master
+    fi
+else
+    echo "Reset ignored because you are not on 'master' or 'develop'."
+fi
+
+python3.6 -m venv .env
+updateenv
+}
+
+function config_generator () {
+
+echo "Starting to generate config.json"
+
+echo "
+-------------------------
+General configuration
+-------------------------
+"
+read -p "Max open trades: (Default: 3)
+" max_trades
+
+read -p "Stake amount: (Default: 0.05)
+" stake_amount
+
+read -p "Stake currency: (Default: BTC)
+" stake_currency
+
+read -p "Fiat currency: (Default: USD)
+" fiat_currency
+
+echo "
+------------------------
+Bittrex config generator
+------------------------
+"
+read -p "Exchange API key
+" api_key
+read -p "Exchange API Secret
+" -s api_secret
+
+echo "
+-------------------------
+Telegram config generator
+-------------------------
+"
+read -p "Telegram Token
+" -s token
+read -p "Telegram Chat_id
+" chat_id
+
+sed -e "s/\"max_open_trades\": 3,/\"max_open_trades\": $max_trades,/g" \
+    -e "s/\"stake_amount\": 0.05,/\"stake_amount\": $stake_amount,/g" \
+    -e "s/\"stake_currency\": \"BTC\",/\"stake_currency\": \"$stake_currency\",/g" \
+    -e "s/\"fiat_display_currency\": \"USD\",/\"fiat_display_currency\": \"$fiat_currency\",/g" \
+    -e "s/\"your_echange_key\"/\"$api_key\"/g" \
+    -e "s/\"your_echange_secret\"/\"$api_secret\"/g" \
+    -e "s/\"your_instagram_token\"/\"$token\"/g" \
+    -e "s/\"your_instagram_chat_id\"/\"$chat_id\"/g"
+    -e "s/\"dry_run\": false,/\"dry_run\": true,/g" config.json.example > config.json
+
+}
+
+function config () {
+go_to_folder
+if [ -f config.json ]
+then
+read -p "A config file already exist, do you want to override it [Y/N]?
+"
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    config_generator
+else
+    echo "Configuration of config.json ignored."
+fi
+else
+    config_generator
+fi
+
+echo "Edit ./config.json to modify Pair and other configurations."
+}
+
+function install () {
+echo "
+-------------------------
+Install mandatory dependencies
+-------------------------
+"
+
+go_to_folder
+if [ "$(uname -s)" == "Darwin" ]
+then
+    echo "- You are on macOS"
+    install_macos
+elif [ -x "$(command -v apt-get)" ]
+then
+    echo "- You are on Debian/Ubuntu"
+    install_debian
+else
+    echo "This script does not support your OS."
+    echo "If you have Python3.6, pip, virtualenv, ta-lib you can continue."
+    echo "Wait 10 seconds to continue the next install steps or use ctrl+c to interrupt this shell."
+    sleep 10
+fi
+reset
+echo "
+- Install complete.
+"
+config
+echo "You can now use the bot by executing 'source .env/bin/activate; python3 freqtrade/main.py'."
+}
+
+function help () {
+echo "usage:"
+echo "	-i,--install    Install freqtrade from scratch"
+echo "	-u,--update     Command git pull to update."
+echo "	-r,--reset      Hard reset your develop/master branch."
+echo "	-c,--config     Easy config generator (Will override your existing file)."
+}
+
+case $* in
+--install|-i)
+install
+;;
+--config|-c)
+config
+;;
+--update|-u)
+update
+;;
+--reset|-r)
+reset
+;;
+*)
+help
+;;
+esac
+exit 0


### PR DESCRIPTION
## Summary
This PR adds a script to Install/Update/Reset the bot on MacOS and Linux. It was created to help users to install the bot.

## Script features
The script `setup.sh` can
- Install the bot from scratch
- Update dependencies on an existing bot
- Reset a branch and virtual env
- Configure config.json

## Script usage
```
$ ./setup.sh
usage:
	-i,--install    Install freqtrade from scratch
	-u,--update     Command git pull to update.
	-r,--reset      Hard reset your develop/master branch.
	-c,--config     Easy config generator (Will override your existing file).
	-p,--plot       Install dependencies for Plotting scripts.
```