### PR TITLE
Conversion script for Ticker history data

### DIFF
--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -5,6 +5,7 @@ Various tool function for Freqtrade and scripts
 import json
 import logging
 import re
+import gzip
 from datetime import datetime
 from typing import Dict
 
@@ -63,15 +64,21 @@ def common_datearray(dfs: Dict[str, DataFrame]) -> np.ndarray:
     return np.sort(arr, axis=0)
 
 
-def file_dump_json(filename, data) -> None:
+def file_dump_json(filename, data, is_zip=False) -> None:
     """
     Dump JSON data into a file
     :param filename: file to create
     :param data: JSON Data to save
     :return:
     """
-    with open(filename, 'w') as fp:
-        json.dump(data, fp, default=str)
+    if not is_zip:
+        with open(filename, 'w') as fp:
+            json.dump(data, fp, default=str)
+    else:
+        if not filename.endswith('.gz'):
+            filename = filename + '.gz'
+        with gzip.open(filename, 'w') as fp:
+            json.dump(data, fp, default=str)
 
 
 def format_ms_time(date: str) -> str:

--- a/freqtrade/misc.py
+++ b/freqtrade/misc.py
@@ -71,13 +71,13 @@ def file_dump_json(filename, data, is_zip=False) -> None:
     :param data: JSON Data to save
     :return:
     """
-    if not is_zip:
-        with open(filename, 'w') as fp:
-            json.dump(data, fp, default=str)
-    else:
+    if is_zip:
         if not filename.endswith('.gz'):
             filename = filename + '.gz'
         with gzip.open(filename, 'w') as fp:
+            json.dump(data, fp, default=str)
+    else:
+        with open(filename, 'w') as fp:
             json.dump(data, fp, default=str)
 
 

--- a/freqtrade/tests/test_misc.py
+++ b/freqtrade/tests/test_misc.py
@@ -71,3 +71,8 @@ def test_file_dump_json(mocker) -> None:
     file_dump_json('somefile', [1, 2, 3])
     assert file_open.call_count == 1
     assert json_dump.call_count == 1
+    file_open = mocker.patch('freqtrade.misc.gzip.open', MagicMock())
+    json_dump = mocker.patch('json.dump', MagicMock())
+    file_dump_json('somefile', [1, 2, 3], True)
+    assert file_open.call_count == 1
+    assert json_dump.call_count == 1

--- a/scripts/convert_backtestdata.py
+++ b/scripts/convert_backtestdata.py
@@ -27,7 +27,7 @@ from pandas import DataFrame
 
 import dateutil.parser
 
-logger = Logger(name="Convert data", level=10).get_logger()
+logger = Logger(name="freqtrade").get_logger()
 
 
 def load_old_file(filename) -> (List[Dict], bool):

--- a/scripts/convert_backtestdata.py
+++ b/scripts/convert_backtestdata.py
@@ -84,9 +84,8 @@ def convert_dataframe(frame: DataFrame):
     return list(list(x) for x in zip(*by_column))
 
 
-
 def convert_file(filename: str, filename_new: str):
-    """Converts a file following the old format to the new format"""
+    """Converts a file from old format to ccxt format"""
     pairdata = load_old_file(filename)
     if pairdata and type(pairdata) is list and len(pairdata) > 0:
         if type(pairdata[0]) is list:

--- a/scripts/convert_backtestdata.py
+++ b/scripts/convert_backtestdata.py
@@ -69,7 +69,9 @@ def parse_old_backtest_data(ticker) -> DataFrame:
         .rename(columns=columns)
     if 'BV' in frame:
         frame.drop('BV', 1, inplace=True)
-
+    if not 'date' in frame:
+        logger.warning("Date not in frame - probably not a Ticker file")
+        return None
     frame.sort_values('date', inplace=True)
     return frame
 
@@ -98,8 +100,9 @@ def convert_file(filename: str, filename_new: str):
 
     frame = parse_old_backtest_data(pairdata)
     # Convert frame to new format
-    frame1 = convert_dataframe(frame)
-    misc.file_dump_json(filename_new, frame1, is_zip)
+    if frame is not None:
+        frame1 = convert_dataframe(frame)
+        misc.file_dump_json(filename_new, frame1, is_zip)
 
 
 def convert_main(args: Namespace) -> None:

--- a/scripts/convert_backtestdata.py
+++ b/scripts/convert_backtestdata.py
@@ -90,13 +90,13 @@ def convert_dataframe(frame: DataFrame):
     return list(list(x) for x in zip(*by_column))
 
 
-def convert_file(filename: str, filename_new: str):
+def convert_file(filename: str, filename_new: str) -> None:
     """Converts a file from old format to ccxt format"""
     (pairdata, is_zip) = load_old_file(filename)
-    if pairdata and type(pairdata) is list and len(pairdata) > 0:
+    if pairdata and type(pairdata) is list:
         if type(pairdata[0]) is list:
             logger.error("pairdata for %s already in new format", filename)
-            return 1
+            return
 
     frame = parse_old_backtest_data(pairdata)
     # Convert frame to new format

--- a/scripts/convert_backtestdata.py
+++ b/scripts/convert_backtestdata.py
@@ -110,7 +110,7 @@ def convert_main(args: Namespace) -> None:
     converts a folder given in --datadir from old to new format to support ccxt
     """
 
-    workdir = args.datadir if args.datadir.endswith("/") else args.datadir + "/"
+    workdir = path.join(args.datadir, "")
     logger.info("Workdir: %s", workdir)
 
     for filename in glob.glob(workdir + "*.json"):
@@ -135,10 +135,10 @@ def convert_main(args: Namespace) -> None:
                 logger.warning("file %s could not be converted, interval not found", filename)
                 continue
             interval = ret.group(0)
-            # filename = "user_data/data/BTC_ADA-5.json"
-            # filename_new = "user_data/data/ADA_BTC-5.json"
-            filename_new = "{}/{}_{}-{}.json".format(path.dirname(filename),
-                                                     currencies[1], currencies[0], interval)
+
+            filename_new = path.join(path.dirname(filename),
+                                     "{}_{}-{}.json".format(currencies[1],
+                                                            currencies[0], interval))
         logger.debug("Converting and renaming %s to %s", filename, filename_new)
         convert_file(filename, filename_new)
 


### PR DESCRIPTION
## Summary
Add conversion script for Ticker history from bittrex to ccxt format


## Quick changelog

- add conversion script
- add handling for gzip files in file_dump_json (could be useful in other places, when downloading longer history maybe)

Tests are expected to fail, as work on ccxt is ongoing.