### PR TITLE
Adding the pair name when populating indicators/buy signals/sell signals

### DIFF
--- a/docs/bot-optimization.md
+++ b/docs/bot-optimization.md
@@ -51,7 +51,7 @@ update your buy strategy.
 
 Sample from `user_data/strategies/test_strategy.py`:  
 ```python
-def populate_buy_trend(self, dataframe: DataFrame) -> DataFrame:
+def populate_buy_trend(self, dataframe: DataFrame, pair : str) -> DataFrame:
     """
     Based on TA indicators, populates the buy signal for the given dataframe
     :param dataframe: DataFrame
@@ -74,7 +74,7 @@ update your sell strategy.
 
 Sample from `user_data/strategies/test_strategy.py`:  
 ```python
-def populate_sell_trend(self, dataframe: DataFrame) -> DataFrame:
+def populate_sell_trend(self, dataframe: DataFrame, pair : str) -> DataFrame:
     """
     Based on TA indicators, populates the sell signal for the given dataframe
     :param dataframe: DataFrame
@@ -97,7 +97,7 @@ the method `populate_indicators()` from your strategy file.
 
 Sample:
 ```python
-def populate_indicators(dataframe: DataFrame) -> DataFrame:
+def populate_indicators(dataframe: DataFrame, pair : str) -> DataFrame:
     """
     Adds several different TA indicators to the given DataFrame
     """

--- a/docs/hyperopt.md
+++ b/docs/hyperopt.md
@@ -42,7 +42,7 @@ If you have updated the buy strategy, means change the content of
 
 As for an example if your `populate_buy_trend()` method is:
 ```python
-def populate_buy_trend(dataframe: DataFrame) -> DataFrame:
+def populate_buy_trend(dataframe: DataFrame, pair: str) -> DataFrame:
     dataframe.loc[
         (dataframe['rsi'] < 35) &
         (dataframe['adx'] > 65),
@@ -81,7 +81,7 @@ space = {
 
 ... 
 
-def populate_buy_trend(self, dataframe: DataFrame) -> DataFrame:
+def populate_buy_trend(self, dataframe: DataFrame, pair: str) -> DataFrame:
         conditions = []
         # GUARDS AND TRENDS
         if params['adx']['enabled']:
@@ -280,7 +280,7 @@ at `adx`-block, that translates to the following code block:
 So translating your whole hyperopt result to as the new buy-signal 
 would be the following:
 ```
-def populate_buy_trend(self, dataframe: DataFrame) -> DataFrame:
+def populate_buy_trend(self, dataframe: DataFrame, pair: str) -> DataFrame:
     dataframe.loc[
         (
             (dataframe['adx'] > 15.0) & # adx-value

--- a/freqtrade/analyze.py
+++ b/freqtrade/analyze.py
@@ -37,7 +37,7 @@ def parse_ticker_dataframe(ticker: list) -> DataFrame:
     return frame
 
 
-def populate_indicators(dataframe: DataFrame) -> DataFrame:
+def populate_indicators(dataframe: DataFrame, pair: str) -> DataFrame:
     """
     Adds several different TA indicators to the given DataFrame
 
