### PR TITLE
use local config-object for check_exchange (fixes Nonetype Attribute error when starting the bot)

### DIFF
--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -102,7 +102,7 @@ class Configuration(object):
                 self.logger.info('Dry run is disabled. (--dry_run_db ignored)')
 
         # Check if the exchange set by the user is supported
-        self.check_exchange()
+        self.check_exchange(config)
 
         return config
 
@@ -203,12 +203,12 @@ class Configuration(object):
 
         return self.config
 
-    def check_exchange(self) -> bool:
+    def check_exchange(self, config: Dict[str, Any]) -> bool:
         """
         Check if the exchange name in the config file is supported by Freqtrade
         :return: True or raised an exception if the exchange if not supported
         """
-        exchange = self.config.get('exchange', {}).get('name').lower()
+        exchange = config.get('exchange', {}).get('name').lower()
         if exchange not in ccxt.exchanges:
 
             exception_msg = 'Exchange "{}" not supported.\n' \

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -326,13 +326,11 @@ def test_check_exchange(default_conf) -> None:
 
     # Test a valid exchange
     conf.get('exchange').update({'name': 'BITTREX'})
-    configuration.config = conf
-    assert configuration.check_exchange()
+    assert configuration.check_exchange(conf)
 
     # Test a valid exchange
     conf.get('exchange').update({'name': 'binance'})
-    configuration.config = conf
-    assert configuration.check_exchange()
+    assert configuration.check_exchange(conf)
 
     # Test a invalid exchange
     conf.get('exchange').update({'name': 'unknown_exchange'})
@@ -342,4 +340,4 @@ def test_check_exchange(default_conf) -> None:
         OperationalException,
         match=r'.*Exchange "unknown_exchange" not supported.*'
     ):
-        configuration.check_exchange()
+        configuration.check_exchange(conf)


### PR DESCRIPTION
## Summary
Fix check_exchange_supported

## Quick changelog

* fixes new feature introduced in 052404ffbd36d9754d824af3211e3f9247997396, which caused an Exception as the class-object (self.config) is not yet loaded.


## Notes:
* Tests will not pass in this branch yet
* not sure if the function shouldn't be made private as it's only used from within the Class.