### PR TITLE
Aggregate ticks in parse_ticker_dataframe

### DIFF
--- a/freqtrade/analyze.py
+++ b/freqtrade/analyze.py
@@ -50,6 +50,14 @@ class Analyze(object):
             .rename(columns=columns)
         if 'BV' in frame:
             frame.drop('BV', 1, inplace=True)
+        # group by date to eliminate duplicate ticks
+        frame.groupby('date').agg({
+            'volume': 'max',
+            'open': 'first',
+            'close': 'last',
+            'high': 'max',
+            'low': 'min',
+        })
         frame['date'] = to_datetime(frame['date'], utc=True, infer_datetime_format=True)
         frame.sort_values('date', inplace=True)
         return frame

--- a/freqtrade/analyze.py
+++ b/freqtrade/analyze.py
@@ -46,20 +46,20 @@ class Analyze(object):
         :return: DataFrame
         """
         columns = {'C': 'close', 'V': 'volume', 'O': 'open', 'H': 'high', 'L': 'low', 'T': 'date'}
-        frame = DataFrame(ticker) \
-            .rename(columns=columns)
+        frame = DataFrame(ticker).rename(columns=columns)
         if 'BV' in frame:
-            frame.drop('BV', 1, inplace=True)
-        # group by date to eliminate duplicate ticks
-        frame.groupby('date').agg({
-            'volume': 'max',
-            'open': 'first',
+            frame.drop('BV', axis=1, inplace=True)
+
+        frame['date'] = to_datetime(frame['date'], utc=True, infer_datetime_format=True)
+
+        # group by index and aggregate results to eliminate duplicate ticks
+        frame = frame.groupby(by='date', as_index=False, sort=True).agg({
             'close': 'last',
             'high': 'max',
             'low': 'min',
+            'open': 'first',
+            'volume': 'max',
         })
-        frame['date'] = to_datetime(frame['date'], utc=True, infer_datetime_format=True)
-        frame.sort_values('date', inplace=True)
         return frame
 
     def populate_indicators(self, dataframe: DataFrame) -> DataFrame:

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -4,11 +4,12 @@
 This module contains the backtesting logic
 """
 import logging
+import operator
 from argparse import Namespace
 from typing import Dict, Tuple, Any, List, Optional
 
 import arrow
-from pandas import DataFrame, Series
+from pandas import DataFrame
 from tabulate import tabulate
 
 import freqtrade.optimize as optimize
@@ -60,11 +61,12 @@ class Backtesting(object):
         :param data: dictionary with preprocessed backtesting data
         :return: tuple containing min_date, max_date
         """
-        all_dates = Series([])
-        for pair_data in data.values():
-            all_dates = all_dates.append(pair_data['date'])
-        all_dates.sort_values(inplace=True)
-        return arrow.get(all_dates.iloc[0]), arrow.get(all_dates.iloc[-1])
+        timeframe = [
+            (arrow.get(min(frame.date)), arrow.get(max(frame.date)))
+            for frame in data.values()
+        ]
+        return min(timeframe, key=operator.itemgetter(0))[0], \
+            max(timeframe, key=operator.itemgetter(1))[1]
 
     def _generate_text_table(self, data: Dict[str, Dict], results: DataFrame) -> str:
         """

--- a/freqtrade/tests/optimize/test_optimize.py
+++ b/freqtrade/tests/optimize/test_optimize.py
@@ -182,10 +182,11 @@ def test_download_backtesting_testdata(ticker_history, mocker) -> None:
 
 def test_download_backtesting_testdata2(mocker) -> None:
     tick = [{'T': 'bar'}, {'T': 'foo'}]
-    mocker.patch('freqtrade.misc.file_dump_json', return_value=None)
+    json_dump_mock = mocker.patch('freqtrade.misc.file_dump_json', return_value=None)
     mocker.patch('freqtrade.optimize.__init__.get_ticker_history', return_value=tick)
