### PR TITLE
adapt bin/freqtrade to pass required parameters

### DIFF
--- a/bin/freqtrade
+++ b/bin/freqtrade
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
 
-from freqtrade.main import main
-main()
+import sys
+
+from freqtrade.main import main, set_loggers
+set_loggers()
+main(sys.argv[1:])


### PR DESCRIPTION
## Summary

Fixes a `TypeError` when launching the bot via the bin wrapper.

```
$ freqtrade
Traceback (most recent call last):
  File "freqtrade/.env/bin/freqtrade", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "freqtrade/bin/freqtrade", line 6, in <module>
    main()
TypeError: main() missing 1 required positional argument: 'sysargv'
```
## Quick changelog

- adapt `bin/freqtrade` wrapper to call set_loggers() and pass required arguments to main().
