### PR TITLE
Use the ticker_interval defined by Strategy()

### DIFF
--- a/freqtrade/analyze.py
+++ b/freqtrade/analyze.py
@@ -77,6 +77,13 @@ class Analyze(object):
         """
         return self.strategy.populate_sell_trend(dataframe=dataframe)
 
+    def get_ticker_interval(self) -> int:
+        """
+        Return ticker interval to use
+        :return: Ticker interval value to use
+        """
+        return self.strategy.ticker_interval
+
     def analyze_ticker(self, ticker_history: List[Dict]) -> DataFrame:
         """
         Parses the given ticker history and returns a populated DataFrame

--- a/freqtrade/strategy/strategy.py
+++ b/freqtrade/strategy/strategy.py
@@ -64,7 +64,7 @@ class Strategy(object):
         # Optimal stoploss designed for the strategy
         self.stoploss = float(self.custom_strategy.stoploss)
 
-        self.ticker_interval = self.custom_strategy.ticker_interval
+        self.ticker_interval = int(self.custom_strategy.ticker_interval)
 
     def _load_strategy(self, strategy_name: str) -> None:
         """

--- a/freqtrade/tests/rpc/test_rpc.py
+++ b/freqtrade/tests/rpc/test_rpc.py
@@ -51,7 +51,7 @@ def test_rpc_trade_status(default_conf, ticker, mocker) -> None:
     assert error
     assert 'no active trade' in result
 
-    freqtradebot.create_trade(0.001, 5)
+    freqtradebot.create_trade()
     (error, result) = rpc.rpc_trade_status()
     assert not error
     trade = result[0]
@@ -99,7 +99,7 @@ def test_rpc_status_table(default_conf, ticker, mocker) -> None:
     assert error
     assert '*Status:* `no active order`' in result
 
-    freqtradebot.create_trade(0.001, 5)
+    freqtradebot.create_trade()
     (error, result) = rpc.rpc_status_table()
     assert 'just now' in result['Since'].all()
     assert 'BTC_ETH' in result['Pair'].all()
@@ -127,7 +127,7 @@ def test_rpc_daily_profit(default_conf, update, ticker, limit_buy_order, limit_s
     rpc = RPC(freqtradebot)
 
     # Create some test data
-    freqtradebot.create_trade(0.001, 5)
+    freqtradebot.create_trade()
     trade = Trade.query.first()
     assert trade
 
@@ -188,7 +188,7 @@ def test_rpc_trade_statistics(
     assert stats.find('no closed trade') >= 0
 
     # Create some test data
-    freqtradebot.create_trade(0.001, 5)
+    freqtradebot.create_trade()
     trade = Trade.query.first()
     # Simulate fulfilled LIMIT_BUY order for trade
     trade.update(limit_buy_order)
@@ -247,7 +247,7 @@ def test_rpc_trade_statistics_closed(mocker, default_conf, ticker, ticker_sell_u
     rpc = RPC(freqtradebot)
 
     # Create some test data
-    freqtradebot.create_trade(0.001, 5)
+    freqtradebot.create_trade()
     trade = Trade.query.first()
     # Simulate fulfilled LIMIT_BUY order for trade
     trade.update(limit_buy_order)
@@ -427,7 +427,7 @@ def test_rpc_forcesell(default_conf, ticker, mocker) -> None:
     assert not error
     assert res == ''
 
-    freqtradebot.create_trade(0.001, 5)
+    freqtradebot.create_trade()
     (error, res) = rpc.rpc_forcesell('all')
     assert not error
     assert res == ''
@@ -462,7 +462,7 @@ def test_rpc_forcesell(default_conf, ticker, mocker) -> None:
     assert res == ''
     assert cancel_order_mock.call_count == 1
 
-    freqtradebot.create_trade(0.001, 5)
+    freqtradebot.create_trade()
     # make an limit-sell open trade
     mocker.patch(
         'freqtrade.freqtradebot.exchange.get_order',
@@ -497,7 +497,7 @@ def test_performance_handle(default_conf, ticker, limit_buy_order,
     rpc = RPC(freqtradebot)
 
     # Create some test data
-    freqtradebot.create_trade(0.001, int(default_conf['ticker_interval']))
+    freqtradebot.create_trade()
     trade = Trade.query.first()
     assert trade
 
@@ -540,7 +540,7 @@ def test_rpc_count(mocker, default_conf, ticker) -> None:
     assert nb_trades == 0
 
     # Create some test data
-    freqtradebot.create_trade(0.001, int(default_conf['ticker_interval']))
+    freqtradebot.create_trade()
     (error, trades) = rpc.rpc_count()
     nb_trades = len(trades)
     assert not error

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -266,7 +266,7 @@ def test_status(default_conf, update, mocker, ticker) -> None:
 
     # Create some test data
     for _ in range(3):
-        freqtradebot.create_trade(0.001, 5)
+        freqtradebot.create_trade()
 
     telegram._status(bot=MagicMock(), update=update)
     assert msg_mock.call_count == 3
@@ -314,7 +314,7 @@ def test_status_handle(default_conf, update, ticker, mocker) -> None:
     msg_mock.reset_mock()
 
     # Create some test data
-    freqtradebot.create_trade(0.001, int(default_conf['ticker_interval']))
+    freqtradebot.create_trade()
     # Trigger status while we have a fulfilled order for the open trade
     telegram._status(bot=MagicMock(), update=update)
 
@@ -342,7 +342,9 @@ def test_status_table_handle(default_conf, update, ticker, mocker) -> None:
     )
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
 
-    freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
+    conf = deepcopy(default_conf)
+    conf['stake_amount'] = 15.0
+    freqtradebot = FreqtradeBot(conf, create_engine('sqlite://'))
     telegram = Telegram(freqtradebot)
 
     freqtradebot.update_state(State.STOPPED)
@@ -358,7 +360,7 @@ def test_status_table_handle(default_conf, update, ticker, mocker) -> None:
     msg_mock.reset_mock()
 
     # Create some test data
-    freqtradebot.create_trade(15.0, int(default_conf['ticker_interval']))
+    freqtradebot.create_trade()
 
     telegram._status_table(bot=MagicMock(), update=update)
 
@@ -399,7 +401,7 @@ def test_daily_handle(default_conf, update, ticker, limit_buy_order,
     telegram = Telegram(freqtradebot)
 
     # Create some test data
-    freqtradebot.create_trade(0.001, int(default_conf['ticker_interval']))
+    freqtradebot.create_trade()
     trade = Trade.query.first()
     assert trade
 
@@ -426,8 +428,8 @@ def test_daily_handle(default_conf, update, ticker, limit_buy_order,
     # Reset msg_mock
     msg_mock.reset_mock()
     # Add two other trades
-    freqtradebot.create_trade(0.001, int(default_conf['ticker_interval']))
-    freqtradebot.create_trade(0.001, int(default_conf['ticker_interval']))
+    freqtradebot.create_trade()
+    freqtradebot.create_trade()
 
     trades = Trade.query.all()
     for trade in trades:
@@ -512,7 +514,7 @@ def test_profit_handle(default_conf, update, ticker, ticker_sell_up,
     msg_mock.reset_mock()
 
     # Create some test data
-    freqtradebot.create_trade(0.001, int(default_conf['ticker_interval']))
+    freqtradebot.create_trade()
     trade = Trade.query.first()
 
     # Simulate fulfilled LIMIT_BUY order for trade
@@ -764,7 +766,7 @@ def test_forcesell_handle(default_conf, update, ticker, ticker_sell_up, mocker) 
     telegram = Telegram(freqtradebot)
 
     # Create some test data
-    freqtradebot.create_trade(0.001, int(default_conf['ticker_interval']))
+    freqtradebot.create_trade()
 
     trade = Trade.query.first()
     assert trade
@@ -803,7 +805,7 @@ def test_forcesell_down_handle(default_conf, update, ticker, ticker_sell_down, m
     telegram = Telegram(freqtradebot)
 
     # Create some test data
-    freqtradebot.create_trade(0.001, int(default_conf['ticker_interval']))
+    freqtradebot.create_trade()
 
     # Decrease the price and sell it
     mocker.patch.multiple(
@@ -847,7 +849,7 @@ def test_forcesell_all_handle(default_conf, update, ticker, mocker) -> None:
 
     # Create some test data
     for _ in range(4):
-        freqtradebot.create_trade(0.001, int(default_conf['ticker_interval']))
+        freqtradebot.create_trade()
     rpc_mock.reset_mock()
 
     update.message.text = '/forcesell all'
@@ -925,7 +927,7 @@ def test_performance_handle(default_conf, update, ticker, limit_buy_order,
     telegram = Telegram(freqtradebot)
 
     # Create some test data
-    freqtradebot.create_trade(0.001, int(default_conf['ticker_interval']))
+    freqtradebot.create_trade()
     trade = Trade.query.first()
     assert trade
 
@@ -995,7 +997,7 @@ def test_count_handle(default_conf, update, ticker, mocker) -> None:
     freqtradebot.update_state(State.RUNNING)
 
     # Create some test data
-    freqtradebot.create_trade(0.001, int(default_conf['ticker_interval']))
+    freqtradebot.create_trade()
     msg_mock.reset_mock()
     telegram._count(bot=MagicMock(), update=update)
 


### PR DESCRIPTION
## Summary
This PR simplify the usage of ticker_interval in `FraqtradeBot()` class. 

`Strategy()` class already define the right ticker_interval to use (1. Select the value in the strategy file, then 2. override it if set in config file or passed in cli arguments).
However, the bot is mostly using the ticker_interval set in the config file and ignore the ticker_interval recommended by the Strategy logic. This PR fixes this issue.

## Quick changelog

- Remove from FraqtradeBot() methods the ticker_interval passed in parameter
- Remove duplicate code
- Avoid using a wrong ticker interval
