### PR TITLE
Update dockerfile to python:3.6.4-slim-stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.6.2
+FROM python:3.6.4-slim-stretch
 
 # Install TA-lib
-RUN apt-get update && apt-get -y install build-essential && apt-get clean
+RUN apt-get update && apt-get -y install curl build-essential && apt-get clean
 RUN curl -L http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz | \
   tar xzvf - && \
   cd ta-lib && \


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/gcarq/freqtrade/blob/develop/CONTRIBUTING.md)

all tests Passing, no new tests required

## Summary
Update dockerfile to python:3.6.4-slim-stretch

By using the "slim" version of the image, the final size of the image goes from 1.37GB down to 1.02GB while maintaining all functions.

also updated python to the lasest 3.6.4 version, as the minor hop from 3.6.2 to 3.6.4 will not be breaking.

## Quick changelog

- update python from 3.6.2 to 3.6.4 in Dockerfile
- Change to slim version to reduce size of final image

## What's new?
Smaller size of the docker image.
