### PR TITLE
Fix test_dataframe when ran standalone

### DIFF
--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from freqtrade.optimize.hyperopt import calculate_loss, TARGET_TRADES, EXPECTED_MAX_PROFIT, start, \
     log_results, save_trials, read_trials, generate_roi_table, has_space
-
+from freqtrade.strategy.strategy import Strategy
 import freqtrade.optimize.hyperopt as hyperopt
 
 
@@ -72,6 +72,7 @@ def test_start_calls_fmin(mocker):
 
     args = mocker.Mock(epochs=1, config='config.json.example', mongodb=False,
                        timerange=None, spaces='all')
+    Strategy().init({'strategy': 'default_strategy'})
     start(args)
 
     mock_fmin.assert_called_once()
@@ -86,6 +87,7 @@ def test_start_uses_mongotrials(mocker):
 
     args = mocker.Mock(epochs=1, config='config.json.example', mongodb=True,
                        timerange=None, spaces='all')
+    Strategy().init({'strategy': 'default_strategy'})
     start(args)
 
     mock_mongotrials.assert_called_once()
@@ -149,6 +151,7 @@ def test_fmin_best_results(mocker, caplog):
 
     args = mocker.Mock(epochs=1, config='config.json.example',
                        timerange=None, spaces='all')
+    Strategy().init({'strategy': 'default_strategy'})
     start(args)
 
     exists = [
@@ -166,6 +169,7 @@ def test_fmin_best_results(mocker, caplog):
 
 def test_fmin_throw_value_error(mocker, caplog):
     caplog.set_level(logging.INFO)
+    Strategy().init({'strategy': 'default_strategy'})
     mocker.patch('freqtrade.optimize.hyperopt.MongoTrials', return_value=create_trials(mocker))
     mocker.patch('freqtrade.optimize.tickerdata_to_dataframe')
     mocker.patch('freqtrade.optimize.load_data')
@@ -173,6 +177,7 @@ def test_fmin_throw_value_error(mocker, caplog):
 
     args = mocker.Mock(epochs=1, config='config.json.example',
                        timerange=None, spaces='all')
+    Strategy().init({'strategy': 'default_strategy'})
     start(args)
 
     exists = [
@@ -209,7 +214,7 @@ def test_resuming_previous_hyperopt_results_succeeds(mocker):
                        mongodb=False,
                        timerange=None,
                        spaces='all')
-
+    Strategy().init({'strategy': 'default_strategy'})
     start(args)
 
     mock_read.assert_called_once()

--- a/freqtrade/tests/optimize/test_optimize.py
+++ b/freqtrade/tests/optimize/test_optimize.py
@@ -10,6 +10,7 @@ from freqtrade.exchange import Bittrex
 from freqtrade.optimize.__init__ import make_testdata_path, download_pairs,\
     download_backtesting_testdata, load_tickerdata_file, trim_tickerlist, file_dump_json
 from freqtrade.tests.conftest import log_has
+from freqtrade.strategy.strategy import Strategy
 
 # Change this if modifying BTC_UNITEST testdatafile
 _BTC_UNITTEST_LENGTH = 13681
@@ -218,6 +219,7 @@ def test_init(default_conf, mocker):
 
 
 def test_tickerdata_to_dataframe():
+    Strategy().init({'strategy': 'default_strategy'})
     timerange = ((None, 'line'), None, -100)
     tick = load_tickerdata_file(None, 'BTC_UNITEST', 1, timerange=timerange)
     tickerlist = {'BTC_UNITEST': tick}

--- a/freqtrade/tests/test_dataframe.py
+++ b/freqtrade/tests/test_dataframe.py
@@ -3,6 +3,7 @@
 import pandas
 import freqtrade.optimize
 from freqtrade import analyze
+from freqtrade.strategy.strategy import Strategy
 
 _pairs = ['BTC_ETH']
 
@@ -17,11 +18,13 @@ def load_dataframe_pair(pairs):
 
 
 def test_dataframe_load():
+    Strategy().init({'strategy': 'default_strategy'})
     dataframe = load_dataframe_pair(_pairs)
     assert isinstance(dataframe, pandas.core.frame.DataFrame)
 
 
 def test_dataframe_columns_exists():
+    Strategy().init({'strategy': 'default_strategy'})
     dataframe = load_dataframe_pair(_pairs)
     assert 'high' in dataframe.columns
     assert 'low' in dataframe.columns


### PR DESCRIPTION
## Summary
This fixes the test_dataframe when not run together with test_analyz

## Quick changelog

- initialize default strategy first

## What's new?
Running pytest over all files works.
running pytest with the following works as well (because the analyze-tests initialize Strategy correctly.
```
pytest freqtrade/tests/test_analyze.py freqtrade/tests/test_dataframe.py
```

When running pytest "standalone" on the dataframe test, the test fails, as Strategy is not properly initialized.

```
$ pytest freqtrade/tests/test_dataframe.py
.
.
.
    def populate_indicators(self, dataframe: DataFrame) -> DataFrame:
        """
            Populate indicators that will be used in the Buy and Sell strategy
            :param dataframe: Raw data from the exchange and parsed by parse_ticker_dataframe()
            :return: a Dataframe with all mandatory indicators for the strategies
            """
>       return self.custom_strategy.populate_indicators(dataframe)
E       AttributeError: 'Strategy' object has no attribute 'custom_strategy'

freqtrade/strategy/strategy.py:163: AttributeError
```

Noticed the same behaviour also in test_optimize.py and test_hyperopt.py.

All other tests seem to run fine both when running the whole test-suite, as well as "standalone" only this test/file.