### PR TITLE
add mocks for exchange.get_fee

### DIFF
--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -450,10 +450,12 @@ def test_backtesting_start(default_conf, mocker, caplog) -> None:
         assert log_has(line, caplog.record_tuples)
 
 
-def test_backtest(init_backtesting, default_conf) -> None:
+def test_backtest(init_backtesting, default_conf, fee, mocker) -> None:
     """
     Test Backtesting.backtest() method
     """
+    mocker.patch('freqtrade.exchange.get_fee', fee)
+
     backtesting = _BACKTESTING
 
     data = optimize.load_data(None, ticker_interval='5m', pairs=['UNITTEST/BTC'])
@@ -469,10 +471,12 @@ def test_backtest(init_backtesting, default_conf) -> None:
     assert not results.empty
 
 
-def test_backtest_1min_ticker_interval(init_backtesting, default_conf) -> None:
+def test_backtest_1min_ticker_interval(init_backtesting, default_conf, fee, mocker) -> None:
     """
     Test Backtesting.backtest() method with 1 min ticker
     """
+    mocker.patch('freqtrade.exchange.get_fee', fee)
+
     backtesting = _BACKTESTING
 
     # Run a backtesting for an exiting 5min ticker_interval
@@ -513,10 +517,11 @@ def test_backtest_pricecontours(init_backtesting, default_conf, fee, mocker) -> 
 
 
 # Test backtest using offline data (testdata directory)
-def test_backtest_ticks(init_backtesting, default_conf):
+def test_backtest_ticks(init_backtesting, default_conf, fee, mocker):
+    mocker.patch('freqtrade.exchange.get_fee', fee)
     ticks = [1, 5]
     fun = _BACKTESTING.populate_buy_trend
-    for tick in ticks:
+    for _ in ticks:
         backtest_conf = _make_backtest_conf(conf=default_conf)
         results = _run_backtest_1(fun, backtest_conf)
         assert not results.empty

--- a/freqtrade/tests/rpc/test_rpc.py
+++ b/freqtrade/tests/rpc/test_rpc.py
@@ -391,7 +391,7 @@ def test_rpc_stop(mocker, default_conf) -> None:
     assert freqtradebot.state == State.STOPPED
 
 
-def test_rpc_forcesell(default_conf, ticker, mocker) -> None:
+def test_rpc_forcesell(default_conf, ticker, fee, mocker) -> None:
     """
     Test rpc_forcesell() method
     """
@@ -411,7 +411,8 @@ def test_rpc_forcesell(default_conf, ticker, mocker) -> None:
                 'type': 'limit',
                 'side': 'buy'
             }
-        )
+        ),
+        get_fee=fee,
     )
 
     freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
@@ -524,7 +525,7 @@ def test_performance_handle(default_conf, ticker, limit_buy_order, fee,
     assert prec_satoshi(res[0]['profit'], 6.2)
 
 
-def test_rpc_count(mocker, default_conf, ticker) -> None:
+def test_rpc_count(mocker, default_conf, ticker, fee) -> None:
     """
     Test rpc_count() method
     """
@@ -535,7 +536,8 @@ def test_rpc_count(mocker, default_conf, ticker) -> None:
         'freqtrade.freqtradebot.exchange',
         validate_pairs=MagicMock(),
         get_balances=MagicMock(return_value=ticker),
-        get_ticker=ticker
+        get_ticker=ticker,
+        get_fee=fee,
     )
 
     freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -234,7 +234,7 @@ def test_authorized_only_exception(default_conf, mocker, caplog) -> None:
     )
 
 
-def test_status(default_conf, update, mocker, ticker) -> None:
+def test_status(default_conf, update, mocker, fee, ticker) -> None:
     """
     Test _status() method
     """
@@ -249,7 +249,8 @@ def test_status(default_conf, update, mocker, ticker) -> None:
         'freqtrade.freqtradebot.exchange',
         validate_pairs=MagicMock(),
         get_ticker=ticker,
-        get_pair_detail_url=MagicMock()
+        get_pair_detail_url=MagicMock(),
+        get_fee=fee,
     )
     msg_mock = MagicMock()
     status_table = MagicMock()
@@ -278,7 +279,7 @@ def test_status(default_conf, update, mocker, ticker) -> None:
     assert status_table.call_count == 1
 
 
