### PR TITLE
Fix --export trades while backtesting 

### DIFF
--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -62,7 +62,7 @@ def common_datearray(dfs):
 
 def file_dump_json(filename, data) -> None:
     with open(filename, 'w') as fp:
-        json.dump(data, fp)
+        json.dump(data, fp, default=str)
 
 
 @synchronized

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -62,7 +62,7 @@ def common_datearray(dfs):
 
 def file_dump_json(filename, data) -> None:
     with open(filename, 'w') as fp:
-        json.dump(data, fp, default=str)
+        json.dump(data, fp)
 
 
 @synchronized

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -146,7 +146,7 @@ def backtest(args) -> DataFrame:
                     records.append((pair, trade_entry[1],
                                     row.date.strftime('%s'),
                                     row2.date.strftime('%s'),
-                                    row.date, trade_entry[3]))
+                                    index, trade_entry[3]))
     # For now export inside backtest(), maybe change so that backtest()
     # returns a tuple like: (dataframe, records, logs, etc)
     if record and record.find('trades') >= 0:


### PR DESCRIPTION
## Summary
Fix exception `TypeError: Object of type 'Timestamp' is not JSON serializable`
 when using backtesting with`--export trades` 

The bug seems fixed in objectify - until that branch can be solved, the problem should also be fixed in the main branch.

Solve the issue: #535

## Quick changelog

- Default to str for json extracts

## What's new?
* Fixes issue pointed out in #535 
