### PR TITLE
Fix some tests for ccxt branch

### DIFF
--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -150,7 +150,7 @@ def limit_buy_order_old():
     return {
         'id': 'mocked_limit_buy_old',
         'type': 'LIMIT_BUY',
-        'pair': 'BTC_ETH',
+        'pair': 'ETH/BTC',
         'opened': str(arrow.utcnow().shift(minutes=-601).datetime),
         'rate': 0.00001099,
         'amount': 90.99181073,
@@ -163,7 +163,7 @@ def limit_sell_order_old():
     return {
         'id': 'mocked_limit_sell_old',
         'type': 'LIMIT_SELL',
-        'pair': 'BTC_ETH',
+        'pair': 'ETH/BTC',
         'opened': str(arrow.utcnow().shift(minutes=-601).datetime),
         'rate': 0.00001099,
         'amount': 90.99181073,
@@ -176,7 +176,7 @@ def limit_buy_order_old_partial():
     return {
         'id': 'mocked_limit_buy_old_partial',
         'type': 'LIMIT_BUY',
-        'pair': 'BTC_ETH',
+        'pair': 'ETH/BTC',
         'opened': str(arrow.utcnow().shift(minutes=-601).datetime),
         'rate': 0.00001099,
         'amount': 90.99181073,

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -103,32 +103,40 @@ def ticker_sell_down():
 
 @pytest.fixture
 def health():
-    return MagicMock(return_value=[{
-        'Currency': 'BTC',
-        'IsActive': True,
-        'LastChecked': '2017-11-13T20:15:00.00',
-        'Notice': None
-    }, {
-        'Currency': 'ETH',
-        'IsActive': True,
-        'LastChecked': '2017-11-13T20:15:00.00',
-        'Notice': None
-    }, {
-        'Currency': 'TRST',
-        'IsActive': True,
-        'LastChecked': '2017-11-13T20:15:00.00',
-        'Notice': None
-    }, {
-        'Currency': 'SWT',
-        'IsActive': True,
-        'LastChecked': '2017-11-13T20:15:00.00',
-        'Notice': None
-    }, {
-        'Currency': 'BCC',
-        'IsActive': False,
-        'LastChecked': '2017-11-13T20:15:00.00',
-        'Notice': None
-    }])
+    return MagicMock(return_value={
+        'ETH/BTC': {
+            'Currency': 'BTC',
+            'base': 'ETH',
+            'quote': 'BTC',
+            'active': True,
+            'LastChecked': '2017-11-13T20:15:00.00',
+            'Notice': None
+        },
+        'TRST/BTC': {
+            'Currency': 'TRST',
+            'base': 'TRST',
+            'quote': 'BTC',
+            'active': True,
+            'LastChecked': '2017-11-13T20:15:00.00',
+            'Notice': None
+        },
+        'SWT/BTC': {
+            'Currency': 'SWT',
+            'base': 'SWT',
+            'quote': 'BTC',
+            'active': True,
+            'LastChecked': '2017-11-13T20:15:00.00',
+            'Notice': None
+        },
+        'BCC/BTC': {
+            'Currency': 'BCC',
+            'base': 'BCC',
+            'quote': 'BTC',
+            'active': False,
+            'LastChecked': '2017-11-13T20:15:00.00',
+            'Notice': None
+        }
+    })
 
 
 @pytest.fixture

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -108,7 +108,7 @@ def test_status_handle(default_conf, update, ticker, mocker):
     _status(bot=MagicMock(), update=update)
 
     assert msg_mock.call_count == 1
-    assert '[BTC_ETH]' in msg_mock.call_args_list[0][0][0]
+    assert '[ETH/BTC]' in msg_mock.call_args_list[0][0][0]
 
 
 def test_status_table_handle(default_conf, update, ticker, mocker):
@@ -148,7 +148,7 @@ def test_status_table_handle(default_conf, update, ticker, mocker):
     fields = re.sub('[ ]+', ' ', line[2].strip()).split(' ')
 
     assert int(fields[0]) == 1
-    assert fields[1] == 'BTC_ETH'
+    assert fields[1] == 'ETH/BTC'
     assert msg_mock.call_count == 1
 
 
@@ -206,7 +206,7 @@ def test_profit_handle(
     assert '∙ `0.00006217 BTC (6.20%)`' in msg_mock.call_args_list[-1][0][0]
     assert '∙ `0.933 USD`' in msg_mock.call_args_list[-1][0][0]
 
-    assert '*Best Performing:* `BTC_ETH: 6.20%`' in msg_mock.call_args_list[-1][0][0]
+    assert '*Best Performing:* `ETH/BTC: 6.20%`' in msg_mock.call_args_list[-1][0][0]
 
 
 def test_forcesell_handle(default_conf, update, ticker, ticker_sell_up, mocker):
@@ -239,7 +239,7 @@ def test_forcesell_handle(default_conf, update, ticker, ticker_sell_up, mocker):
 
     assert rpc_mock.call_count == 2
     assert 'Selling' in rpc_mock.call_args_list[-1][0][0]
-    assert '[BTC_ETH]' in rpc_mock.call_args_list[-1][0][0]
+    assert '[ETH/BTC]' in rpc_mock.call_args_list[-1][0][0]
     assert 'Amount' in rpc_mock.call_args_list[-1][0][0]
     assert '0.00001172' in rpc_mock.call_args_list[-1][0][0]
     assert 'profit: 6.11%, 0.00006126' in rpc_mock.call_args_list[-1][0][0]
@@ -276,7 +276,7 @@ def test_forcesell_down_handle(default_conf, update, ticker, ticker_sell_down, m
 
     assert rpc_mock.call_count == 2
     assert 'Selling' in rpc_mock.call_args_list[-1][0][0]
-    assert '[BTC_ETH]' in rpc_mock.call_args_list[-1][0][0]
+    assert '[ETH/BTC]' in rpc_mock.call_args_list[-1][0][0]
     assert 'Amount' in rpc_mock.call_args_list[-1][0][0]
     assert '0.00001044' in rpc_mock.call_args_list[-1][0][0]
     assert 'loss: -5.48%, -0.00005492' in rpc_mock.call_args_list[-1][0][0]
@@ -294,7 +294,7 @@ def test_exec_forcesell_open_orders(default_conf, ticker, mocker):
                           }),
                           cancel_order=cancel_order_mock)
     trade = Trade(
-        pair='BTC_ETH',
+        pair='ETH/BTC',
         open_rate=1,
         exchange='BITTREX',
         open_order_id='123456789',
@@ -403,7 +403,7 @@ def test_performance_handle(
     _performance(bot=MagicMock(), update=update)
     assert msg_mock.call_count == 1
     assert 'Performance' in msg_mock.call_args_list[0][0][0]
-    assert '<code>BTC_ETH\t6.20% (1)</code>' in msg_mock.call_args_list[0][0][0]
+    assert '<code>ETH/BTC\t6.20% (1)</code>' in msg_mock.call_args_list[0][0][0]
 
 
 def test_daily_handle(default_conf, update, ticker, limit_buy_order, limit_sell_order, mocker):

--- a/freqtrade/tests/test_acl_pair.py
+++ b/freqtrade/tests/test_acl_pair.py
@@ -12,22 +12,23 @@ def whitelist_conf():
         'stake_currency': 'BTC',
         'exchange': {
             'pair_whitelist': [
-                'BTC_ETH',
-                'BTC_TKN',
-                'BTC_TRST',
-                'BTC_SWT',
-                'BTC_BCC'
+                'ETH/BTC',
+                'TKN/BTC',
+                'TRST/BTC',
+                'SWT/BTC',
+                'BCC/BTC'
             ],
             'pair_blacklist': [
-                'BTC_BLK'
+                'BLK/BTC'
             ],
         },
     }
 
 
 def get_market_summaries():
-    return [{
-        'MarketName': 'BTC-TKN',
+    return {'TKN/BTC': {
+        'symbol': 'TKN/BTC',
+        'MarketName': 'TKN/BTC',
         'High': 0.00000919,
         'Low': 0.00000820,
         'Volume': 74339.61396015,
@@ -40,9 +41,11 @@ def get_market_summaries():
         'OpenSellOrders': 15,
         'PrevDay': 0.00000821,
         'Created': '2014-03-20T06:00:00',
-        'DisplayMarketName': ''
-    }, {
-        'MarketName': 'BTC-ETH',
+        'DisplayMarketName': '',
+        'info': {},
+    }, 'ETH/BTC': {
+        'symbol': 'ETH/BTC',
+        'MarketName': 'ETH/BTC',
         'High': 0.00000072,
         'Low': 0.00000001,
         'Volume': 166340678.42280999,
@@ -55,9 +58,11 @@ def get_market_summaries():
         'OpenSellOrders': 18,
         'PrevDay': 0.00000002,
         'Created': '2014-05-30T07:57:49.637',
-        'DisplayMarketName': ''
-    }, {
-        'MarketName': 'BTC-BLK',
+        'DisplayMarketName': '',
+        'info': {},
+    }, 'BLK/BTC': {
+        'symbol': 'BLK/BTC',
+        'MarketName': 'BLK/BTC',
         'High': 0.00000072,
         'Low': 0.00000001,
         'Volume': 166340678.42280999,
@@ -70,18 +75,21 @@ def get_market_summaries():
         'OpenSellOrders': 18,
         'PrevDay': 0.00000002,
         'Created': '2014-05-30T07:57:49.637',
-        'DisplayMarketName': ''
-    }]
+        'DisplayMarketName': '',
+        'info': {},
+    }}
 
 
 def get_health():
-    return [{'Currency': 'ETH', 'IsActive': True},
-            {'Currency': 'TKN', 'IsActive': True},
-            {'Currency': 'BLK', 'IsActive': True}]
+    return {
+        'ETH/BTC': {'Currency': 'ETH', 'base': 'ETH', 'quote': 'BTC', 'active': True},
+        'TKN/BTC': {'Currency': 'TKN', 'base': 'TKN', 'quote': 'BTC', 'active': True},
+        'BLK/BTC': {'Currency': 'BLK', 'base': 'BLK', 'quote': 'BTC', 'active': True}
+        }
 
 
 def get_health_empty():
-    return []
+    return {}
 
 
 def test_refresh_market_pair_not_in_whitelist(mocker):
@@ -90,9 +98,9 @@ def test_refresh_market_pair_not_in_whitelist(mocker):
     mocker.patch.multiple('freqtrade.main.exchange',
                           get_wallet_health=get_health)
     refreshedwhitelist = refresh_whitelist(
-        conf['exchange']['pair_whitelist'] + ['BTC_XXX'])
+        conf['exchange']['pair_whitelist'] + ['XXX/BTC'])
     # List ordered by BaseVolume
-    whitelist = ['BTC_ETH', 'BTC_TKN']
+    whitelist = ['ETH/BTC', 'TKN/BTC']
     # Ensure all except those in whitelist are removed
     assert whitelist == refreshedwhitelist
 
@@ -104,7 +112,7 @@ def test_refresh_whitelist(mocker):
                           get_wallet_health=get_health)
     refreshedwhitelist = refresh_whitelist(conf['exchange']['pair_whitelist'])
     # List ordered by BaseVolume
-    whitelist = ['BTC_ETH', 'BTC_TKN']
+    whitelist = ['ETH/BTC', 'TKN/BTC']
     # Ensure all except those in whitelist are removed
     assert whitelist == refreshedwhitelist
 
@@ -117,7 +125,7 @@ def test_refresh_whitelist_dynamic(mocker):
     mocker.patch.multiple('freqtrade.main.exchange',
                           get_market_summaries=get_market_summaries)
     # argument: use the whitelist dynamically by exchange-volume
-    whitelist = ['BTC_TKN', 'BTC_ETH']
+    whitelist = ['TKN/BTC', 'ETH/BTC']
     refreshedwhitelist = refresh_whitelist(
         gen_pair_whitelist(conf['stake_currency']))
     assert whitelist == refreshedwhitelist

--- a/freqtrade/tests/test_analyze.py
+++ b/freqtrade/tests/test_analyze.py
@@ -113,7 +113,7 @@ def test_get_signal_handles_exceptions(mocker):
 
 def test_parse_ticker_dataframe(ticker_history, ticker_history_without_bv):
 
-    columns = ['close', 'high', 'low', 'open', 'date', 'volume']
+    columns = ['date', 'open', 'high', 'low', 'close', 'volume']
 
     # Test file with BV data
     dataframe = parse_ticker_dataframe(ticker_history)

--- a/freqtrade/tests/test_dataframe.py
+++ b/freqtrade/tests/test_dataframe.py
@@ -4,7 +4,7 @@ import pandas
 import freqtrade.optimize
 from freqtrade import analyze
 
-_pairs = ['BTC_ETH']
+_pairs = ['ETH/BTC']
 
 
 def load_dataframe_pair(pairs):

--- a/freqtrade/tests/test_main.py
+++ b/freqtrade/tests/test_main.py
@@ -100,7 +100,7 @@ def test_process_trade_creation(default_conf, ticker, limit_buy_order, health, m
     assert trade.stake_amount == default_conf['stake_amount']
     assert trade.is_open
     assert trade.open_date is not None
-    assert trade.exchange == Exchanges.BITTREX.name
+    assert trade.exchange == 'BITTREX'
     assert trade.open_rate == 0.00001099
     assert trade.amount == 90.99181073703367
 

--- a/freqtrade/tests/test_persistence.py
+++ b/freqtrade/tests/test_persistence.py
@@ -2,7 +2,6 @@
 import os
 import pytest
 from sqlalchemy import create_engine
-from freqtrade.exchange import Exchanges
 from freqtrade.persistence import Trade, init, clean_dry_run_db
 
 
@@ -117,10 +116,10 @@ def test_update_with_bittrex(limit_buy_order, limit_sell_order):
     """
 
     trade = Trade(
-        pair='BTC_ETH',
+        pair='ETH/BTC',
         stake_amount=0.001,
         fee=0.0025,
-        exchange=Exchanges.BITTREX,
+        exchange="BITTREX",
     )
     assert trade.open_order_id is None
     assert trade.open_rate is None
@@ -144,10 +143,10 @@ def test_update_with_bittrex(limit_buy_order, limit_sell_order):
 
 def test_calc_open_close_trade_price(limit_buy_order, limit_sell_order):
     trade = Trade(
-        pair='BTC_ETH',
+        pair='ETH/BTC',
         stake_amount=0.001,
         fee=0.0025,
-        exchange=Exchanges.BITTREX,
+        exchange="BITTREX",
     )
 
     trade.open_order_id = 'something'
@@ -166,10 +165,10 @@ def test_calc_open_close_trade_price(limit_buy_order, limit_sell_order):
 
 def test_calc_close_trade_price_exception(limit_buy_order):
     trade = Trade(
-        pair='BTC_ETH',
+        pair='ETH/BTC',
         stake_amount=0.001,
         fee=0.0025,
-        exchange=Exchanges.BITTREX,
+        exchange="BITTREX",
     )
 
     trade.open_order_id = 'something'
@@ -179,10 +178,10 @@ def test_calc_close_trade_price_exception(limit_buy_order):
 
 def test_update_open_order(limit_buy_order):
     trade = Trade(
-        pair='BTC_ETH',
+        pair='ETH/BTC',
         stake_amount=1.00,
         fee=0.1,
-        exchange=Exchanges.BITTREX,
+        exchange="BITTREX",
     )
 
     assert trade.open_order_id is None
@@ -201,10 +200,10 @@ def test_update_open_order(limit_buy_order):
 
 def test_update_invalid_order(limit_buy_order):
     trade = Trade(
-        pair='BTC_ETH',
+        pair='ETH/BTC',
         stake_amount=1.00,
         fee=0.1,
-        exchange=Exchanges.BITTREX,
+        exchange="BITTREX"
     )
     limit_buy_order['type'] = 'invalid'
     with pytest.raises(ValueError, match=r'Unknown order type'):
@@ -213,10 +212,10 @@ def test_update_invalid_order(limit_buy_order):
 
 def test_calc_open_trade_price(limit_buy_order):
     trade = Trade(
-        pair='BTC_ETH',
+        pair='ETH/BTC',
         stake_amount=0.001,
         fee=0.0025,
-        exchange=Exchanges.BITTREX,
+        exchange="BITTREX",
     )
     trade.open_order_id = 'open_trade'
     trade.update(limit_buy_order)  # Buy @ 0.00001099
@@ -230,10 +229,10 @@ def test_calc_open_trade_price(limit_buy_order):
 
 def test_calc_close_trade_price(limit_buy_order, limit_sell_order):
     trade = Trade(
-        pair='BTC_ETH',
+        pair='ETH/BTC',
         stake_amount=0.001,
         fee=0.0025,
-        exchange=Exchanges.BITTREX,
+        exchange="BITTREX",
     )
     trade.open_order_id = 'close_trade'
     trade.update(limit_buy_order)  # Buy @ 0.00001099
@@ -251,10 +250,10 @@ def test_calc_close_trade_price(limit_buy_order, limit_sell_order):
 
 def test_calc_profit(limit_buy_order, limit_sell_order):
     trade = Trade(
-        pair='BTC_ETH',
+        pair='ETH/BTC',
         stake_amount=0.001,
         fee=0.0025,
-        exchange=Exchanges.BITTREX,
+        exchange="BITTREX",
     )
     trade.open_order_id = 'profit_percent'
     trade.update(limit_buy_order)  # Buy @ 0.00001099
@@ -285,10 +284,10 @@ def test_calc_profit(limit_buy_order, limit_sell_order):
 
 def test_calc_profit_percent(limit_buy_order, limit_sell_order):
     trade = Trade(
-        pair='BTC_ETH',
+        pair='ETH/BTC',
         stake_amount=0.001,
         fee=0.0025,
-        exchange=Exchanges.BITTREX,
+        exchange="BITTREX",
     )
     trade.open_order_id = 'profit_percent'
     trade.update(limit_buy_order)  # Buy @ 0.00001099


### PR DESCRIPTION
## Summary
Fix some tests for ccxt branch
Not all tests are working yet, but I hope it helps @shusso to complete work on the ccxt branch

## Quick changelog
Fixed tests necessary to support ccxt:
some datastructures have changed type, therefore a change in the test-structure was necessary as well. 
* freqtrade/tests/test_main.py
* freqtrade/tests/test_persistence.py
* freqtrade/tests/test_acl_pair.py

Partially fixed tests: 
* freqtrade/tests/rpc/test_rpc_telegram.py  (2 still failing, down from 8)

no file outside of tests/ folder has been touched.

Please note that Travis build is expected to fail as not all tests pass yet.
## What's new?
* Help test coverage in CCXT branch