### PR TITLE
Fix Backtesting / Hyperopt ticker_interval download

### DIFF
--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -218,7 +218,6 @@ def backtesting_options(parser: argparse.ArgumentParser) -> None:
         '-i', '--ticker-interval',
         help='specify ticker interval in minutes (1, 5, 30, 60, 1440)',
         dest='ticker_interval',
-        default=5,
         type=int,
         metavar='INT',
     )
@@ -269,9 +268,8 @@ def hyperopt_options(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         '-i', '--ticker-interval',
-        help='specify ticker interval in minutes (default: 5)',
+        help='specify ticker interval in minutes (1, 5, 30, 60, 1440)',
         dest='ticker_interval',
-        default=5,
         type=int,
         metavar='INT',
     )

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -229,5 +229,5 @@ def start(args):
                         })
     logger.info(
         '\n==================================== BACKTESTING REPORT ====================================\n%s',  # noqa
-        generate_text_table(data, results, config['stake_currency'], args.ticker_interval)
+        generate_text_table(data, results, config['stake_currency'], strategy.ticker_interval)
     )

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -461,6 +461,11 @@ def start(args):
     config = load_config(args.config)
     pairs = config['exchange']['pair_whitelist']
 
+    # If -i/--ticker-interval is use we override the configuration parameter
+    # (that will override the strategy configuration)
+    if args.ticker_interval:
+        config.update({'ticker_interval': args.ticker_interval})
+
     # init the strategy to use
     config.update({'strategy': args.strategy})
     strategy = Strategy()
@@ -468,7 +473,7 @@ def start(args):
 
     timerange = misc.parse_timerange(args.timerange)
     data = optimize.load_data(args.datadir, pairs=pairs,
-                              ticker_interval=args.ticker_interval,
+                              ticker_interval=strategy.ticker_interval,
                               timerange=timerange)
     optimize.populate_indicators = populate_indicators
     PROCESSED = optimize.tickerdata_to_dataframe(data)

--- a/freqtrade/tests/test_main.py
+++ b/freqtrade/tests/test_main.py
@@ -32,7 +32,7 @@ def test_parse_args_backtesting(mocker):
     assert call_args.loglevel == 20
     assert call_args.subparser == 'backtesting'
     assert call_args.func is not None
-    assert call_args.ticker_interval == None
+    assert call_args.ticker_interval is None
 
 
 def test_main_start_hyperopt(mocker):

--- a/freqtrade/tests/test_main.py
+++ b/freqtrade/tests/test_main.py
@@ -32,7 +32,7 @@ def test_parse_args_backtesting(mocker):
     assert call_args.loglevel == 20
     assert call_args.subparser == 'backtesting'
     assert call_args.func is not None
-    assert call_args.ticker_interval == 5
+    assert call_args.ticker_interval == None
 
 
 def test_main_start_hyperopt(mocker):


### PR DESCRIPTION
## Summary
Backtesting and Hyperopt had the same bug with `ticker_interval`. 
As you know we have 3 way to define the `ticker_interval` to use

1. inside the strategy
2. from the config.json (override the strategy)
3. from the cli param -i/--ticker-interval (override the configuration)

Until know only `-i/--ticker-interval` was taken into consideration. The param from `config.json` and `ticker_interval` from the strategy was ignored.

Solve the issue: #478

## Quick changelog

- Fix the `ticker_interval` behavior on backtesting and hyperopt