### PR TITLE
Hyperopt Mongodb Patch

### DIFF
--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -200,7 +200,7 @@ class Arguments(object):
 
         # Add hyperopt subcommand
         hyperopt_cmd = subparsers.add_parser('hyperopt', help='hyperopt module')
-        hyperopt_cmd.set_defaults(func=hyperopt.start)
+        hyperopt_cmd.set_defaults(func=hyperopt.sta)
         self.optimizer_shared_options(hyperopt_cmd)
         self.hyperopt_options(hyperopt_cmd)
 

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -497,7 +497,7 @@ class Hyperopt(Backtesting):
                     results.duration.mean(),
                 )
 
-    def start(self) -> None:
+    def sta(self) -> None:
         timerange = Arguments.parse_timerange(self.config.get('timerange'))
         data = load_data(
             datadir=self.config.get('datadir'),
@@ -586,7 +586,7 @@ class Hyperopt(Backtesting):
         sys.exit(0)
 
 
-def start(args: Namespace) -> None:
+def sta(args: Namespace) -> None:
     """
     Start Backtesting script
     :param args: Cli args from Arguments()
@@ -612,5 +612,4 @@ def start(args: Namespace) -> None:
     config['exchange']['secret'] = ''
 
     # Initialize backtesting object
-    hyperopt = Hyperopt(config)
-    hyperopt.start()
+    Hyperopt(config).start()


### PR DESCRIPTION
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/gcarq/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary
Explain in one sentence the goal of this PR

Solve the issue: #568 

## Quick changelog
Renamed 'Start' to 'Sta' for debugging to make sure hyperopt does not detect it as a thread.
Moved .start() thread to the end of Hyperopt(config) in hyperopt.py Removed threadlock error by forcing output into hyperopt = Hyperopt(config)

## What's new?
*Explain in details what this PR solve or improve. You can include visuals.* 

Solves hyper-opt thread lock. I had a successful run on debian network install, python 3.6 from the debian testing deb repository (not ppa) and pip3.6. All commands were run and scripts were initialized with python3.6

My output:
```
(.env) root@debian:/home/owner/freqtrade# python3.6 ./freqtrade/main.py -c config.json hyperopt --use-mongodb
2018-03-21 23:21:49,049 - root - INFO - Generating grammar tables from /usr/lib/python3.6/lib2to3/Grammar.txt
2018-03-21 23:21:49,112 - root - INFO - Generating grammar tables from /usr/lib/python3.6/lib2to3/PatternGrammar.txt
2018-03-21 23:21:49,395 - freqtrade.optimize.hyperopt - INFO - Starting freqtrade in Hyperopt mode
2018-03-21 23:21:49,395 - freqtrade.configuration - INFO - Log level set at 20
2018-03-21 23:21:49,396 - freqtrade.configuration - INFO - Using max_open_trades: 3 ...
2018-03-21 23:21:49,396 - freqtrade.configuration - INFO - Parameter --datadir detected: freqtrade/tests/testdata ...
2018-03-21 23:21:49,396 - freqtrade.configuration - INFO - Parameter --epochs detected ...
2018-03-21 23:21:49,396 - freqtrade.configuration - INFO - Will run Hyperopt with for 100 epochs ...
2018-03-21 23:21:49,396 - freqtrade.configuration - INFO - Parameter --use-mongodb detected ...
2018-03-21 23:21:49,397 - freqtrade.configuration - INFO - Parameter -s/--spaces detected: all
2018-03-21 23:21:49,398 - freqtrade.strategy.strategy - INFO - Load strategy class: DefaultStrategy (.default_strategy.py)
2018-03-21 23:21:49,398 - freqtrade.strategy.strategy - INFO - Override strategy 'minimal_roi' with value in config file.
2018-03-21 23:21:49,398 - freqtrade.strategy.strategy - INFO - Override strategy 'stoploss' with value in config file: -0.1.
2018-03-21 23:21:49,399 - freqtrade.optimize.hyperopt - INFO - Using stake_currency: BTC ...
2018-03-21 23:21:49,399 - freqtrade.optimize.hyperopt - INFO - Using stake_amount: 0.01 ...
2018-03-21 23:21:49,399 - freqtrade.optimize.hyperopt - INFO - Using local backtesting data (using whitelist in given config) ...
2018-03-21 23:21:49,631 - freqtrade.optimize.hyperopt - INFO - Ignoring max_open_trades (realistic_simulation not set) ...
2018-03-21 23:21:50,737 - freqtrade.optimize.hyperopt - INFO - Measuring data from 2018-01-10T04:55:00+00:00 up to 2018-01-30T04:50:00+00:00 (19 days)..

==================================== BACKTESTING REPORT ====================================
pair        buy count    avg profit %    total profit BTC    avg duration    profit    loss
--------  -----------  --------------  ------------------  --------------  --------  ------
BTC_ETH            98            0.45          0.00439448           126.4        98       0
BTC_LTC            30            1.17          0.00346794            67.8        30       0
BTC_ETC           102            0.85          0.00870789           105.6       100       2
BTC_DASH          128            0.47          0.00604338           178.7       128       0
BTC_ZEC           102            0.56          0.00570054            86.7       102       0
BTC_XLM           176            1.14          0.01996379            98.5       170       6
BTC_NXT            71           -0.63         -0.00447112            52.6        60      11
BTC_POWR          104            0.63          0.00655239            84.8        97       7
BTC_ADA           199            0.12          0.00224027           163.9       185      14
BTC_XMR           119            0.53          0.00629366           179.6       118       1
TOTAL            1129            0.52          0.05889322           124.7      1088      41```