### PR TITLE
Write logs when trying to sell opened trades

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -378,7 +378,7 @@ class FreqtradeBot(object):
         if self.analyze.should_sell(trade, current_rate, datetime.utcnow(), buy, sell):
             self.execute_sell(trade, current_rate)
             return True
-
+        logger.info('Found no sell signals for whitelisted currencies. Trying again..')
         return False
 
     def check_handle_timedout(self, timeoutvalue: int) -> None:


### PR DESCRIPTION
## Summary
The bot doesn't write any log when there are only trades ready to be sold, so in my case I was monitoring the logs and I thought that the bot had stopped working.

## Quick changelog

- Write logs when trying to sell trades 
