### PR TITLE
Fixing bug in backtesting preventing sell events to be executed

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -84,7 +84,9 @@ def get_sell_trade_entry(pair, row, buy_subset, ticker, trade_count_lock, args):
             # Increase trade_count_lock for every iteration
             trade_count_lock[row2.date] = trade_count_lock.get(row2.date, 0) + 1
 
-        buy_signal = buy_subset[buy_subset.date == row2.date].empty
+        # Buy is on is in the buy_subset there is a row that matches the date
+        # of the sell event
+        buy_signal = not buy_subset[buy_subset.date == row2.date].empty
         if(should_sell(trade, row2.close, row2.date, buy_signal, row2.sell)):
             return row2, (pair,
                           trade.calc_profit_percent(rate=row2.close),


### PR DESCRIPTION
Since PR #469 backtesting is showing bad results.

## Summary
The sell event was mis-fired due to mis-calculation of the buy event which was always on (preventing the sell event to be executed)
## Quick changelog

- fixing the buy event calculation

## What's new?
*Before*
```
pair       buy count    avg profit %    total profit BTC    avg duration    profit    loss
-------  -----------  --------------  ------------------  --------------  --------  ------
BTC_XVG           22            0.25          0.00005391           154.1        20       2
BTC_LTC           12            0.90          0.00010606           104.2        12       0
BTC_XRP           36            0.12          0.00004152           201.0        33       3
TOTAL             70            0.29          0.00020149           169.6        65       5

```
*After*
```
pair       buy count    avg profit %    total profit BTC    avg duration    profit    loss
-------  -----------  --------------  ------------------  --------------  --------  ------
BTC_XVG           25           -0.29         -0.00007180            54.8        14      11
BTC_LTC           12            0.77          0.00009084            32.5        10       2
BTC_XRP           51           -0.15         -0.00007370            50.0        30      21
TOTAL             88           -0.06         -0.00005466            49.0        54      34
```