@@ -46,39 +46,39 @@ def populate_indicators(dataframe: DataFrame) -> DataFrame:
     or your hyperopt configuration, otherwise you will waste your memory and CPU usage.
     """
     strategy = Strategy()
-    return strategy.populate_indicators(dataframe=dataframe)
+    return strategy.populate_indicators(dataframe=dataframe, pair=pair)
 
 
-def populate_buy_trend(dataframe: DataFrame) -> DataFrame:
+def populate_buy_trend(dataframe: DataFrame, pair: str) -> DataFrame:
     """
     Based on TA indicators, populates the buy signal for the given dataframe
     :param dataframe: DataFrame
     :return: DataFrame with buy column
     """
     strategy = Strategy()
-    return strategy.populate_buy_trend(dataframe=dataframe)
+    return strategy.populate_buy_trend(dataframe=dataframe, pair=pair)
 
 
-def populate_sell_trend(dataframe: DataFrame) -> DataFrame:
+def populate_sell_trend(dataframe: DataFrame, pair: str) -> DataFrame:
     """
     Based on TA indicators, populates the sell signal for the given dataframe
     :param dataframe: DataFrame
     :return: DataFrame with buy column
     """
     strategy = Strategy()
-    return strategy.populate_sell_trend(dataframe=dataframe)
+    return strategy.populate_sell_trend(dataframe=dataframe, pair=pair)
 
 
-def analyze_ticker(ticker_history: List[Dict]) -> DataFrame:
+def analyze_ticker(ticker_history: List[Dict], pair: str) -> DataFrame:
     """
     Parses the given ticker history and returns a populated DataFrame
     add several TA indicators and buy signal to it
     :return DataFrame with ticker data and indicator data
     """
     dataframe = parse_ticker_dataframe(ticker_history)
-    dataframe = populate_indicators(dataframe)
-    dataframe = populate_buy_trend(dataframe)
-    dataframe = populate_sell_trend(dataframe)
+    dataframe = populate_indicators(dataframe, pair)
+    dataframe = populate_buy_trend(dataframe, pair)
+    dataframe = populate_sell_trend(dataframe, pair)
     return dataframe
 
 
@@ -96,7 +96,7 @@ def get_signal(pair: str, interval: int) -> (bool, bool):
         return (False, False)  # return False ?
 
     try:
-        dataframe = analyze_ticker(ticker_hist)
+        dataframe = analyze_ticker(ticker_hist, pair)
     except ValueError as ex:
         logger.warning('Unable to analyze ticker for pair %s: %s', pair, str(ex))
         return (False, False)  # return False ?

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -158,6 +158,8 @@ def handle_timedout_limit_buy(trade: Trade, order: Dict) -> bool:
         logger.info('Buy order timeout for %s.', trade)
         rpc.send_msg('*Timeout:* Unfilled buy order for {} cancelled'.format(
                      trade.pair.replace('_', '/')))
+        strategy = Strategy()
+        strategy.did_cancel_buy(trade.pair)
         return True
 
     # if trade is partially complete, edit the stake details for the trade
@@ -188,6 +190,8 @@ def handle_timedout_limit_sell(trade: Trade, order: Dict) -> bool:
         rpc.send_msg('*Timeout:* Unfilled sell order for {} cancelled'.format(
                      trade.pair.replace('_', '/')))
         logger.info('Sell order timeout for %s.', trade)
+        strategy = Strategy()
+        strategy.did_cancel_sell(trade.pair)
         return True
 
     # TODO: figure out how to handle partially complete sell orders

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -231,6 +231,9 @@ def execute_sell(trade: Trade, limit: float) -> None:
     order_id = exchange.sell(str(trade.pair), limit, trade.amount)
     trade.open_order_id = order_id
 
+    strategy = Strategy()
+    strategy.did_sold(trade.pair)
+
     fmt_exp_profit = round(trade.calc_profit_percent(rate=limit) * 100, 2)
     profit_trade = trade.calc_profit(rate=limit)
     current_rate = exchange.get_ticker(trade.pair, False)['bid']
@@ -409,6 +412,8 @@ def create_trade(stake_amount: float, interval: int) -> bool:
         _CONF['stake_currency'],
         _CONF['fiat_display_currency']
     )
+    strategy = Strategy()
+    strategy.did_bought(pair)
 
     # Create trade entity and return
     rpc.send_msg('*{}:* Buying [{}]({}) with limit `{:.8f} ({:.6f} {}, {:.3f} {})` '.format(

--- a/freqtrade/optimize/__init__.py
+++ b/freqtrade/optimize/__init__.py
@@ -91,7 +91,7 @@ def tickerdata_to_dataframe(data):
 
 def preprocess(tickerdata: Dict[str, List]) -> Dict[str, DataFrame]:
     """Creates a dataframe and populates indicators for given ticker data"""
-    return {pair: populate_indicators(parse_ticker_dataframe(pair_data))
+    return {pair: populate_indicators(parse_ticker_dataframe(pair_data), pair)
             for pair, pair_data in tickerdata.items()}
 
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -117,7 +117,7 @@ def backtest(args) -> DataFrame:
     exchange._API = Bittrex({'key': '', 'secret': ''})
     for pair, pair_data in processed.items():
         pair_data['buy'], pair_data['sell'] = 0, 0
-        ticker = populate_sell_trend(populate_buy_trend(pair_data))
+        ticker = populate_sell_trend(populate_buy_trend(pair_data, pair), pair)
         # for each buy point
         lock_pair_until = None
         headers = ['buy', 'open', 'close', 'date', 'sell']

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -61,7 +61,7 @@ TRIALS = Trials()
 main._CONF = OPTIMIZE_CONFIG
 
 
-def populate_indicators(dataframe: DataFrame) -> DataFrame:
+def populate_indicators(dataframe: DataFrame, pair: str) -> DataFrame:
     """
     Adds several different TA indicators to the given DataFrame
     """
@@ -320,7 +320,7 @@ def buy_strategy_generator(params: Dict[str, Any]) -> Callable:
     """
     Define the buy strategy parameters to be used by hyperopt
     """
-    def populate_buy_trend(dataframe: DataFrame) -> DataFrame:
+    def populate_buy_trend(dataframe: DataFrame, pair: str) -> DataFrame:
         conditions = []
         # GUARDS AND TRENDS
         if 'uptrend_long_ema' in params and params['uptrend_long_ema']['enabled']:

--- a/freqtrade/strategy/default_strategy.py
+++ b/freqtrade/strategy/default_strategy.py
@@ -250,15 +250,15 @@ class DefaultStrategy(IStrategy):
         we are notified that a given pair was sold
         :param pair: the pair that was is concerned by the dataframe
         """
