### PR TITLE
Align calling convention in backtesting and plotting docu

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -53,13 +53,13 @@ python3 ./freqtrade/main.py backtesting --datadir freqtrade/tests/testdata-20180
 
 **With a (custom) strategy file**
 ```bash
-python3.6 ./freqtrade/main.py -s currentstrategy backtesting
+python3 ./freqtrade/main.py -s currentstrategy backtesting
 ```
 Where `-s currentstrategy` refers to a filename `currentstrategy.py` in `freqtrade/user_data/strategies`
 
 **Exporting trades to file**
 ```bash
-freqtrade backtesting --export trades
+python3 ./freqtrade/main.py backtesting --export trades
 ```
 
 **Running backtest with smaller testset**  
@@ -99,7 +99,7 @@ cd user_data/data-20180113
 Possibly edit pairs.json file to include/exclude pairs
 
 ```bash
-python freqtrade/tests/testdata/download_backtest_data.py -p pairs.json
+python3 freqtrade/tests/testdata/download_backtest_data.py -p pairs.json
 ```
 
 The script will read your pairs.json file, and download ticker data

--- a/docs/plotting.md
+++ b/docs/plotting.md
@@ -73,5 +73,5 @@ The `-p` pair argument, can be used to plot a single pair
 
 Example
 ```
-python3.6 scripts/plot_profit.py --datadir ../freqtrade/freqtrade/tests/testdata-20171221/ -p BTC_LTC
+python3 scripts/plot_profit.py --datadir ../freqtrade/freqtrade/tests/testdata-20171221/ -p BTC_LTC
 ```


### PR DESCRIPTION
## Summary
align documentation to use `python3 ./freqtrade/main.py`.

## Quick changelog

- documentation - calls adjusted

## What's new?
To create consistency within the document (all lines should use the same calling convention - previously,  `python3`, `python3.6` and sometimes `freqtrade` was used.
