### PR TITLE
Make backtesting 5x faster

### DIFF
--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -303,9 +303,9 @@ def min_roi_reached(trade: Trade, current_rate: float, current_time: datetime) -
     # Check if time matches and current rate is above threshold
     time_diff = (current_time.timestamp() - trade.open_date.timestamp()) / 60
     for duration, threshold in strategy.minimal_roi.items():
-        if time_diff < duration:
+        if time_diff <= duration:
             return False
-        if time_diff > duration and current_profit > threshold:
+        if current_profit > threshold:
             return True
     return False
 

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -296,14 +296,13 @@ def min_roi_reached(trade: Trade, current_rate: float, current_time: datetime) -
     strategy = Strategy()
 
     current_profit = trade.calc_profit_percent(current_rate)
-    if strategy.stoploss is not None and current_profit < float(strategy.stoploss):
+    if strategy.stoploss is not None and current_profit < strategy.stoploss:
         logger.debug('Stop loss hit.')
         return True
 
     # Check if time matches and current rate is above threshold
     time_diff = (current_time.timestamp() - trade.open_date.timestamp()) / 60
-    for duration_string, threshold in strategy.minimal_roi.items():
-        duration = float(duration_string)
+    for duration, threshold in strategy.minimal_roi.items():
         if time_diff < duration:
             return False
         if time_diff > duration and current_profit > threshold:

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -304,10 +304,10 @@ def min_roi_reached(trade: Trade, current_rate: float, current_time: datetime) -
     time_diff = (current_time.timestamp() - trade.open_date.timestamp()) / 60
     for duration_string, threshold in strategy.minimal_roi.items():
         duration = float(duration_string)
-        if time_diff > duration and current_profit > threshold:
-            return True
         if time_diff < duration:
             return False
+        if time_diff > duration and current_profit > threshold:
+            return True
     return False
 
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -133,9 +133,6 @@ def backtest(args) -> DataFrame:
                 # Check if max_open_trades has already been reached for the given date
                 if not trade_count_lock.get(row.date, 0) < max_open_trades:
                     continue
-
-            if max_open_trades > 0:
-                # Increase lock
                 trade_count_lock[row.date] = trade_count_lock.get(row.date, 0) + 1
 
             ret = get_sell_trade_entry(pair, row, ticker[index+1:], trade_count_lock, args)

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -67,29 +67,29 @@ def generate_text_table(
     return tabulate(tabular_data, headers=headers, floatfmt=floatfmt)
 
 
-def get_sell_trade_entry(pair, row, partial_ticker, trade_count_lock, args):
+def get_sell_trade_entry(pair, buy_row, partial_ticker, trade_count_lock, args):
     stake_amount = args['stake_amount']
     max_open_trades = args.get('max_open_trades', 0)
-    trade = Trade(open_rate=row.close,
-                  open_date=row.date,
+    trade = Trade(open_rate=buy_row.close,
+                  open_date=buy_row.date,
                   stake_amount=stake_amount,
-                  amount=stake_amount / row.open,
+                  amount=stake_amount / buy_row.open,
                   fee=exchange.get_fee()
                   )
 
     # calculate win/lose forwards from buy point
-    for row2 in partial_ticker:
+    for sell_row in partial_ticker:
         if max_open_trades > 0:
             # Increase trade_count_lock for every iteration
-            trade_count_lock[row2.date] = trade_count_lock.get(row2.date, 0) + 1
+            trade_count_lock[sell_row.date] = trade_count_lock.get(sell_row.date, 0) + 1
 
-        buy_signal = row2.buy
-        if should_sell(trade, row2.close, row2.date, buy_signal, row2.sell):
-            return row2, (pair,
-                          trade.calc_profit_percent(rate=row2.close),
-                          trade.calc_profit(rate=row2.close),
-                          (row2.date - row.date).seconds // 60
-                          ), row2.date
+        buy_signal = sell_row.buy
+        if should_sell(trade, sell_row.close, sell_row.date, buy_signal, sell_row.sell):
+            return sell_row, (pair,
+                              trade.calc_profit_percent(rate=sell_row.close),
+                              trade.calc_profit(rate=sell_row.close),
+                              (sell_row.date - buy_row.date).seconds // 60
+                              ), sell_row.date
     return None
 
 

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -225,12 +225,12 @@ def calculate_loss(total_profit: float, trade_count: int, trade_duration: float)
     return trade_loss + profit_loss + duration_loss
 
 
-def generate_roi_table(params) -> Dict[str, float]:
+def generate_roi_table(params) -> Dict[int, float]:
     roi_table = {}
-    roi_table["0"] = params['roi_p1'] + params['roi_p2'] + params['roi_p3']
-    roi_table[str(params['roi_t3'])] = params['roi_p1'] + params['roi_p2']
-    roi_table[str(params['roi_t3'] + params['roi_t2'])] = params['roi_p1']
-    roi_table[str(params['roi_t3'] + params['roi_t2'] + params['roi_t1'])] = 0
+    roi_table[0] = params['roi_p1'] + params['roi_p2'] + params['roi_p3']
+    roi_table[params['roi_t3']] = params['roi_p1'] + params['roi_p2']
+    roi_table[params['roi_t3'] + params['roi_t2']] = params['roi_p1']
+    roi_table[params['roi_t3'] + params['roi_t2'] + params['roi_t1']] = 0
 
     return roi_table
 

--- a/freqtrade/strategy/strategy.py
+++ b/freqtrade/strategy/strategy.py
@@ -71,11 +71,11 @@ class Strategy(object):
 
         # Minimal ROI designed for the strategy
         self.minimal_roi = OrderedDict(sorted(
-            self.custom_strategy.minimal_roi.items(),
-            key=lambda tuple: float(tuple[0])))  # sort after converting to number
+            {int(key): value for (key, value) in self.custom_strategy.minimal_roi.items()}.items(),
+            key=lambda tuple: tuple[0]))  # sort after converting to number
 
         # Optimal stoploss designed for the strategy
