### PR TITLE
Random indicator helpers

### DIFF
--- a/freqtrade/indicator_helpers.py
+++ b/freqtrade/indicator_helpers.py
@@ -1,5 +1,7 @@
 from math import exp, pi, sqrt, cos
 
+import numpy
+import talib as ta
 from pandas import Series
 
 
@@ -25,3 +27,14 @@ def ehlers_super_smoother(series: Series, smoothing: float = 6):
             coeff2 * filtered.iloc[i-1] + coeff3 * filtered.iloc[i-2]
 
     return filtered
+
+
+def fishers_inverse(series: Series, smoothing: float = 0):
+    """ Does a smoothed fishers inverse transformation.
+        Can be used with any oscillator that goes from 0 to 100 like RSI or MFI """
+    v1 = 0.1 * (series - 50)
+    if smoothing > 0:
+        v2 = ta.WMA(v1.values, timeperiod=smoothing)
+    else:
+        v2 = v1
+    return (numpy.exp(2 * v2)-1) / (numpy.exp(2 * v2) + 1)

--- a/freqtrade/indicator_helpers.py
+++ b/freqtrade/indicator_helpers.py
@@ -1,3 +1,5 @@
+from math import exp, pi, sqrt, cos
+
 from pandas import Series
 
 
@@ -7,3 +9,19 @@ def went_up(series: Series) -> Series:
 
 def went_down(series: Series) -> Series:
     return series < series.shift(1)
+
+
+def ehlers_super_smoother(series: Series, smoothing: float = 6):
+    magic = pi * sqrt(2) / smoothing
+    a1 = exp(-magic)
+    coeff2 = 2 * a1 * cos(magic)
+    coeff3 = -a1 * a1
+    coeff1 = (1 - coeff2 - coeff3) / 2
+
+    filtered = series.copy()
+
+    for i in range(2, len(series)):
+        filtered.iloc[i] = coeff1 * (series.iloc[i] + series.iloc[i-1]) + \
+            coeff2 * filtered.iloc[i-1] + coeff3 * filtered.iloc[i-2]
+
+    return filtered

--- a/freqtrade/indicator_helpers.py
+++ b/freqtrade/indicator_helpers.py
@@ -1,0 +1,9 @@
+from pandas import Series
+
+
+def went_up(series: Series) -> Series:
+    return series > series.shift(1)
+
+
+def went_down(series: Series) -> Series:
+    return series < series.shift(1)

--- a/freqtrade/strategy/default_strategy.py
+++ b/freqtrade/strategy/default_strategy.py
@@ -4,7 +4,7 @@ import talib.abstract as ta
 from pandas import DataFrame
 import freqtrade.vendor.qtpylib.indicators as qtpylib
 from freqtrade.strategy.interface import IStrategy
-
+from freqtrade.indicator_helpers import fishers_inverse
 
 class_name = 'DefaultStrategy'
 
@@ -76,8 +76,8 @@ class DefaultStrategy(IStrategy):
         dataframe['rsi'] = ta.RSI(dataframe)
         """
         # Inverse Fisher transform on RSI, values [-1.0, 1.0] (https://goo.gl/2JGGoy)
-        rsi = 0.1 * (dataframe['rsi'] - 50)
-        dataframe['fisher_rsi'] = (numpy.exp(2 * rsi) - 1) / (numpy.exp(2 * rsi) + 1)
+        dataframe['fisher_rsi'] = fishers_inverse(dataframe['rsi'])
+
         # Inverse Fisher transform on RSI normalized, value [0.0, 100.0] (https://goo.gl/2JGGoy)
         dataframe['fisher_rsi_norma'] = 50 * (dataframe['fisher_rsi'] + 1)
         # Stoch

--- a/freqtrade/strategy/default_strategy.py
+++ b/freqtrade/strategy/default_strategy.py
@@ -74,17 +74,18 @@ class DefaultStrategy(IStrategy):
         """
         # RSI
         dataframe['rsi'] = ta.RSI(dataframe)
-        """
+
         # Inverse Fisher transform on RSI, values [-1.0, 1.0] (https://goo.gl/2JGGoy)
         dataframe['fisher_rsi'] = fishers_inverse(dataframe['rsi'])
 
         # Inverse Fisher transform on RSI normalized, value [0.0, 100.0] (https://goo.gl/2JGGoy)
         dataframe['fisher_rsi_norma'] = 50 * (dataframe['fisher_rsi'] + 1)
+
         # Stoch
         stoch = ta.STOCH(dataframe)
         dataframe['slowd'] = stoch['slowd']
         dataframe['slowk'] = stoch['slowk']
-        """
+
         # Stoch fast
         stoch_fast = ta.STOCHF(dataframe)
         dataframe['fastd'] = stoch_fast['fastd']

--- a/freqtrade/tests/test_indicator_helpers.py
+++ b/freqtrade/tests/test_indicator_helpers.py
@@ -1,0 +1,12 @@
+import pandas as pd
+from freqtrade.indicator_helpers import went_up, went_down
+
+
+def test_went_up():
+    series = pd.Series([1, 2, 3, 1])
+    assert went_up(series).equals(pd.Series([False, True, True, False]))
+
+
+def test_went_down():
+    series = pd.Series([1, 2, 3, 1])
+    assert went_down(series).equals(pd.Series([False, False, False, True]))


### PR DESCRIPTION
- Adds simple helpers `went_up` and `went_down` that are same as `df['x'] > df['x'].shift(1)` and `df['x'] < df['x'].shift(1)`.
- Adds generic Fisher's Inverse Transform that can be fed with any indicator that goes from 0 to 100, like RSI, MFI, CyberCycle. Also has built-in smoothing.
- Adds a very low-lag Ehler's Super Smoother. Here a chart with close price and super smoothed price:
<img width="1050" alt="screenshot 2018-02-13 17 04 14" src="https://user-images.githubusercontent.com/557751/36200908-d8cf62aa-1186-11e8-84e0-a11515bd51a5.png">