-    
+
     def did_cancel_buy(self, pair: str):
         """
-        we are notified that a given pair was bought
+        we are notified that a given pair buy was not filled
         :param pair: the pair that was is concerned by the dataframe
         """
 
     def did_cancel_sell(self, pair: str):
         """
-        we are notified that a given pair was sold
+        we are notified that a given pair was not sold 
         :param pair: the pair that was is concerned by the dataframe
         """

--- a/freqtrade/strategy/default_strategy.py
+++ b/freqtrade/strategy/default_strategy.py
@@ -29,7 +29,7 @@ class DefaultStrategy(IStrategy):
     # Optimal ticker interval for the strategy
     ticker_interval = 5
 
-    def populate_indicators(self, dataframe: DataFrame) -> DataFrame:
+    def populate_indicators(self, dataframe: DataFrame, pair: str) -> DataFrame:
         """
         Adds several different TA indicators to the given DataFrame
 
@@ -196,7 +196,7 @@ class DefaultStrategy(IStrategy):
 
         return dataframe
 
-    def populate_buy_trend(self, dataframe: DataFrame) -> DataFrame:
+    def populate_buy_trend(self, dataframe: DataFrame, pair: str) -> DataFrame:
         """
         Based on TA indicators, populates the buy signal for the given dataframe
         :param dataframe: DataFrame
@@ -217,7 +217,7 @@ class DefaultStrategy(IStrategy):
 
         return dataframe
 
-    def populate_sell_trend(self, dataframe: DataFrame) -> DataFrame:
+    def populate_sell_trend(self, dataframe: DataFrame, pair: str) -> DataFrame:
         """
         Based on TA indicators, populates the sell signal for the given dataframe
         :param dataframe: DataFrame

--- a/freqtrade/strategy/default_strategy.py
+++ b/freqtrade/strategy/default_strategy.py
@@ -244,11 +244,21 @@ class DefaultStrategy(IStrategy):
         we are notified that a given pair was bought
         :param pair: the pair that was is concerned by the dataframe
         """
-        assert False is not True
 
     def did_sold(self, pair: str):
         """
         we are notified that a given pair was sold
         :param pair: the pair that was is concerned by the dataframe
         """
