### PR TITLE
Update documentation for docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ vi config.json
 **3. Build your docker image and run it**
 ```bash
 docker build -t freqtrade .
-docker run --rm -v `pwd`/config.json:/freqtrade/config.json -it freqtrade
+docker run --rm -v /etc/localtime:/etc/localtime:ro -v `pwd`/config.json:/freqtrade/config.json -it freqtrade
 ```
 
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -129,7 +129,7 @@ docker images
 You can run a one-off container that is immediately deleted upon exiting with the following command (`config.json` must be in the current working directory):
 
 ```bash
-docker run --rm -v `pwd`/config.json:/freqtrade/config.json -it freqtrade
+docker run --rm -v /etc/localtime:/etc/localtime:ro	-v `pwd`/config.json:/freqtrade/config.json -it freqtrade
 ```
 
 In this example, the database will be created inside the docker instance and will be lost when you will refresh your image.
@@ -152,6 +152,7 @@ mv tradesv3.sqlite ~/.freqtrade
 ```bash
 docker run -d \
   --name freqtrade \
+  -v /etc/localtime:/etc/localtime:ro \
   -v ~/.freqtrade/config.json:/freqtrade/config.json \
   -v ~/.freqtrade/tradesv3.sqlite:/freqtrade/tradesv3.sqlite \
   freqtrade

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -129,7 +129,7 @@ docker images
 You can run a one-off container that is immediately deleted upon exiting with the following command (`config.json` must be in the current working directory):
 
 ```bash
-docker run --rm -v /etc/localtime:/etc/localtime:ro	-v `pwd`/config.json:/freqtrade/config.json -it freqtrade
+docker run --rm -v /etc/localtime:/etc/localtime:ro -v `pwd`/config.json:/freqtrade/config.json -it freqtrade
 ```
 
 In this example, the database will be created inside the docker instance and will be lost when you will refresh your image.


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/gcarq/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary
Update documentation to bind /etc/localtime to Docker container to have correct local time

## Quick changelog

- Updates documentation to include -v /etc/localtime:/etc/localtime:ro on docker run commands

## What's new?
* changed documentation for Docker run
* tested on linux (arch and debian stretch)
* should be working on Mac (please refview if possible, i have no way of testing that)
* will not work on Windows - bot neither will the existing `docker run` commands 
