### PR TITLE
This PR is a fix to issue #219. ('INSUFFICIENT_FUNDS')

### DIFF
--- a/freqtrade/exchange/bittrex.py
+++ b/freqtrade/exchange/bittrex.py
@@ -50,6 +50,7 @@ class Bittrex(Exchange):
         temp_error_messages = [
             'NO_API_RESPONSE',
             'MIN_TRADE_REQUIREMENT_NOT_MET',
+            'INSUFFICIENT_FUNDS'
         ]
         if response['message'] in temp_error_messages:
             raise ContentDecodingError(response['message'])


### PR DESCRIPTION
## Summary
Sometimes when there are insufficient funds, bot gets killed by throwing an ‘OperationalException’ and has to be restarted.
According to me, having insufficient funds cannot be a fatal error causing application to break.

Solve the issue: 
#By adding the error 'INSUFFICIENT_FUNDS' to non-fatal exceptions. It will not kill the bot.

## Quick changelog

- Added error 'INSUFFICIENT_FUNDS' to non-fatal exceptions list.

## What's new?
* Handled the case when there are insufficient funds for a buy and prevents the crash which was causing bot to be stopped.