-        assert False is not True
+    
+    def did_cancel_buy(self, pair: str):
+        """
+        we are notified that a given pair was bought
+        :param pair: the pair that was is concerned by the dataframe
+        """
+
+    def did_cancel_sell(self, pair: str):
+        """
+        we are notified that a given pair was sold
+        :param pair: the pair that was is concerned by the dataframe
+        """

--- a/freqtrade/strategy/default_strategy.py
+++ b/freqtrade/strategy/default_strategy.py
@@ -238,3 +238,17 @@ class DefaultStrategy(IStrategy):
             ),
             'sell'] = 1
         return dataframe
+
+    def did_bought(self, pair: str):
+        """
+        we are notified that a given pair was bought
+        :param pair: the pair that was is concerned by the dataframe
+        """
+        assert False is not True
+
+    def did_sold(self, pair: str):
+        """
+        we are notified that a given pair was sold
+        :param pair: the pair that was is concerned by the dataframe
+        """
+        assert False is not True

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -23,6 +23,7 @@ class IStrategy(ABC):
         """
         Populate indicators that will be used in the Buy and Sell strategy
         :param dataframe: Raw data from the exchange and parsed by parse_ticker_dataframe()
+        :param pair: the pair that was is concerned by the dataframe
         :return: a Dataframe with all mandatory indicators for the strategies
         """
 
@@ -31,6 +32,7 @@ class IStrategy(ABC):
         """
         Based on TA indicators, populates the buy signal for the given dataframe
         :param dataframe: DataFrame
+        :param pair: the pair that was is concerned by the dataframe
         :return: DataFrame with buy column
         :return:
         """
@@ -40,5 +42,6 @@ class IStrategy(ABC):
         """
         Based on TA indicators, populates the sell signal for the given dataframe
         :param dataframe: DataFrame
+        :param pair: the pair that was is concerned by the dataframe
         :return: DataFrame with buy column
         """

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -19,7 +19,7 @@ class IStrategy(ABC):
     """
 
     @abstractmethod
-    def populate_indicators(self, dataframe: DataFrame) -> DataFrame:
+    def populate_indicators(self, dataframe: DataFrame, pair: str) -> DataFrame:
         """
         Populate indicators that will be used in the Buy and Sell strategy
         :param dataframe: Raw data from the exchange and parsed by parse_ticker_dataframe()
@@ -27,7 +27,7 @@ class IStrategy(ABC):
         """
 
     @abstractmethod
-    def populate_buy_trend(self, dataframe: DataFrame) -> DataFrame:
+    def populate_buy_trend(self, dataframe: DataFrame, pair: str) -> DataFrame:
         """
         Based on TA indicators, populates the buy signal for the given dataframe
         :param dataframe: DataFrame
@@ -36,7 +36,7 @@ class IStrategy(ABC):
         """
 
     @abstractmethod
-    def populate_sell_trend(self, dataframe: DataFrame) -> DataFrame:
+    def populate_sell_trend(self, dataframe: DataFrame, pair: str) -> DataFrame:
         """
         Based on TA indicators, populates the sell signal for the given dataframe
         :param dataframe: DataFrame

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -45,3 +45,17 @@ class IStrategy(ABC):
         :param pair: the pair that was is concerned by the dataframe
         :return: DataFrame with buy column
         """
+
+    @abstractmethod
+    def did_bought(self, pair: str):
+        """
+        we are notified that a given pair was bought
+        :param pair: the pair that was is concerned by the dataframe
+        """
+
+    @abstractmethod
+    def did_sold(self, pair: str):
+        """
+        we are notified that a given pair was sold
+        :param pair: the pair that was is concerned by the dataframe
+        """

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -59,3 +59,17 @@ class IStrategy(ABC):
         we are notified that a given pair was sold
         :param pair: the pair that was is concerned by the dataframe
         """
+
+    @abstractmethod
+    def did_cancel_buy(self, pair: str):
+        """
+        we are notified that a given buy for a pair was cancelled
+        :param pair: the pair that was is concerned by the dataframe
+        """
+
+    @abstractmethod
+    def did_cancel_sell(self, pair: str):
+        """
+        we are notified that a given sell for a pair was cancelled
+        :param pair: the pair that was is concerned by the dataframe
+        """