-def test_status_handle(default_conf, update, ticker, mocker) -> None:
+def test_status_handle(default_conf, update, ticker, fee, mocker) -> None:
     """
     Test _status() method
     """
@@ -287,7 +288,8 @@ def test_status_handle(default_conf, update, ticker, mocker) -> None:
     mocker.patch.multiple(
         'freqtrade.freqtradebot.exchange',
         validate_pairs=MagicMock(),
-        get_ticker=ticker
+        get_ticker=ticker,
+        get_fee=fee,
     )
     msg_mock = MagicMock()
     status_table = MagicMock()
@@ -323,7 +325,7 @@ def test_status_handle(default_conf, update, ticker, mocker) -> None:
     assert '[ETH/BTC]' in msg_mock.call_args_list[0][0][0]
 
 
-def test_status_table_handle(default_conf, update, ticker, mocker) -> None:
+def test_status_table_handle(default_conf, update, ticker, fee, mocker) -> None:
     """
     Test _status_table() method
     """
@@ -333,7 +335,8 @@ def test_status_table_handle(default_conf, update, ticker, mocker) -> None:
         'freqtrade.freqtradebot.exchange',
         validate_pairs=MagicMock(),
         get_ticker=ticker,
-        buy=MagicMock(return_value={'id': 'mocked_order_id'})
+        buy=MagicMock(return_value={'id': 'mocked_order_id'}),
+        get_fee=fee,
     )
     msg_mock = MagicMock()
     mocker.patch.multiple(
@@ -976,7 +979,7 @@ def test_performance_handle_invalid(default_conf, update, mocker) -> None:
     assert 'not running' in msg_mock.call_args_list[0][0][0]
 
 
-def test_count_handle(default_conf, update, ticker, mocker) -> None:
+def test_count_handle(default_conf, update, ticker, fee, mocker) -> None:
     """
     Test _count() method
     """
@@ -994,6 +997,7 @@ def test_count_handle(default_conf, update, ticker, mocker) -> None:
         get_ticker=ticker,
         buy=MagicMock(return_value={'id': 'mocked_order_id'})
     )
+    mocker.patch('freqtrade.optimize.backtesting.exchange.get_fee', fee)
     freqtradebot = FreqtradeBot(default_conf, create_engine('sqlite://'))
     telegram = Telegram(freqtradebot)
 

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -235,7 +235,7 @@ def test_refresh_whitelist() -> None:
     pass
 
 
-def test_create_trade(default_conf, ticker, limit_buy_order, mocker) -> None:
+def test_create_trade(default_conf, ticker, limit_buy_order, fee, mocker) -> None:
     """
     Test create_trade() method
     """
@@ -246,7 +246,8 @@ def test_create_trade(default_conf, ticker, limit_buy_order, mocker) -> None:
         'freqtrade.freqtradebot.exchange',
         validate_pairs=MagicMock(),
         get_ticker=ticker,
-        buy=MagicMock(return_value={'id': limit_buy_order['id']})
+        buy=MagicMock(return_value={'id': limit_buy_order['id']}),
+        get_fee=fee,
     )
 
     # Save state of current whitelist
@@ -270,7 +271,7 @@ def test_create_trade(default_conf, ticker, limit_buy_order, mocker) -> None:
     assert whitelist == default_conf['exchange']['pair_whitelist']
 
 
-def test_create_trade_minimal_amount(default_conf, ticker, limit_buy_order, mocker) -> None:
+def test_create_trade_minimal_amount(default_conf, ticker, limit_buy_order, fee, mocker) -> None:
     """
     Test create_trade() method
     """
@@ -282,7 +283,8 @@ def test_create_trade_minimal_amount(default_conf, ticker, limit_buy_order, mock
         'freqtrade.freqtradebot.exchange',
         validate_pairs=MagicMock(),
         get_ticker=ticker,
-        buy=buy_mock
+        buy=buy_mock,
+        get_fee=fee,
     )
 
     conf = deepcopy(default_conf)
