### PR TITLE
[ccxt] fix unsupported fiat failures

### DIFF
--- a/freqtrade/fiat_convert.py
+++ b/freqtrade/fiat_convert.py
@@ -182,7 +182,7 @@ class CryptoToFiatConverter(object):
             raise ValueError('The fiat {} is not supported.'.format(fiat_symbol))
 
         if crypto_symbol not in self.CRYPTOMAP:
-            # simply return 0 for unsupported stake currencies (fiat-convert should not break the bot)
+            # return 0 for unsupported stake currencies (fiat-convert should not break the bot)
             logger.warning("unsupported crypto-symbol %s - returning 0.0", crypto_symbol)
             return 0.0
         try:

--- a/freqtrade/fiat_convert.py
+++ b/freqtrade/fiat_convert.py
@@ -76,7 +76,8 @@ class CryptoToFiatConverter(object):
     CRYPTOMAP = {
         'BTC': 'bitcoin',
         'ETH': 'ethereum',
-        'USDT': 'thether'
+        'USDT': 'thether',
+        'BNB': 'binance-coin'
     }
 
     def __new__(cls):

--- a/freqtrade/fiat_convert.py
+++ b/freqtrade/fiat_convert.py
@@ -99,6 +99,8 @@ class CryptoToFiatConverter(object):
         :param fiat_symbol: fiat to convert to
         :return: float, value in fiat of the crypto-currency amount
         """
+        if crypto_symbol == fiat_symbol:
+            return crypto_amount
         price = self.get_price(crypto_symbol=crypto_symbol, fiat_symbol=fiat_symbol)
         return float(crypto_amount) * float(price)
 

--- a/freqtrade/fiat_convert.py
+++ b/freqtrade/fiat_convert.py
@@ -182,8 +182,9 @@ class CryptoToFiatConverter(object):
             raise ValueError('The fiat {} is not supported.'.format(fiat_symbol))
 
         if crypto_symbol not in self.CRYPTOMAP:
-            raise ValueError(
-                'The crypto symbol {} is not supported.'.format(crypto_symbol))
+            # simply return 0 for unsupported stake currencies (fiat-convert should not break the bot)
+            logger.warning("unsupported crypto-symbol %s - returning 0.0", crypto_symbol)
+            return 0.0
         try:
             return float(
                 self._coinmarketcap.ticker(

--- a/freqtrade/tests/test_fiat_convert.py
+++ b/freqtrade/tests/test_fiat_convert.py
@@ -77,7 +77,6 @@ def test_fiat_convert_find_price(mocker):
     with pytest.raises(ValueError, match=r'The fiat ABC is not supported.'):
         fiat_convert._find_price(crypto_symbol='BTC', fiat_symbol='ABC')
 
-    # with pytest.raises(ValueError, match=r'The crypto symbol XRP is not supported.'):
     assert fiat_convert.get_price(crypto_symbol='XRP', fiat_symbol='USD') == 0.0
 
     mocker.patch('freqtrade.fiat_convert.CryptoToFiatConverter._find_price', return_value=12345.0)

--- a/freqtrade/tests/test_fiat_convert.py
+++ b/freqtrade/tests/test_fiat_convert.py
@@ -77,8 +77,8 @@ def test_fiat_convert_find_price(mocker):
     with pytest.raises(ValueError, match=r'The fiat ABC is not supported.'):
         fiat_convert._find_price(crypto_symbol='BTC', fiat_symbol='ABC')
 
-    with pytest.raises(ValueError, match=r'The crypto symbol XRP is not supported.'):
-        fiat_convert.get_price(crypto_symbol='XRP', fiat_symbol='USD')
+    # with pytest.raises(ValueError, match=r'The crypto symbol XRP is not supported.'):
+    assert fiat_convert.get_price(crypto_symbol='XRP', fiat_symbol='USD') == 0.0
 
     mocker.patch('freqtrade.fiat_convert.CryptoToFiatConverter._find_price', return_value=12345.0)
     assert fiat_convert.get_price(crypto_symbol='BTC', fiat_symbol='USD') == 12345.0


### PR DESCRIPTION
## Summary
First step to facilitate trading with other stake currencies (other than the currently supported BTC, ETH and USDT

Solve the issue: #616 

## Quick changelog
- Don't raise errors from fiat-convert if stake-currency is not known 
- return amount if crypto-symbol (stake-currency) and fiat-symbol are identical 

## What's new?
* This will **not** fully enable trading with other currencies, but prevent failures should someone want to try it out.

## Further  steps to enable trading in other currencies:
* Further necessary steps would be extending the CONF_SCHEMA dict in `constants.py`.
* extend `fiat_convert.py` - CRYPTOMAP dict with desired currency to have conversation working (if trading in a non-fiat currency).