--- a/freqtrade/strategy/strategy.py
+++ b/freqtrade/strategy/strategy.py
@@ -181,3 +181,17 @@ class Strategy(object):
         :param pair: the pair that was is concerned by the dataframe
         """
         return self.custom_strategy.did_sold(pair)
+
+    def did_cancel_buy(self, pair: str):
+        """
+        we are notified that a given pair was bought
+        :param pair: the pair that was is concerned by the dataframe
+        """
+        return self.custom_strategy.did_cancel_buy(pair)
+
+    def did_cancel_sell(self, pair: str):
+        """
+        we are notified that a given pair was sold
+        :param pair: the pair that was is concerned by the dataframe
+        """
+        return self.custom_strategy.did_cancel_sell(pair)

--- a/freqtrade/strategy/strategy.py
+++ b/freqtrade/strategy/strategy.py
@@ -143,27 +143,27 @@ class Strategy(object):
 
         return path
 
-    def populate_indicators(self, dataframe: DataFrame) -> DataFrame:
+    def populate_indicators(self, dataframe: DataFrame, pair: str) -> DataFrame:
         """
         Populate indicators that will be used in the Buy and Sell strategy
         :param dataframe: Raw data from the exchange and parsed by parse_ticker_dataframe()
         :return: a Dataframe with all mandatory indicators for the strategies
         """
-        return self.custom_strategy.populate_indicators(dataframe)
+        return self.custom_strategy.populate_indicators(dataframe, pair)
 
-    def populate_buy_trend(self, dataframe: DataFrame) -> DataFrame:
+    def populate_buy_trend(self, dataframe: DataFrame, pair: str) -> DataFrame:
         """
         Based on TA indicators, populates the buy signal for the given dataframe
         :param dataframe: DataFrame
         :return: DataFrame with buy column
         :return:
         """
-        return self.custom_strategy.populate_buy_trend(dataframe)
+        return self.custom_strategy.populate_buy_trend(dataframe, pair)
 
-    def populate_sell_trend(self, dataframe: DataFrame) -> DataFrame:
+    def populate_sell_trend(self, dataframe: DataFrame, pair: str) -> DataFrame:
         """
         Based on TA indicators, populates the sell signal for the given dataframe
         :param dataframe: DataFrame
         :return: DataFrame with buy column
         """
-        return self.custom_strategy.populate_sell_trend(dataframe)
+        return self.custom_strategy.populate_sell_trend(dataframe, pair)

--- a/freqtrade/strategy/strategy.py
+++ b/freqtrade/strategy/strategy.py
@@ -167,3 +167,17 @@ class Strategy(object):
         :return: DataFrame with buy column
         """
         return self.custom_strategy.populate_sell_trend(dataframe, pair)
+
+    def did_bought(self, pair: str):
+        """
+        we are notified that a given pair was bought
+        :param pair: the pair that was is concerned by the dataframe
+        """
+        return self.custom_strategy.did_bought(pair)
+
+    def did_sold(self, pair: str):
+        """
+        we are notified that a given pair was sold
+        :param pair: the pair that was is concerned by the dataframe
+        """
+        return self.custom_strategy.did_sold(pair)

--- a/freqtrade/tests/strategy/test_default_strategy.py
+++ b/freqtrade/tests/strategy/test_default_strategy.py
@@ -30,7 +30,7 @@ def test_default_strategy(result):
     assert type(strategy.minimal_roi) is dict
     assert type(strategy.stoploss) is float
     assert type(strategy.ticker_interval) is int
-    indicators = strategy.populate_indicators(result)
+    indicators = strategy.populate_indicators(result, None)
     assert type(indicators) is DataFrame
-    assert type(strategy.populate_buy_trend(indicators)) is DataFrame
-    assert type(strategy.populate_sell_trend(indicators)) is DataFrame
+    assert type(strategy.populate_buy_trend(indicators, None)) is DataFrame
+    assert type(strategy.populate_sell_trend(indicators, None)) is DataFrame

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -37,7 +37,7 @@ def test_load_strategy(result):
     assert not hasattr(Strategy, 'custom_strategy')
 
     assert hasattr(strategy.custom_strategy, 'populate_indicators')
