### PR TITLE
let ccxt handle rate limits internally

### DIFF
--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -73,6 +73,7 @@ def init(config: dict) -> None:
             'secret': exchange_config.get('secret'),
             'password': exchange_config.get('password'),
             'uid': exchange_config.get('uid'),
+            'enableRateLimit': True,
         })
     except (KeyError, AttributeError):
         raise OperationalException('Exchange {} is not supported'.format(name))


### PR DESCRIPTION
## Summary
Pass `enableRateLimit: True` to ccxt constructor to avoid hitting exchange rate limits.
Fixes open TODO from #603, previous discussion: #585


## Quick changelog

- Let cctx handle rate limits internally