### PR TITLE
Fix tests run in random order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
 install:
 - ./install_ta-lib.sh
 - export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-- pip install --upgrade flake8 coveralls
+- pip install --upgrade flake8 coveralls pytest-random-order
 - pip install -r requirements.txt
 - pip install -e .
 jobs:

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -46,7 +46,7 @@ def get_patched_freqtradebot(mocker, config) -> FreqtradeBot:
     return FreqtradeBot(config, create_engine('sqlite://'))
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def default_conf():
     """ Returns validated configuration suitable for most tests """
     configuration = {

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -16,9 +16,9 @@ from freqtrade.tests.conftest import log_has
 API_INIT = False
 
 
-def maybe_init_api(conf, mocker):
+def maybe_init_api(conf, mocker, force=False):
     global API_INIT
-    if not API_INIT:
+    if force or not API_INIT:
         mocker.patch('freqtrade.exchange.validate_pairs',
                      side_effect=lambda s: True)
         init(config=conf)
@@ -27,7 +27,7 @@ def maybe_init_api(conf, mocker):
 
 def test_init(default_conf, mocker, caplog):
     caplog.set_level(logging.INFO)
-    maybe_init_api(default_conf, mocker)
+    maybe_init_api(default_conf, mocker, True)
     assert log_has('Instance is running with dry_run enabled', caplog.record_tuples)
 
 

--- a/freqtrade/tests/test_fiat_convert.py
+++ b/freqtrade/tests/test_fiat_convert.py
@@ -126,8 +126,10 @@ def test_fiat_convert_get_price(mocker):
 
 def test_fiat_convert_without_network():
     # Because CryptoToFiatConverter is a Singleton we reset the value of _coinmarketcap
-    CryptoToFiatConverter._coinmarketcap = None
 
     fiat_convert = CryptoToFiatConverter()
+
+    CryptoToFiatConverter._coinmarketcap = None
+
     assert fiat_convert._coinmarketcap is None
     assert fiat_convert._find_price(crypto_symbol='BTC', fiat_symbol='USD') == 0.0

--- a/freqtrade/tests/test_persistence.py
+++ b/freqtrade/tests/test_persistence.py
@@ -7,6 +7,9 @@ from sqlalchemy import create_engine
 from freqtrade.exchange import Exchanges
 from freqtrade.persistence import Trade, init, clean_dry_run_db
 
+@pytest.fixture(scope='function')
+def init_persistence(default_conf):
+    init(default_conf)
 
 def test_init_create_session(default_conf, mocker):
     mocker.patch.dict('freqtrade.persistence._CONF', default_conf)
@@ -90,7 +93,7 @@ def test_init_prod_db(default_conf, mocker):
         os.rename(prod_db_swp, prod_db)
 
 
-def test_update_with_bittrex(limit_buy_order, limit_sell_order):
+def test_update_with_bittrex(init_persistence, limit_buy_order, limit_sell_order):
     """
     On this test we will buy and sell a crypto currency.
 
@@ -144,7 +147,7 @@ def test_update_with_bittrex(limit_buy_order, limit_sell_order):
     assert trade.close_date is not None
 
 
-def test_calc_open_close_trade_price(limit_buy_order, limit_sell_order):
+def test_calc_open_close_trade_price(init_persistence, limit_buy_order, limit_sell_order):
     trade = Trade(
         pair='BTC_ETH',
         stake_amount=0.001,
@@ -166,7 +169,7 @@ def test_calc_open_close_trade_price(limit_buy_order, limit_sell_order):
     assert trade.calc_profit_percent() == 0.06201057
 
 
-def test_calc_close_trade_price_exception(limit_buy_order):
+def test_calc_close_trade_price_exception(init_persistence, limit_buy_order):
     trade = Trade(
         pair='BTC_ETH',
         stake_amount=0.001,
@@ -179,7 +182,7 @@ def test_calc_close_trade_price_exception(limit_buy_order):
     assert trade.calc_close_trade_price() == 0.0
 
 
-def test_update_open_order(limit_buy_order):
+def test_update_open_order(init_persistence, limit_buy_order):
     trade = Trade(
         pair='BTC_ETH',
         stake_amount=1.00,
@@ -201,7 +204,7 @@ def test_update_open_order(limit_buy_order):
     assert trade.close_date is None
 
 
-def test_update_invalid_order(limit_buy_order):
+def test_update_invalid_order(init_persistence, limit_buy_order):
     trade = Trade(
         pair='BTC_ETH',
         stake_amount=1.00,
@@ -213,7 +216,7 @@ def test_update_invalid_order(limit_buy_order):
         trade.update(limit_buy_order)
 
 
-def test_calc_open_trade_price(limit_buy_order):
+def test_calc_open_trade_price(init_persistence, limit_buy_order):
     trade = Trade(
         pair='BTC_ETH',
         stake_amount=0.001,
@@ -230,7 +233,7 @@ def test_calc_open_trade_price(limit_buy_order):
     assert trade.calc_open_trade_price(fee=0.003) == 0.001003000
 
 
-def test_calc_close_trade_price(limit_buy_order, limit_sell_order):
+def test_calc_close_trade_price(init_persistence, limit_buy_order, limit_sell_order):
     trade = Trade(
         pair='BTC_ETH',
         stake_amount=0.001,
@@ -251,7 +254,7 @@ def test_calc_close_trade_price(limit_buy_order, limit_sell_order):
     assert trade.calc_close_trade_price(fee=0.005) == 0.0010619972
 
 
-def test_calc_profit(limit_buy_order, limit_sell_order):
+def test_calc_profit(init_persistence, limit_buy_order, limit_sell_order):
     trade = Trade(
         pair='BTC_ETH',
         stake_amount=0.001,
@@ -281,7 +284,7 @@ def test_calc_profit(limit_buy_order, limit_sell_order):
     assert trade.calc_profit(fee=0.003) == 0.00006163
 
 
-def test_calc_profit_percent(limit_buy_order, limit_sell_order):
+def test_calc_profit_percent(init_persistence, limit_buy_order, limit_sell_order):
     trade = Trade(
         pair='BTC_ETH',
         stake_amount=0.001,

--- a/freqtrade/tests/test_persistence.py
+++ b/freqtrade/tests/test_persistence.py
@@ -95,7 +95,8 @@ def test_init_prod_db(default_conf, mocker):
         os.rename(prod_db_swp, prod_db)
 
 
-def test_update_with_bittrex(init_persistence, limit_buy_order, limit_sell_order):
+@pytest.mark.usefixtures("init_persistence")
+def test_update_with_bittrex(limit_buy_order, limit_sell_order):
     """
     On this test we will buy and sell a crypto currency.
 
@@ -149,7 +150,8 @@ def test_update_with_bittrex(init_persistence, limit_buy_order, limit_sell_order
     assert trade.close_date is not None
 
 
-def test_calc_open_close_trade_price(init_persistence, limit_buy_order, limit_sell_order):
+@pytest.mark.usefixtures("init_persistence")
+def test_calc_open_close_trade_price(limit_buy_order, limit_sell_order):
     trade = Trade(
         pair='BTC_ETH',
         stake_amount=0.001,
@@ -171,7 +173,8 @@ def test_calc_open_close_trade_price(init_persistence, limit_buy_order, limit_se
     assert trade.calc_profit_percent() == 0.06201057
 
 
-def test_calc_close_trade_price_exception(init_persistence, limit_buy_order):
+@pytest.mark.usefixtures("init_persistence")
+def test_calc_close_trade_price_exception(limit_buy_order):
     trade = Trade(
         pair='BTC_ETH',
         stake_amount=0.001,
@@ -184,7 +187,8 @@ def test_calc_close_trade_price_exception(init_persistence, limit_buy_order):
     assert trade.calc_close_trade_price() == 0.0
 
 
-def test_update_open_order(init_persistence, limit_buy_order):
+@pytest.mark.usefixtures("init_persistence")
+def test_update_open_order(limit_buy_order):
     trade = Trade(
         pair='BTC_ETH',
         stake_amount=1.00,
@@ -206,7 +210,8 @@ def test_update_open_order(init_persistence, limit_buy_order):
     assert trade.close_date is None
 
 
-def test_update_invalid_order(init_persistence, limit_buy_order):
+@pytest.mark.usefixtures("init_persistence")
+def test_update_invalid_order(limit_buy_order):
     trade = Trade(
         pair='BTC_ETH',
         stake_amount=1.00,
@@ -218,7 +223,8 @@ def test_update_invalid_order(init_persistence, limit_buy_order):
         trade.update(limit_buy_order)
 
 
-def test_calc_open_trade_price(init_persistence, limit_buy_order):
+@pytest.mark.usefixtures("init_persistence")
+def test_calc_open_trade_price(limit_buy_order):
     trade = Trade(
         pair='BTC_ETH',
         stake_amount=0.001,
@@ -235,7 +241,8 @@ def test_calc_open_trade_price(init_persistence, limit_buy_order):
     assert trade.calc_open_trade_price(fee=0.003) == 0.001003000
 
 
-def test_calc_close_trade_price(init_persistence, limit_buy_order, limit_sell_order):
+@pytest.mark.usefixtures("init_persistence")
+def test_calc_close_trade_price(limit_buy_order, limit_sell_order):
     trade = Trade(
         pair='BTC_ETH',
         stake_amount=0.001,
@@ -256,7 +263,8 @@ def test_calc_close_trade_price(init_persistence, limit_buy_order, limit_sell_or
     assert trade.calc_close_trade_price(fee=0.005) == 0.0010619972
 
 
-def test_calc_profit(init_persistence, limit_buy_order, limit_sell_order):
+@pytest.mark.usefixtures("init_persistence")
+def test_calc_profit(limit_buy_order, limit_sell_order):
     trade = Trade(
         pair='BTC_ETH',
         stake_amount=0.001,
@@ -286,7 +294,8 @@ def test_calc_profit(init_persistence, limit_buy_order, limit_sell_order):
     assert trade.calc_profit(fee=0.003) == 0.00006163
 
 
-def test_calc_profit_percent(init_persistence, limit_buy_order, limit_sell_order):
+@pytest.mark.usefixtures("init_persistence")
+def test_calc_profit_percent(limit_buy_order, limit_sell_order):
     trade = Trade(
         pair='BTC_ETH',
         stake_amount=0.001,

--- a/freqtrade/tests/test_persistence.py
+++ b/freqtrade/tests/test_persistence.py
@@ -7,9 +7,11 @@ from sqlalchemy import create_engine
 from freqtrade.exchange import Exchanges
 from freqtrade.persistence import Trade, init, clean_dry_run_db
 
+
 @pytest.fixture(scope='function')
 def init_persistence(default_conf):
     init(default_conf)
+
 
 def test_init_create_session(default_conf, mocker):
     mocker.patch.dict('freqtrade.persistence._CONF', default_conf)


### PR DESCRIPTION
## Summary
Allow test-execution to be randomized - Tests should be independent, without breaking if the order is different.

## What's new?
* Tests don't fail when run multiple times having `pytest-random-order` installed.
Before this PR, tests do fail at a random rate (depending on which tests run first).

Execution time is slightly higher (~6.4s vs. 5.7s from before) - however i think the benefit of beeing able to run tests in any order outweights the 0.7s delay.

I'm not familiar enough with TravisCI (and did not find anything obvious in google) to know if there is a setting to enable random execution, or if `pytest-random-order` should be in the requirements file so Travis randomizes tests.