@@ -294,7 +296,7 @@ def test_create_trade_minimal_amount(default_conf, ticker, limit_buy_order, mock
     assert rate * amount >= conf['stake_amount']
 
 
-def test_create_trade_no_stake_amount(default_conf, ticker, limit_buy_order, mocker) -> None:
+def test_create_trade_no_stake_amount(default_conf, ticker, limit_buy_order, fee, mocker) -> None:
     """
     Test create_trade() method
     """
@@ -306,7 +308,8 @@ def test_create_trade_no_stake_amount(default_conf, ticker, limit_buy_order, moc
         validate_pairs=MagicMock(),
         get_ticker=ticker,
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
-        get_balance=MagicMock(return_value=default_conf['stake_amount'] * 0.5)
+        get_balance=MagicMock(return_value=default_conf['stake_amount'] * 0.5),
+        get_fee=fee,
     )
     freqtrade = FreqtradeBot(default_conf, create_engine('sqlite://'))
 
@@ -314,7 +317,7 @@ def test_create_trade_no_stake_amount(default_conf, ticker, limit_buy_order, moc
         freqtrade.create_trade()
 
 
-def test_create_trade_no_pairs(default_conf, ticker, limit_buy_order, mocker) -> None:
+def test_create_trade_no_pairs(default_conf, ticker, limit_buy_order, fee, mocker) -> None:
     """
     Test create_trade() method
     """
@@ -325,7 +328,8 @@ def test_create_trade_no_pairs(default_conf, ticker, limit_buy_order, mocker) ->
         'freqtrade.freqtradebot.exchange',
         validate_pairs=MagicMock(),
         get_ticker=ticker,
-        buy=MagicMock(return_value={'id': limit_buy_order['id']})
+        buy=MagicMock(return_value={'id': limit_buy_order['id']}),
+        get_fee=fee,
     )
 
     conf = deepcopy(default_conf)
@@ -340,7 +344,7 @@ def test_create_trade_no_pairs(default_conf, ticker, limit_buy_order, mocker) ->
 
 
 def test_create_trade_no_pairs_after_blacklist(default_conf, ticker,
-                                               limit_buy_order, mocker) -> None:
+                                               limit_buy_order, fee, mocker) -> None:
     """
     Test create_trade() method
     """
@@ -351,7 +355,8 @@ def test_create_trade_no_pairs_after_blacklist(default_conf, ticker,
         'freqtrade.freqtradebot.exchange',
         validate_pairs=MagicMock(),
         get_ticker=ticker,
-        buy=MagicMock(return_value={'id': limit_buy_order['id']})
+        buy=MagicMock(return_value={'id': limit_buy_order['id']}),
+        get_fee=fee,
     )
 
     conf = deepcopy(default_conf)
@@ -365,7 +370,7 @@ def test_create_trade_no_pairs_after_blacklist(default_conf, ticker,
         freqtrade.create_trade()
 
 
-def test_create_trade_no_signal(default_conf, mocker) -> None:
+def test_create_trade_no_signal(default_conf, fee, mocker) -> None:
     """
     Test create_trade() method
     """
@@ -379,7 +384,8 @@ def test_create_trade_no_signal(default_conf, mocker) -> None:
         'freqtrade.freqtradebot.exchange',
         validate_pairs=MagicMock(),
         get_ticker_history=MagicMock(return_value=20),
-        get_balance=MagicMock(return_value=20)
+        get_balance=MagicMock(return_value=20),
+        get_fee=fee,
     )
 
     conf = deepcopy(default_conf)
@@ -392,7 +398,7 @@ def test_create_trade_no_signal(default_conf, mocker) -> None:
 
 
 def test_process_trade_creation(default_conf, ticker, limit_buy_order,
-                                markets, mocker, caplog) -> None:
+                                markets, fee, mocker, caplog) -> None:
     """
     Test the trade creation in _process() method
     """
@@ -405,7 +411,8 @@ def test_process_trade_creation(default_conf, ticker, limit_buy_order,
         get_ticker=ticker,
         get_markets=markets,
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
-        get_order=MagicMock(return_value=limit_buy_order)
+        get_order=MagicMock(return_value=limit_buy_order),
+        get_fee=fee,
     )
     freqtrade = FreqtradeBot(default_conf, create_engine('sqlite://'))
 
@@ -477,7 +484,8 @@ def test_process_operational_exception(default_conf, ticker, markets, mocker) ->
     assert 'OperationalException' in msg_mock.call_args_list[-1][0][0]
 
 
-def test_process_trade_handling(default_conf, ticker, limit_buy_order, markets, mocker) -> None:
+def test_process_trade_handling(
+        default_conf, ticker, limit_buy_order, markets, fee, mocker) -> None:
     """
     Test _process()
     """
