### PR TITLE
Adding 1.6 comment into telegram pre-requirements

### DIFF
--- a/docs/plotting.md
+++ b/docs/plotting.md
@@ -24,7 +24,7 @@ script/plot_dataframe.py [-h] [-p pair] [--live]
 
 Example
 ```
-python script/plot_dataframe.py -p BTC_ETH
+python scripts/plot_dataframe.py -p BTC_ETH
 ```
 
 The `-p` pair argument, can be used to specify what

--- a/docs/pre-requisite.md
+++ b/docs/pre-requisite.md
@@ -39,8 +39,10 @@ Use this token to access the HTTP API:
 
 For a description of the Bot API, see this page: https://core.telegram.org/bots/api
 ```
+**1.6. Don't forget to start the conversation with your bot, by clicking /START button**  
 
 ### 2. Get your user id
 **2.1. Talk to https://telegram.me/userinfobot**  
 **2.2. Get your "Id", you will use it for the config parameter 
 `chat_id`.**
+


### PR DESCRIPTION
## Summary
Adding the fact that conversation must be started before running freqtrade

Solve the issue: none

## Quick changelog

- Add new bullet point 1.6 for detail