-    assert download_backtesting_testdata(None, pair="BTC-UNITEST", interval=1)
-    assert download_backtesting_testdata(None, pair="BTC-UNITEST", interval=3)
+    download_backtesting_testdata(None, pair="BTC-UNITEST", interval=1)
+    download_backtesting_testdata(None, pair="BTC-UNITEST", interval=3)
+    assert json_dump_mock.call_count == 2
 
 
 def test_load_tickerdata_file() -> None:

--- a/freqtrade/tests/test_analyze.py
+++ b/freqtrade/tests/test_analyze.py
@@ -50,7 +50,7 @@ def test_dataframe_correct_length(result):
 
 def test_dataframe_correct_columns(result):
     assert result.columns.tolist() == \
-        ['close', 'high', 'low', 'open', 'date', 'volume']
+        ['date', 'close', 'high', 'low', 'open', 'volume']
 
 
 def test_populates_buy_trend(result):
@@ -170,7 +170,7 @@ def test_get_signal_handles_exceptions(mocker):
 
 
 def test_parse_ticker_dataframe(ticker_history, ticker_history_without_bv):
-    columns = ['close', 'high', 'low', 'open', 'date', 'volume']
+    columns = ['date', 'close', 'high', 'low', 'open', 'volume']
 
     # Test file with BV data
     dataframe = Analyze.parse_ticker_dataframe(ticker_history)


### PR DESCRIPTION
## Summary
Aggregate ticks in `parse_ticker_dataframe` and group them by date to remove duplicates.
This should bring backtesting results slightly closer to production performance (See #477).

Solve the issue: #590

## Quick changelog

- Aggregate duplicate ticks in `parse_ticker_dataframe` and group them by date

## What's new?

Below are the backtesting results from different branches (using `ticker_interval=5`),
the feature branch did one buy less (3064 != 3065) compared to `develop`, so there are even duplicates with a low `ticker_interval`:

### Backtesting result with `feature/remove-duplicate-ticks`
```
==================================== BACKTESTING REPORT ====================================
pair       buy count    avg profit %    total profit BTC    avg duration    profit    loss
-------  -----------  --------------  ------------------  --------------  --------  ------
BTC_ETH          252            0.37          0.00929464           237.9       252       0
BTC_BCC          667           -0.08         -0.00542560           317.1       570      97
BTC_ADA          367            0.65          0.02415711           234.9       366       0
BTC_POT          131            0.56          0.00738966           275.9       131       0
BTC_PAY          320            0.60          0.01933855           268.8       317       3
BTC_CVC          327            0.49          0.01627852           214.7       321       6
BTC_LSK          495            0.43          0.02149914           349.8       495       0
BTC_XRP          378            0.35          0.01327210           311.0       378       0
BTC_MER          127           -0.12         -0.00151626           240.2       123       4
TOTAL           3064            0.34          0.10428786           284.3      2953     110
bin/freqtrade backtesting  143,55s user 1,03s system 100% cpu 2:24,09 total
```

### Backtesting result with `develop`
```
==================================== BACKTESTING REPORT ====================================
pair       buy count    avg profit %    total profit BTC    avg duration    profit    loss
-------  -----------  --------------  ------------------  --------------  --------  ------
BTC_ETH          252            0.37          0.00929464           237.9       252       0
BTC_BCC          667           -0.08         -0.00549960           317.1       570      97
BTC_ADA          367            0.65          0.02415711           234.9       366       0
BTC_POT          131            0.56          0.00738966           275.9       131       0
BTC_PAY          320            0.60          0.01933855           268.8       317       3
BTC_CVC          327            0.49          0.01627852           214.7       321       6
BTC_LSK          495            0.43          0.02149914           349.8       495       0
BTC_XRP          379            0.35          0.01330272           310.3       379       0
BTC_MER          127           -0.12         -0.00151626           240.2       123       4
TOTAL           3065            0.34          0.10424448           284.3      2954     110
bin/freqtrade backtesting  142,40s user 1,02s system 100% cpu 2:22,93 total
```