### PR TITLE
Fix config generation on setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -116,8 +116,8 @@ function config_generator () {
         -e "s/\"fiat_display_currency\": \"USD\",/\"fiat_display_currency\": \"$fiat_currency\",/g" \
         -e "s/\"your_exchange_key\"/\"$api_key\"/g" \
         -e "s/\"your_exchange_secret\"/\"$api_secret\"/g" \
-        -e "s/\"your_instagram_token\"/\"$token\"/g" \
-        -e "s/\"your_instagram_chat_id\"/\"$chat_id\"/g"
+        -e "s/\"your_telegram_token\"/\"$token\"/g" \
+        -e "s/\"your_telegram_chat_id\"/\"$chat_id\"/g"
         -e "s/\"dry_run\": false,/\"dry_run\": true,/g" config.json.example > config.json
 
 }


### PR DESCRIPTION
## Summary
Since #497 was merged, the config generator in `setup.sh` is broken. This PR fixes this issue.

## Quick changelog

- Change the Sed expression `your_instagram_*` for `your_telegram_*`
