### PR TITLE
fix backtesting in ccxt branch

### DIFF
--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -165,7 +165,7 @@ def get_balance(currency: str) -> float:
     if _CONF['dry_run']:
         return 999.9
 
-    return _API.fetch_balance()[currency]
+    return _API.fetch_balance()[currency]["free"]
 
 
 def get_balances():

--- a/freqtrade/optimize/__init__.py
+++ b/freqtrade/optimize/__init__.py
@@ -3,6 +3,7 @@
 import logging
 import json
 import os
+from datetime import datetime
 from typing import Optional, List, Dict
 from pandas import DataFrame
 from freqtrade.exchange import get_ticker_history
@@ -35,7 +36,7 @@ def load_tickerdata_file(datadir, pair, ticker_interval, timerange=None):
     path = make_testdata_path(datadir)
     file = '{abspath}/{pair}-{ticker_interval}.json'.format(
         abspath=path,
-        pair=pair,
+        pair=pair.replace('/', '_'),
         ticker_interval=ticker_interval,
     )
     gzipfile = file + '.gz'
@@ -135,7 +136,7 @@ def download_backtesting_testdata(datadir: str, pair: str, interval: int = 5) ->
         interval=interval,
     ))
 
-    filepair = pair.replace("-", "_")
+    filepair = pair.replace("/", "_")
     filename = os.path.join(path, '{pair}-{interval}.json'.format(
         pair=filepair,
         interval=interval,
@@ -155,9 +156,11 @@ def download_backtesting_testdata(datadir: str, pair: str, interval: int = 5) ->
     for row in new_data:
         if row not in data:
             data.append(row)
-    logger.debug("New Start: {}".format(data[1]['T']))
-    logger.debug("New End: {}".format(data[-1:][0]['T']))
-    data = sorted(data, key=lambda data: data['T'])
+    logger.debug("New Start: {}".format(
+                 datetime.fromtimestamp(data[0][0]/1000.0).strftime('%Y-%m-%dT%H:%M:%S')))
+    logger.debug("New End: {}".format(
+                 datetime.fromtimestamp(data[-1:][0][0]/1000.0).strftime('%Y-%m-%dT%H:%M:%S')))
+    data = sorted(data, key=lambda data: data[0])
 
     misc.file_dump_json(filename, data)
 

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -73,7 +73,7 @@ def get_sell_trade_entry(pair, row, buy_subset, ticker, trade_count_lock, args):
                   open_date=row.date,
                   stake_amount=stake_amount,
                   amount=stake_amount / row.open,
-                  fee=exchange.get_fee()
+                  fee=exchange.get_fee_taker()
                   )
 
     # calculate win/lose forwards from buy point
@@ -113,7 +113,6 @@ def backtest(args) -> DataFrame:
     records = []
     trades = []
     trade_count_lock: dict = {}
-    exchange._API = Bittrex({'key': '', 'secret': ''})
     for pair, pair_data in processed.items():
         pair_data['buy'], pair_data['sell'] = 0, 0
         ticker = populate_sell_trend(populate_buy_trend(pair_data))
@@ -164,13 +163,14 @@ def start(args):
         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     )
 
-    exchange._API = Bittrex({'key': '', 'secret': ''})
-
     logger.info('Using config: %s ...', args.config)
     config = misc.load_config(args.config)
     ticker_interval = config.get('ticker_interval', args.ticker_interval)
     logger.info('Using ticker_interval: %s ...', ticker_interval)
-
+    # patch config to no key
+    config['key'] = ''
+    config['secret'] = ''
+    exchange.init(config)
     data = {}
     pairs = config['exchange']['pair_whitelist']
     if args.live:


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/gcarq/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary
makes backtesting work in ccxt branch (tested against binance and kraken)

Reads "free" balance (as shown in [ccxt base](https://github.com/ccxt/ccxt/blob/master/python/ccxt/base/exchange.py#L1009))

## Quick changelog

- read "free" balance (get trading working in non-dry mode - tested against binance)
- have backtesting working in ccxt branch
- fixes backtest downloads (saves in the list/list format - not sure if we should try to preserve the json-based backtesting data format or provide a "converter"-script?)

## What's new?
see above

Tests will fail as tests are not fully implemented in ccxt.