@@ -490,7 +498,8 @@ def test_process_trade_handling(default_conf, ticker, limit_buy_order, markets, 
         get_ticker=ticker,
         get_markets=markets,
         buy=MagicMock(return_value={'id': limit_buy_order['id']}),
-        get_order=MagicMock(return_value=limit_buy_order)
+        get_order=MagicMock(return_value=limit_buy_order),
+        get_fee=fee,
     )
     freqtrade = FreqtradeBot(default_conf, create_engine('sqlite://'))
 
@@ -621,7 +630,7 @@ def test_handle_trade(default_conf, limit_buy_order, limit_sell_order, fee, mock
     assert trade.close_date is not None
 
 
-def test_handle_overlpapping_signals(default_conf, ticker, limit_buy_order, mocker) -> None:
+def test_handle_overlpapping_signals(default_conf, ticker, limit_buy_order, fee, mocker) -> None:
     """
     Test check_handle() method
     """
@@ -636,7 +645,8 @@ def test_handle_overlpapping_signals(default_conf, ticker, limit_buy_order, mock
         'freqtrade.freqtradebot.exchange',
         validate_pairs=MagicMock(),
         get_ticker=ticker,
-        buy=MagicMock(return_value={'id': limit_buy_order['id']})
+        buy=MagicMock(return_value={'id': limit_buy_order['id']}),
+        get_fee=fee,
     )
 
     freqtrade = FreqtradeBot(conf, create_engine('sqlite://'))
@@ -678,7 +688,7 @@ def test_handle_overlpapping_signals(default_conf, ticker, limit_buy_order, mock
     assert freqtrade.handle_trade(trades[0]) is True
 
 
-def test_handle_trade_roi(default_conf, ticker, limit_buy_order, mocker, caplog) -> None:
+def test_handle_trade_roi(default_conf, ticker, limit_buy_order, fee, mocker, caplog) -> None:
     """
     Test check_handle() method
     """
@@ -693,7 +703,8 @@ def test_handle_trade_roi(default_conf, ticker, limit_buy_order, mocker, caplog)
         'freqtrade.freqtradebot.exchange',
         validate_pairs=MagicMock(),
         get_ticker=ticker,
-        buy=MagicMock(return_value={'id': limit_buy_order['id']})
+        buy=MagicMock(return_value={'id': limit_buy_order['id']}),
+        get_fee=fee,
     )
 
     mocker.patch('freqtrade.freqtradebot.Analyze.min_roi_reached', return_value=True)
@@ -713,7 +724,8 @@ def test_handle_trade_roi(default_conf, ticker, limit_buy_order, mocker, caplog)
     assert log_has('Required profit reached. Selling..', caplog.record_tuples)
 
 
-def test_handle_trade_experimental(default_conf, ticker, limit_buy_order, mocker, caplog) -> None:
+def test_handle_trade_experimental(
+        default_conf, ticker, limit_buy_order, fee, mocker, caplog) -> None:
     """
     Test check_handle() method
     """
@@ -728,7 +740,8 @@ def test_handle_trade_experimental(default_conf, ticker, limit_buy_order, mocker
         'freqtrade.freqtradebot.exchange',
         validate_pairs=MagicMock(),
         get_ticker=ticker,
-        buy=MagicMock(return_value={'id': limit_buy_order['id']})
+        buy=MagicMock(return_value={'id': limit_buy_order['id']}),
+        get_fee=fee,
     )
     mocker.patch('freqtrade.freqtradebot.Analyze.min_roi_reached', return_value=False)
 
@@ -746,7 +759,7 @@ def test_handle_trade_experimental(default_conf, ticker, limit_buy_order, mocker
     assert log_has('Sell signal received. Selling..', caplog.record_tuples)
 
 
-def test_close_trade(default_conf, ticker, limit_buy_order, limit_sell_order, mocker) -> None:
+def test_close_trade(default_conf, ticker, limit_buy_order, limit_sell_order, fee, mocker) -> None:
     """
     Test check_handle() method
     """
@@ -757,7 +770,8 @@ def test_close_trade(default_conf, ticker, limit_buy_order, limit_sell_order, mo
         'freqtrade.freqtradebot.exchange',
         validate_pairs=MagicMock(),
         get_ticker=ticker,
-        buy=MagicMock(return_value={'id': limit_buy_order['id']})
+        buy=MagicMock(return_value={'id': limit_buy_order['id']}),
+        get_fee=fee,
     )
     freqtrade = FreqtradeBot(default_conf, create_engine('sqlite://'))
 
@@ -1153,7 +1167,7 @@ def test_execute_sell_without_conf_sell_down(default_conf, ticker, fee,
     assert 'loss: -5.48%, -0.00005492' in rpc_mock.call_args_list[-1][0][0]
 
 
-def test_sell_profit_only_enable_profit(default_conf, limit_buy_order, mocker) -> None:
+def test_sell_profit_only_enable_profit(default_conf, limit_buy_order, fee, mocker) -> None:
     """
     Test sell_profit_only feature when enabled
     """
@@ -1169,7 +1183,8 @@ def test_sell_profit_only_enable_profit(default_conf, limit_buy_order, mocker) -
             'ask': 0.00002173,
             'last': 0.00002172
         }),
-        buy=MagicMock(return_value={'id': limit_buy_order['id']})
+        buy=MagicMock(return_value={'id': limit_buy_order['id']}),
+        get_fee=fee,
     )
     conf = deepcopy(default_conf)
     conf['experimental'] = {
@@ -1185,7 +1200,7 @@ def test_sell_profit_only_enable_profit(default_conf, limit_buy_order, mocker) -
     assert freqtrade.handle_trade(trade) is True
 
 
-def test_sell_profit_only_disable_profit(default_conf, limit_buy_order, mocker) -> None:
+def test_sell_profit_only_disable_profit(default_conf, limit_buy_order, fee, mocker) -> None:
     """
     Test sell_profit_only feature when disabled
     """
@@ -1201,7 +1216,8 @@ def test_sell_profit_only_disable_profit(default_conf, limit_buy_order, mocker) 
             'ask': 0.00002173,
             'last': 0.00002172
         }),
