### PR TITLE
update Docker image to python-3.6.5-slim-stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.4-slim-stretch
+FROM python:3.6.5-slim-stretch
 
 # Install TA-lib
 RUN apt-get update && apt-get -y install curl build-essential && apt-get clean


### PR DESCRIPTION
## Summary
Update docker image `python-3.6.4-slim-stretch` to `python-3.6.5-slim-stretch`.

Requires a full rebuild of the image - but updates to the latest and greatest version of python.