-        self.stoploss = self.custom_strategy.stoploss
+        self.stoploss = float(self.custom_strategy.stoploss)
 
         self.ticker_interval = self.custom_strategy.ticker_interval
 

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -255,7 +255,7 @@ def test_roi_table_generation():
         'roi_p2': 2,
         'roi_p3': 3,
     }
-    assert generate_roi_table(params) == {'0': 6, '15': 3, '25': 1, '30': 0}
+    assert generate_roi_table(params) == {0: 6, 15: 3, 25: 1, 30: 0}
 
 
 # test log_trials_result

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -57,7 +57,7 @@ def test_strategy(result):
     strategy.init({'strategy': 'default_strategy'})
 
     assert hasattr(strategy.custom_strategy, 'minimal_roi')
-    assert strategy.minimal_roi['0'] == 0.04
+    assert strategy.minimal_roi[0] == 0.04
 
     assert hasattr(strategy.custom_strategy, 'stoploss')
     assert strategy.stoploss == -0.10
@@ -86,7 +86,7 @@ def test_strategy_override_minimal_roi(caplog):
     strategy.init(config)
 
     assert hasattr(strategy.custom_strategy, 'minimal_roi')
-    assert strategy.minimal_roi['0'] == 0.5
+    assert strategy.minimal_roi[0] == 0.5
     assert ('freqtrade.strategy.strategy',
             logging.INFO,
             'Override strategy \'minimal_roi\' with value in config file.'
@@ -142,8 +142,8 @@ def test_strategy_singleton():
     strategy1.init({'strategy': 'default_strategy'})
 
     assert hasattr(strategy1.custom_strategy, 'minimal_roi')
-    assert strategy1.minimal_roi['0'] == 0.04
+    assert strategy1.minimal_roi[0] == 0.04
 
     strategy2 = Strategy()
     assert hasattr(strategy2.custom_strategy, 'minimal_roi')
-    assert strategy2.minimal_roi['0'] == 0.04
+    assert strategy2.minimal_roi[0] == 0.04


### PR DESCRIPTION
This PR makes backtesting and hyperopt roughly **five times** faster than before.

Speed up is mainly accomplished by iterating over regular arrays instead dataframe's `.itertuples()` which for a regular three month backtesting data removes creation of roughly 1 billion tuples.