### PR TITLE
Disable dynamic whitelist if not specified

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -114,10 +114,7 @@ class FreqtradeBot(object):
                 Constants.PROCESS_THROTTLE_SECS
             )
 
-            nb_assets = self.config.get(
-                'dynamic_whitelist',
-                Constants.DYNAMIC_WHITELIST
-            )
+            nb_assets = self.config.get('dynamic_whitelist', None)
 
             self._throttle(func=self._process,
                            min_secs=min_secs,


### PR DESCRIPTION
## Summary
Revert regression introduced in refactoring for objectify related to dynamic whitelist - which enables this by default without possibility to Disable dynamic whitelist.

## Quick changelog
- Disable dynamic whitelist if not specified in comand line

### reproduce
run freqtrade with a config with only one Asset in whitelist (without parameter --dynamic-whitelist) still uses dynamic-whitelist with a default of 20.

### new behaviour
* Running freqtrade without `--dynamic-whitelist` disables dynamic whitelisting and only uses the assets specified in the configuration.
* Running freqtrade with `--dynamic-whitelist` defaults to 20 assets (as previously)
* Running freqtrade with `--dynamic-whitelist 5` runs with 5 assets (as before objectify).