### PR TITLE
Add --strategy-path parameter and simplify StrategyResolver

### DIFF
--- a/config_full.json.example
+++ b/config_full.json.example
@@ -48,5 +48,7 @@
     "initial_state": "running",
     "internals": {
         "process_throttle_secs": 5
-    }
+    },
+    "strategy": "DefaultStrategy",
+    "strategy_path": "/some/folder/"
 }

--- a/docs/bot-optimization.md
+++ b/docs/bot-optimization.md
@@ -42,6 +42,13 @@ You can test it with the parameter: `--strategy TestStrategy`
 python3 ./freqtrade/main.py --strategy AwesomeStrategy
 ```
 
+### Specify custom strategy location
+If you want to use a strategy from a different folder you can pass `--strategy-path`
+
+```bash
+python3 ./freqtrade/main.py --strategy AwesomeStrategy --strategy-path /some/folder
+```
+
 **For the following section we will use the [user_data/strategies/test_strategy.py](https://github.com/gcarq/freqtrade/blob/develop/user_data/strategies/test_strategy.py)
 file as reference.**
 

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -28,6 +28,7 @@ optional arguments:
                         specify configuration file (default: config.json)
   -s NAME, --strategy NAME
                         specify strategy class name (default: DefaultStrategy)
+  --strategy-path PATH  specify additional strategy lookup path
   --dry-run-db          Force dry run to use a local DB
                         "tradesv3.dry_run.sqlite" instead of memory DB. Work
                         only if dry_run is enabled.
@@ -67,9 +68,16 @@ message the reason (File not found, or errors in your code).
 
 Learn more about strategy file in [optimize your bot](https://github.com/gcarq/freqtrade/blob/develop/docs/bot-optimization.md).
 
+### How to use --strategy-path?
+This parameter allows you to add an additional strategy lookup path, which gets
+checked before the default locations (The passed path must be a folder!):
+```bash
+python3 ./freqtrade/main.py --strategy AwesomeStrategy --strategy-path /some/folder
+```
+
 #### How to install a strategy?
 This is very simple. Copy paste your strategy file into the folder 
-`user_data/strategies`. And voila, the bot is ready to use it.
+`user_data/strategies` or use `--strategy-path`. And voila, the bot is ready to use it.
 
 ### How to use --dynamic-whitelist?
 Per default `--dynamic-whitelist` will retrieve the 20 currencies based 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,8 @@ The table below will list all configuration parameters.
 | `telegram.token` | token | No | Your Telegram bot token. Only required if `telegram.enabled` is `true`.
 | `telegram.chat_id` | chat_id | No | Your personal Telegram account id. Only required if `telegram.enabled` is `true`.
 | `initial_state` | running | No | Defines the initial application state. More information below.
+| `strategy` | DefaultStrategy | No | Defines Strategy class to use.
+| `strategy_path` | null | No | Adds an additional strategy lookup path (must be a folder).
 | `internals.process_throttle_secs` | 5 | Yes | Set the process throttle. Value in second.
 
 The definition of each config parameters is in 

--- a/freqtrade/analyze.py
+++ b/freqtrade/analyze.py
@@ -36,7 +36,7 @@ class Analyze(object):
         :param config: Bot configuration (use the one from Configuration())
         """
         self.config = config
-        self.strategy = StrategyResolver(self.config)
+        self.strategy = StrategyResolver(self.config).strategy
 
     @staticmethod
     def parse_ticker_dataframe(ticker: list) -> DataFrame:

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -87,6 +87,13 @@ class Arguments(object):
             metavar='NAME',
         )
         self.parser.add_argument(
+            '--strategy-path',
+            help='specify additional strategy lookup path',
+            dest='strategy_path',
+            type=str,
+            metavar='PATH',
+        )
+        self.parser.add_argument(
             '--dynamic-whitelist',
             help='dynamically generate and update whitelist \
                                   based on 24h BaseVolume (Default 20 currencies)',  # noqa

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -36,6 +36,9 @@ class Configuration(object):
         # Add the strategy file to use
         config.update({'strategy': self.args.strategy})
 
+        if self.args.strategy_path:
+            config.update({'strategy_path': self.args.strategy_path})
+
         # Load Common configuration
         config = self._load_common_config(config)
 

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -33,8 +33,9 @@ class Configuration(object):
         logger.info('Using config: %s ...', self.args.config)
         config = self._load_config_file(self.args.config)
 
-        # Add the strategy file to use
-        config.update({'strategy': self.args.strategy})
+        # Override strategy if specified
+        if self.args.strategy != Constants.DEFAULT_STRATEGY:
+            config.update({'strategy': self.args.strategy})
 
         if self.args.strategy_path:
             config.update({'strategy_path': self.args.strategy_path})

--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -33,8 +33,8 @@ class Configuration(object):
         logger.info('Using config: %s ...', self.args.config)
         config = self._load_config_file(self.args.config)
 
-        # Override strategy if specified
-        if self.args.strategy != Constants.DEFAULT_STRATEGY:
+        # Set strategy if not specified in config and or if it's non default
+        if self.args.strategy != Constants.DEFAULT_STRATEGY or not config.get('strategy'):
             config.update({'strategy': self.args.strategy})
 
         if self.args.strategy_path:

--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -3,7 +3,6 @@
 Main Freqtrade bot script.
 Read the documentation to know what cli arguments you need.
 """
-
 import logging
 import sys
 from typing import List

--- a/freqtrade/strategy/interface.py
+++ b/freqtrade/strategy/interface.py
@@ -33,7 +33,6 @@ class IStrategy(ABC):
         Based on TA indicators, populates the buy signal for the given dataframe
         :param dataframe: DataFrame
         :return: DataFrame with buy column
-        :return:
         """
 
     @abstractmethod
@@ -41,5 +40,5 @@ class IStrategy(ABC):
         """
         Based on TA indicators, populates the sell signal for the given dataframe
         :param dataframe: DataFrame
-        :return: DataFrame with buy column
+        :return: DataFrame with sell column
         """

--- a/freqtrade/strategy/resolver.py
+++ b/freqtrade/strategy/resolver.py
@@ -30,13 +30,7 @@ class StrategyResolver(object):
         config = config or {}
 
         # Verify the strategy is in the configuration, otherwise fallback to the default strategy
-        if 'strategy' in config:
-            strategy = config['strategy']
-        else:
-            strategy = Constants.DEFAULT_STRATEGY
-
-        # Try to load the strategy
-        self.strategy = self._load_strategy(strategy)
+        self.strategy = self._load_strategy(config.get('strategy') or Constants.DEFAULT_STRATEGY)
 
         # Set attributes
         # Check if we need to override configuration

--- a/freqtrade/strategy/resolver.py
+++ b/freqtrade/strategy/resolver.py
@@ -27,8 +27,7 @@ class StrategyResolver(object):
     def __init__(self, config: Optional[Dict] = None) -> None:
         """
         Load the custom class from config parameter
-        :param config:
-        :return:
+        :param config: configuration dictionary or None
         """
         config = config or {}
 

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -21,28 +21,18 @@ def test_search_strategy():
 
 def test_load_strategy(result):
     resolver = StrategyResolver()
-
-    assert not hasattr(StrategyResolver, 'custom_strategy')
     resolver._load_strategy('TestStrategy')
-
-    assert not hasattr(StrategyResolver, 'custom_strategy')
-
     assert hasattr(resolver.strategy, 'populate_indicators')
     assert 'adx' in resolver.strategy.populate_indicators(result)
 
 
 def test_load_strategy_custom_directory(result):
     resolver = StrategyResolver()
-
-    assert not hasattr(StrategyResolver, 'custom_strategy')
-
     extra_dir = os.path.join('some', 'path')
     with pytest.raises(
             FileNotFoundError,
             match=r".*No such file or directory: '{}'".format(extra_dir)):
         resolver._load_strategy('TestStrategy', extra_dir)
-
-    assert not hasattr(StrategyResolver, 'custom_strategy')
 
     assert hasattr(resolver.strategy, 'populate_indicators')
     assert 'adx' in resolver.strategy.populate_indicators(result)

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -115,7 +115,6 @@ def test_strategy_override_ticker_interval(caplog):
 
 def test_strategy_fallback_default_strategy():
     strategy = StrategyResolver()
-    strategy.logger = logging.getLogger(__name__)
 
     assert not hasattr(StrategyResolver, 'custom_strategy')
     strategy._load_strategy('../../super_duper')

--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -19,15 +19,15 @@ def test_search_strategy():
 
 
 def test_load_strategy(result):
-    strategy = StrategyResolver()
+    resolver = StrategyResolver()
 
     assert not hasattr(StrategyResolver, 'custom_strategy')
-    strategy._load_strategy('TestStrategy')
+    resolver._load_strategy('TestStrategy')
 
     assert not hasattr(StrategyResolver, 'custom_strategy')
 
-    assert hasattr(strategy.custom_strategy, 'populate_indicators')
-    assert 'adx' in strategy.populate_indicators(result)
+    assert hasattr(resolver.strategy, 'populate_indicators')
+    assert 'adx' in resolver.strategy.populate_indicators(result)
 
 
 def test_load_not_found_strategy(caplog):
@@ -42,23 +42,23 @@ def test_load_not_found_strategy(caplog):
 
 
 def test_strategy(result):
-    strategy = StrategyResolver({'strategy': 'DefaultStrategy'})
+    resolver = StrategyResolver({'strategy': 'DefaultStrategy'})
 
-    assert hasattr(strategy.custom_strategy, 'minimal_roi')
-    assert strategy.minimal_roi[0] == 0.04
+    assert hasattr(resolver.strategy, 'minimal_roi')
+    assert resolver.strategy.minimal_roi[0] == 0.04
 
-    assert hasattr(strategy.custom_strategy, 'stoploss')
-    assert strategy.stoploss == -0.10
+    assert hasattr(resolver.strategy, 'stoploss')
+    assert resolver.strategy.stoploss == -0.10
 
-    assert hasattr(strategy.custom_strategy, 'populate_indicators')
-    assert 'adx' in strategy.populate_indicators(result)
+    assert hasattr(resolver.strategy, 'populate_indicators')
+    assert 'adx' in resolver.strategy.populate_indicators(result)
 
-    assert hasattr(strategy.custom_strategy, 'populate_buy_trend')
-    dataframe = strategy.populate_buy_trend(strategy.populate_indicators(result))
+    assert hasattr(resolver.strategy, 'populate_buy_trend')
+    dataframe = resolver.strategy.populate_buy_trend(resolver.strategy.populate_indicators(result))
     assert 'buy' in dataframe.columns
 
-    assert hasattr(strategy.custom_strategy, 'populate_sell_trend')
-    dataframe = strategy.populate_sell_trend(strategy.populate_indicators(result))
+    assert hasattr(resolver.strategy, 'populate_sell_trend')
+    dataframe = resolver.strategy.populate_sell_trend(resolver.strategy.populate_indicators(result))
     assert 'sell' in dataframe.columns
 
 
@@ -70,10 +70,10 @@ def test_strategy_override_minimal_roi(caplog):
             "0": 0.5
         }
     }
-    strategy = StrategyResolver(config)
+    resolver = StrategyResolver(config)
 
-    assert hasattr(strategy.custom_strategy, 'minimal_roi')
-    assert strategy.minimal_roi[0] == 0.5
+    assert hasattr(resolver.strategy, 'minimal_roi')
+    assert resolver.strategy.minimal_roi[0] == 0.5
     assert ('freqtrade.strategy.resolver',
             logging.INFO,
             'Override strategy \'minimal_roi\' with value in config file.'
@@ -86,10 +86,10 @@ def test_strategy_override_stoploss(caplog):
         'strategy': 'DefaultStrategy',
         'stoploss': -0.5
     }
-    strategy = StrategyResolver(config)
+    resolver = StrategyResolver(config)
 
-    assert hasattr(strategy.custom_strategy, 'stoploss')
-    assert strategy.stoploss == -0.5
+    assert hasattr(resolver.strategy, 'stoploss')
+    assert resolver.strategy.stoploss == -0.5
     assert ('freqtrade.strategy.resolver',
             logging.INFO,
             'Override strategy \'stoploss\' with value in config file: -0.5.'
@@ -103,10 +103,10 @@ def test_strategy_override_ticker_interval(caplog):
         'strategy': 'DefaultStrategy',
         'ticker_interval': 60
     }
-    strategy = StrategyResolver(config)
+    resolver = StrategyResolver(config)
 
-    assert hasattr(strategy.custom_strategy, 'ticker_interval')
-    assert strategy.ticker_interval == 60
+    assert hasattr(resolver.strategy, 'ticker_interval')
+    assert resolver.strategy.ticker_interval == 60
     assert ('freqtrade.strategy.resolver',
             logging.INFO,
             'Override strategy \'ticker_interval\' with value in config file: 60.'
@@ -120,14 +120,3 @@ def test_strategy_fallback_default_strategy():
     assert not hasattr(StrategyResolver, 'custom_strategy')
     strategy._load_strategy('../../super_duper')
     assert not hasattr(StrategyResolver, 'custom_strategy')
-
-
-def test_strategy_singleton():
-    strategy1 = StrategyResolver({'strategy': 'DefaultStrategy'})
-
-    assert hasattr(strategy1.custom_strategy, 'minimal_roi')
-    assert strategy1.minimal_roi[0] == 0.04
-
-    strategy2 = StrategyResolver()
-    assert hasattr(strategy2.custom_strategy, 'minimal_roi')
-    assert strategy2.minimal_roi[0] == 0.04

--- a/freqtrade/tests/test_arguments.py
+++ b/freqtrade/tests/test_arguments.py
@@ -71,6 +71,26 @@ def test_parse_args_invalid() -> None:
         Arguments(['-c'], '').get_parsed_arg()
 
 
+def test_parse_args_strategy() -> None:
+    args = Arguments(['--strategy', 'SomeStrategy'], '').get_parsed_arg()
+    assert args.strategy == 'SomeStrategy'
+
+
+def test_parse_args_strategy_invalid() -> None:
+    with pytest.raises(SystemExit, match=r'2'):
+        Arguments(['--strategy'], '').get_parsed_arg()
+
+
+def test_parse_args_strategy_path() -> None:
+    args = Arguments(['--strategy-path', '/some/path'], '').get_parsed_arg()
+    assert args.strategy_path == '/some/path'
+
+
+def test_parse_args_strategy_path_invalid() -> None:
+    with pytest.raises(SystemExit, match=r'2'):
+        Arguments(['--strategy-path'], '').get_parsed_arg()
+
+
 def test_parse_args_dynamic_whitelist() -> None:
     args = Arguments(['--dynamic-whitelist'], '').get_parsed_arg()
     assert args.dynamic_whitelist == 20


### PR DESCRIPTION
## Summary
Further improvements to abstract `user_data` from core: Adds `--strategy-path` parameter to add a custom strategy path which gets checked first. Also this PR simplifies `StrategyResolver` (mostly dropping redundant code).

Relates to issue: #435

## Quick changelog

- Add `--strategy-path` parameter
- Simplify `StrategyResolver`

## What's new?

### Example usage:
```
$ mkdir -p /tmp/strategy  # create temp directory
$ cp user_data/strategies/test_strategy.py /tmp/strategy  # copy existing strategy file
$ freqtrade --strategy TestStrategy --strategy-path /tmp/strategy  # execute freqtrade with custom strategy path
2018-03-27 16:43:50,637 - freqtrade.configuration - INFO - Log level set to INFO
2018-03-27 16:43:50,638 - freqtrade.configuration - INFO - Using max_open_trades: 10 ...
2018-03-27 16:43:50,638 - freqtrade.configuration - INFO - Parameter --datadir detected: freqtrade/tests/testdata ...
2018-03-27 16:43:50,638 - freqtrade.freqtradebot - INFO - Starting freqtrade 0.16.0
2018-03-27 16:43:50,639 - freqtrade.strategy.resolver - INFO - Using resolved strategy TestStrategy from '/tmp/strategy'
2018-03-27 16:43:50,639 - freqtrade.strategy.resolver - INFO - Override strategy 'minimal_roi' with value in config file.
2018-03-27 16:43:50,639 - freqtrade.strategy.resolver - INFO - Override strategy 'stoploss' with value in config file: -0.4.
...
```
