### PR TITLE
fix backtest --export format

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -196,7 +196,7 @@ class Backtesting(object):
                         records.append((pair, trade_entry[1],
                                         row.date.strftime('%s'),
                                         row2.date.strftime('%s'),
-                                        row.date, trade_entry[3]))
+                                        index, trade_entry[3]))
         # For now export inside backtest(), maybe change so that backtest()
         # returns a tuple like: (dataframe, records, logs, etc)
         if record and record.find('trades') >= 0:


### PR DESCRIPTION
## Summary
reverts regression introduced in c62356438a60ec40c7e724fa4f0e8dff898751f4.

## Quick changelog
* revert change in trade export format.

### explanation
Tick-frame was exported on position 4 in the array - the fix in feature/objectify exports date - don't think  this change in behavior is intentional as the date is available in fields 2 and 3 already in a different format.

Looking at https://github.com/gcarq/freqtrade/blob/develop/freqtrade/optimize/backtesting.py#L195-L198
``` python
                         records.append((pair, trade_entry[1],
                                         row.date.strftime('%s'),
                                         row2.date.strftime('%s'),
                                        row.date, trade_entry[3]))
```
we see `row.date` exported twice - once in second-format, once in date format.
This was not the case before c62356438a60ec40c7e724fa4f0e8dff898751f4.

Objectify fixed the resulting exception, but left the format to duplicate date export.

new (and pre-c62356438a60ec40c7e724fa4f0e8dff898751f4) format:
```
[["BTC_ETH", 0.00035639, "1520298600", "1520302500", 37, 65], ["BTC_ETH", 0.00201305, "1520307900", "1520328000", 68, 335], ["BTC_ETH", 9.669e-05, "1520332200", "1520443500", 149, 415], ["BTC_ETH", 9.772e-05, "1520446500", "1520468400", 530, 365], ["BTC_ETH", 0.00338524, "1520469000", "1520474100", 605, 85], ["BTC_ETH", 9.048e-05, "1520475000", "1520576700", 625, 255], ["BTC_ETH", 0.00101442, "1520582100", "1520602200", 983, 335], ["BTC_ETH", 0.00838566, "1520607600", "1520611500", 1068, 65], ["BTC_ETH", 0.00361317, "1520615400", "1520637000", 1094, 360], ["BTC_ETH", 0.00121311, "1520642100", "1520646600", 1183, 75], ["BTC_ETH", 0.00105558, "1520649300", "1520757600", 1207, 365]]
```

format introduced in c62356438a60ec40c7e724fa4f0e8dff898751f4:
```
[["BTC_ETH", 0.00035639, "1520298600", "1520302500", "2018-03-06 02:10:00+00:00", 65], ["BTC_ETH", 0.00201305, "1520307900", "1520328000", "2018-03-06 04:45:00+00:00", 335], ["BTC_ETH", 9.669e-05, "1520332200", "1520443500", "2018-03-06 11:30:00+00:00", 415], ["BTC_ETH", 9.772e-05, "1520446500", "1520468400", "2018-03-07 19:15:00+00:00", 365], ["BTC_ETH", 0.00338524, "1520469000", "1520474100", "2018-03-08 01:30:00+00:00", 85], ["BTC_ETH", 9.048e-05, "1520475000", "1520576700", "2018-03-08 03:10:00+00:00", 255], ["BTC_ETH", 0.00101442, "1520582100", "1520602200", "2018-03-09 08:55:00+00:00", 335], ["BTC_ETH", 0.00838566, "1520607600", "1520611500", "2018-03-09 16:00:00+00:00", 65], ["BTC_ETH", 0.00361317, "1520615400", "1520637000", "2018-03-09 18:10:00+00:00", 360], ["BTC_ETH", 0.00121311, "1520642100", "1520646600", "2018-03-10 01:35:00+00:00", 75], ["BTC_ETH", 0.00105558, "1520649300", "1520757600", "2018-03-10 03:35:00+00:00", 365]]
```


this replaces #551 as the commit-history is cleaner on this PR (and the other one was incompatible due to merging objectify).
