### PR TITLE
Remove Strategy fallback to default strategy

### DIFF
--- a/docs/bot-optimization.md
+++ b/docs/bot-optimization.md
@@ -24,7 +24,7 @@ python3 ./freqtrade/main.py --strategy awesome_strategy
 
 ## Change your strategy
 The bot includes a default strategy file. However, we recommend you to 
-use your own file to not have to lose your parameters everytime the default
+use your own file to not have to lose your parameters every time the default
 strategy file will be updated on Github. Put your custom strategy file
 into the folder `user_data/strategies`.
 

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -32,7 +32,7 @@ optional arguments:
   --dry-run-db          Force dry run to use a local DB
                         "tradesv3.dry_run.sqlite" instead of memory DB. Work
                         only if dry_run is enabled.
-  -dd PATH, --datadir PATH
+  --datadir PATH
                         path to backtest data (default freqdata/tests/testdata
   --dynamic-whitelist [INT]
                         dynamically generate and update whitelist based on 24h
@@ -65,8 +65,8 @@ load it:
 python3 ./freqtrade/main.py --strategy my_awesome_strategy
 ```
 
-If the bot does not find your strategy file, it will fallback to the 
-`default_strategy`.
+If the bot does not find your strategy file, it will display in an error
+ message the reason (File not found, or errors in your code).
 
 Learn more about strategy file in [optimize your bot](https://github.com/gcarq/freqtrade/blob/develop/docs/bot-optimization.md).
 

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -163,7 +163,7 @@ def common_args_parser(description: str):
         '-s', '--strategy',
         help='specify strategy file (default: freqtrade/strategy/default_strategy.py)',
         dest='strategy',
-        default='.default_strategy',
+        default='default_strategy',
         type=str,
         metavar='PATH',
     )

--- a/freqtrade/strategy/strategy.py
+++ b/freqtrade/strategy/strategy.py
@@ -95,8 +95,16 @@ class Strategy(object):
             self.custom_strategy = self._load_class(path + strategy_name)
 
         # Fallback to the default strategy
-        except (ImportError, TypeError):
-            self.custom_strategy = self._load_class('.' + self.DEFAULT_STRATEGY)
+        except (ImportError, TypeError) as error:
+            self.logger.error(
+                "Impossible to load Strategy 'user_data/strategies/%s.py'. This file does not exist"
+                " or contains Python code errors",
+                strategy_name
+            )
+            self.logger.error(
+                "The error is:\n%s.",
+                error
+            )
 
     def _load_class(self, filename: str) -> IStrategy:
         """

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -32,12 +32,24 @@ def test_load_strategy(result):
     strategy.logger = logging.getLogger(__name__)
 
     assert not hasattr(Strategy, 'custom_strategy')
-    strategy._load_strategy('default_strategy')
+    strategy._load_strategy('test_strategy')
 
     assert not hasattr(Strategy, 'custom_strategy')
 
     assert hasattr(strategy.custom_strategy, 'populate_indicators')
     assert 'adx' in strategy.populate_indicators(result)
+
+
+def test_load_not_found_strategy(caplog):
+    strategy = Strategy()
+    strategy.logger = logging.getLogger(__name__)
+
+    assert not hasattr(Strategy, 'custom_strategy')
+    strategy._load_strategy('NotFoundStrategy')
+
+    error_msg = "Impossible to load Strategy 'user_data/strategies/{}.py'. This file does not " \
+                "exist or contains Python code errors".format('NotFoundStrategy')
+    assert ('test_strategy', logging.ERROR, error_msg) in caplog.record_tuples
 
 
 def test_strategy(result):


### PR DESCRIPTION
## Summary
Remove the fallback behavior when a strategy is not found or cannot be loaded. Previously when a custom strategy cannot be loaded the bot fallback to the default_strategy.

## Quick changelog

- Remove fallback behavior when a strategy cannot be loaded
- Display an error message with the reason

## Sample of the error message

```
2018-01-31 22:34:43,853 - freqtrade.strategy.strategy - INFO - Load strategy class: IncompleteStrategy (user_data.strategies.incomplete_strategy.py)
2018-01-31 22:34:43,853 - freqtrade.strategy.strategy - ERROR - Impossible to load Strategy 'user_data/strategies/incomplete_strategy.py'. This file does not exist or contains Python code errors
2018-01-31 22:34:43,854 - freqtrade.strategy.strategy - ERROR - The error is:
Can't instantiate abstract class IncompleteStrategy with abstract methods populate_buy_trend, populate_sell_trend.
2018-01-31 22:34:43,854 - freqtrade - ERROR - Got fatal exception!
```