### PR TITLE
Cleaning up backtesting/hyperopt

### DIFF
--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -207,13 +207,7 @@ def scripts_options(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def backtesting_options(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument(
-        '-l', '--live',
-        action='store_true',
-        dest='live',
-        help='using live data',
-    )
+def optimizer_shared_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         '-i', '--ticker-interval',
         help='specify ticker interval in minutes (1, 5, 30, 60, 1440)',
@@ -226,6 +220,22 @@ def backtesting_options(parser: argparse.ArgumentParser) -> None:
         help='uses max_open_trades from config to simulate real world limitations',
         action='store_true',
         dest='realistic_simulation',
+    )
+    parser.add_argument(
+        '--timerange',
+        help='Specify what timerange of data to use.',
+        default=None,
+        type=str,
+        dest='timerange',
+    )
+
+
+def backtesting_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        '-l', '--live',
+        action='store_true',
+        dest='live',
+        help='using live data',
     )
     parser.add_argument(
         '-r', '--refresh-pairs-cached',
@@ -241,13 +251,6 @@ def backtesting_options(parser: argparse.ArgumentParser) -> None:
         type=str,
         default=None,
         dest='export',
-    )
-    parser.add_argument(
-        '--timerange',
-        help='Specify what timerange of data to use.',
-        default=None,
-        type=str,
-        dest='timerange',
     )
 
 
@@ -265,20 +268,6 @@ def hyperopt_options(parser: argparse.ArgumentParser) -> None:
         help='parallelize evaluations with mongodb (requires mongod in PATH)',
         dest='mongodb',
         action='store_true',
-    )
-    parser.add_argument(
-        '-i', '--ticker-interval',
-        help='specify ticker interval in minutes (1, 5, 30, 60, 1440)',
-        dest='ticker_interval',
-        type=int,
-        metavar='INT',
-    )
-    parser.add_argument(
-        '--timerange',
-        help='Specify what timerange of data to use.',
-        default=None,
-        type=str,
-        dest='timerange',
     )
     parser.add_argument(
         '-s', '--spaces',
@@ -330,11 +319,13 @@ def build_subcommands(parser: argparse.ArgumentParser) -> None:
     # Add backtesting subcommand
     backtesting_cmd = subparsers.add_parser('backtesting', help='backtesting module')
     backtesting_cmd.set_defaults(func=backtesting.start)
+    optimizer_shared_options(backtesting_cmd)
     backtesting_options(backtesting_cmd)
 
     # Add hyperopt subcommand
     hyperopt_cmd = subparsers.add_parser('hyperopt', help='hyperopt module')
     hyperopt_cmd.set_defaults(func=hyperopt.start)
+    optimizer_shared_options(hyperopt_cmd)
     hyperopt_options(hyperopt_cmd)
 
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -103,7 +103,6 @@ def backtest(args) -> DataFrame:
         realistic: do we try to simulate realistic trades? (default: True)
         sell_profit_only: sell if profit only
         use_sell_signal: act on sell-signal
-        stoploss: use stoploss
     :return: DataFrame
     """
     headers = ['date', 'buy', 'open', 'close', 'sell']
@@ -224,7 +223,6 @@ def start(args):
                         'realistic': args.realistic_simulation,
                         'sell_profit_only': sell_profit_only,
                         'use_sell_signal': use_sell_signal,
-                        'stoploss': strategy.stoploss,
                         'record': args.export
                         })
     logger.info(

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -109,7 +109,7 @@ def backtest(args) -> DataFrame:
     headers = ['date', 'buy', 'open', 'close', 'sell']
     processed = args['processed']
     max_open_trades = args.get('max_open_trades', 0)
-    realistic = args.get('realistic', True)
+    realistic = args.get('realistic', False)
     record = args.get('record', None)
     records = []
     trades = []

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -415,13 +415,10 @@ def generate_optimizer(args):
             backtesting.populate_buy_trend = buy_strategy_generator(params)
 
         if has_space(args.spaces, 'stoploss'):
-            stoploss = params['stoploss']
-        else:
-            stoploss = strategy.stoploss
+            strategy.stoploss = params['stoploss']
 
         results = backtest({'stake_amount': OPTIMIZE_CONFIG['stake_amount'],
                             'processed': PROCESSED,
-                            'stoploss': stoploss,
                             'realistic': args.realistic_simulation,
                             })
         result_explanation = format_results(results)


### PR DESCRIPTION
Few fixes and refactorings to Hyperopt and backtesting to make the results match between them:

- change realistic simulation to default to false and allow enabling it from both hyperopt and backtesting with `--realistic-simulation`
- combine CLI flags that are shared by both hyperopt and backtesting
- make CLI flags available to the optimizer in hyperopt
- use `--spaces` flag properly in hyperopt instead of hacky guessing from `params`
- fix that backtest ignored the given stoploss

After this PR, the call to backtest is quite different from Hyperopt than it is from backtesting.py, but these cleanups are necessary prework.
