### PR TITLE
allow max_open_trades to be 0

### DIFF
--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -333,7 +333,7 @@ def build_subcommands(parser: argparse.ArgumentParser) -> None:
 CONF_SCHEMA = {
     'type': 'object',
     'properties': {
-        'max_open_trades': {'type': 'integer', 'minimum': 1},
+        'max_open_trades': {'type': 'integer', 'minimum': 0},
         'ticker_interval': {'type': 'integer', 'enum': [1, 5, 30, 60, 1440]},
         'stake_currency': {'type': 'string', 'enum': ['BTC', 'ETH', 'USDT']},
         'stake_amount': {'type': 'number', 'minimum': 0.0005},


### PR DESCRIPTION

Solves issue: #534

## Quick changelog

- allow `max_open_trades` to be 0

## What's new?
Modifies `CONF_SCHEMA` and sets 0 as the minimum required value of allows `max_open_trades`.
This allows to only sell existing open orders and not creating any new ones.