-    assert 'adx' in strategy.populate_indicators(result)
+    assert 'adx' in strategy.populate_indicators(result, None)
 
 
 def test_strategy(result):
@@ -51,14 +51,14 @@ def test_strategy(result):
     assert strategy.stoploss == -0.10
 
     assert hasattr(strategy.custom_strategy, 'populate_indicators')
-    assert 'adx' in strategy.populate_indicators(result)
+    assert 'adx' in strategy.populate_indicators(result, None)
 
     assert hasattr(strategy.custom_strategy, 'populate_buy_trend')
-    dataframe = strategy.populate_buy_trend(strategy.populate_indicators(result))
+    dataframe = strategy.populate_buy_trend(strategy.populate_indicators(result, None), None)
     assert 'buy' in dataframe.columns
 
     assert hasattr(strategy.custom_strategy, 'populate_sell_trend')
-    dataframe = strategy.populate_sell_trend(strategy.populate_indicators(result))
+    dataframe = strategy.populate_sell_trend(strategy.populate_indicators(result, None), None)
     assert 'sell' in dataframe.columns
 
 

--- a/freqtrade/tests/test_analyze.py
+++ b/freqtrade/tests/test_analyze.py
@@ -26,7 +26,7 @@ def test_populates_buy_trend(result):
     # Load the default strategy for the unit test, because this logic is done in main.py
     Strategy().init({'strategy': 'default_strategy'})
 
-    dataframe = populate_buy_trend(populate_indicators(result))
+    dataframe = populate_buy_trend(populate_indicators(result, None), None)
     assert 'buy' in dataframe.columns
 
 
@@ -34,7 +34,7 @@ def test_populates_sell_trend(result):
     # Load the default strategy for the unit test, because this logic is done in main.py
     Strategy().init({'strategy': 'default_strategy'})
 
-    dataframe = populate_sell_trend(populate_indicators(result))
+    dataframe = populate_sell_trend(populate_indicators(result, None), None)
     assert 'sell' in dataframe.columns
 
 

--- a/freqtrade/tests/test_dataframe.py
+++ b/freqtrade/tests/test_dataframe.py
@@ -12,7 +12,7 @@ def load_dataframe_pair(pairs):
     assert isinstance(ld, dict)
     assert isinstance(pairs[0], str)
     dataframe = ld[pairs[0]]
-    dataframe = analyze.analyze_ticker(dataframe)
+    dataframe = analyze.analyze_ticker(dataframe, pairs[0])
     return dataframe
 
 

--- a/user_data/strategies/test_strategy.py
+++ b/user_data/strategies/test_strategy.py
@@ -47,7 +47,7 @@ class TestStrategy(IStrategy):
     # Optimal ticker interval for the strategy
     ticker_interval = 5
 
-    def populate_indicators(self, dataframe: DataFrame) -> DataFrame:
+    def populate_indicators(self, dataframe: DataFrame, pair: str) -> DataFrame:
         """
         Adds several different TA indicators to the given DataFrame
 
@@ -214,7 +214,7 @@ class TestStrategy(IStrategy):
 
         return dataframe
 
-    def populate_buy_trend(self, dataframe: DataFrame) -> DataFrame:
+    def populate_buy_trend(self, dataframe: DataFrame, pair: str) -> DataFrame:
         """
         Based on TA indicators, populates the buy signal for the given dataframe
         :param dataframe: DataFrame
@@ -230,7 +230,7 @@ class TestStrategy(IStrategy):
 
         return dataframe
 
-    def populate_sell_trend(self, dataframe: DataFrame) -> DataFrame:
+    def populate_sell_trend(self, dataframe: DataFrame, pair: str) -> DataFrame:
         """
         Based on TA indicators, populates the sell signal for the given dataframe
         :param dataframe: DataFrame


### PR DESCRIPTION
## Summary
This PR allow a user to have his strategy behave differently or have different settings according to the pair being traded

## Quick changelog

- adding the pair name to all populate_XXXX functions