-        buy=MagicMock(return_value={'id': limit_buy_order['id']})
+        buy=MagicMock(return_value={'id': limit_buy_order['id']}),
+        get_fee=fee,
     )
     conf = deepcopy(default_conf)
     conf['experimental'] = {
@@ -1217,7 +1233,7 @@ def test_sell_profit_only_disable_profit(default_conf, limit_buy_order, mocker) 
     assert freqtrade.handle_trade(trade) is True
 
 
-def test_sell_profit_only_enable_loss(default_conf, limit_buy_order, mocker) -> None:
+def test_sell_profit_only_enable_loss(default_conf, limit_buy_order, fee, mocker) -> None:
     """
     Test sell_profit_only feature when enabled and we have a loss
     """
@@ -1233,7 +1249,8 @@ def test_sell_profit_only_enable_loss(default_conf, limit_buy_order, mocker) -> 
             'ask': 0.00000173,
             'last': 0.00000172
         }),
-        buy=MagicMock(return_value={'id': limit_buy_order['id']})
+        buy=MagicMock(return_value={'id': limit_buy_order['id']}),
+        get_fee=fee,
     )
     conf = deepcopy(default_conf)
     conf['experimental'] = {
@@ -1249,7 +1266,7 @@ def test_sell_profit_only_enable_loss(default_conf, limit_buy_order, mocker) -> 
     assert freqtrade.handle_trade(trade) is False
 
 
-def test_sell_profit_only_disable_loss(default_conf, limit_buy_order, mocker) -> None:
+def test_sell_profit_only_disable_loss(default_conf, limit_buy_order, fee, mocker) -> None:
     """
     Test sell_profit_only feature when enabled and we have a loss
     """
@@ -1265,7 +1282,8 @@ def test_sell_profit_only_disable_loss(default_conf, limit_buy_order, mocker) ->
             'ask': 0.00000173,
             'last': 0.00000172
         }),
-        buy=MagicMock(return_value={'id': limit_buy_order['id']})
+        buy=MagicMock(return_value={'id': limit_buy_order['id']}),
+        get_fee=fee,
     )
 
     conf = deepcopy(default_conf)


### PR DESCRIPTION
## Summary
Add mocks for `exchange.get_fee` because ccxt does a HTTP request for this.
Fixes the testsuite if no internet connection is available, reproducible at 1332ab397ff52ea75a31cd0c32d234bf47ad012d with:
```
sudo unshare -n pytest freqtrade
```

## TODO / open issues suitable for followup PR:
* Backtesting calls exchange.get_fee quite frequently within `_get_sell_trade_entry`. We should call get_fee() once in `Backtesting.__init__` and reuse this value.

