### PR TITLE
added additional column for the status table to see current stake cur…

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -98,10 +98,11 @@ class RPC(object):
                     trade.id,
                     trade.pair,
                     shorten_date(arrow.get(trade.open_date).humanize(only_distance=True)),
-                    '{:.2f}%'.format(100 * trade.calc_profit_percent(current_rate))
+                    '{:.2f}%'.format(100 * trade.calc_profit_percent(current_rate)),
+                    '{:.6f}'.format(trade.amount * current_rate)
                 ])
 
-            columns = ['ID', 'Pair', 'Since', 'Profit']
+            columns = ['ID', 'Pair', 'Since', 'Profit', 'Value']
             df_statuses = DataFrame.from_records(trades_list, columns=columns)
             df_statuses = df_statuses.set_index(columns[0])
             # The style used throughout is to return a tuple

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -76,7 +76,7 @@ class RPC(object):
                               current_rate=current_rate,
                               amount=round(trade.amount, 8),
                               close_profit=fmt_close_profit,
-                              stake_value=round(current_rate * trade.amount,6),
+                              stake_value=round(current_rate * trade.amount, 8),
                               current_profit=round(current_profit * 100, 2),
                               open_order='({} rem={:.8f})'.format(
                                   order['type'], order['remaining']
@@ -101,7 +101,7 @@ class RPC(object):
                     trade.pair,
                     shorten_date(arrow.get(trade.open_date).humanize(only_distance=True)),
                     '{:.2f}%'.format(100 * trade.calc_profit_percent(current_rate)),
-                    '{:.6f}'.format(trade.amount * current_rate)
+                    '{:.8f}'.format(trade.amount * current_rate)
                 ])
 
             columns = ['ID', 'Pair', 'Since', 'Profit', 'Value']

--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -63,6 +63,7 @@ class RPC(object):
                           "*Close Rate:* `{close_rate}`\n" \
                           "*Current Rate:* `{current_rate:.8f}`\n" \
                           "*Close Profit:* `{close_profit}`\n" \
+                          "*Stake Value:* `{stake_value}`\n" \
                           "*Current Profit:* `{current_profit:.2f}%`\n" \
                           "*Open Order:* `{open_order}`"\
                           .format(
@@ -75,6 +76,7 @@ class RPC(object):
                               current_rate=current_rate,
                               amount=round(trade.amount, 8),
                               close_profit=fmt_close_profit,
+                              stake_value=round(current_rate * trade.amount,6),
                               current_profit=round(current_profit * 100, 2),
                               open_order='({} rem={:.8f})'.format(
                                   order['type'], order['remaining']

--- a/freqtrade/tests/rpc/test_rpc.py
+++ b/freqtrade/tests/rpc/test_rpc.py
@@ -66,6 +66,7 @@ def test_rpc_trade_status(default_conf, ticker, mocker) -> None:
         '*Close Rate:* `None`\n'
         '*Current Rate:* `0.00001098`\n'
         '*Close Profit:* `None`\n'
+        '*Stake Value:* `0.000999`\n'        
         '*Current Profit:* `-0.59%`\n'
         '*Open Order:* `(LIMIT_BUY rem=0.00000000)`'
     ]

--- a/freqtrade/tests/rpc/test_rpc.py
+++ b/freqtrade/tests/rpc/test_rpc.py
@@ -66,7 +66,7 @@ def test_rpc_trade_status(default_conf, ticker, mocker) -> None:
         '*Close Rate:* `None`\n'
         '*Current Rate:* `0.00001098`\n'
         '*Close Profit:* `None`\n'
-        '*Stake Value:* `0.000999`\n'
+        '*Stake Value:* `0.00099999`\n'
         '*Current Profit:* `-0.59%`\n'
         '*Open Order:* `(LIMIT_BUY rem=0.00000000)`'
     ]

--- a/freqtrade/tests/rpc/test_rpc.py
+++ b/freqtrade/tests/rpc/test_rpc.py
@@ -106,6 +106,7 @@ def test_rpc_status_table(default_conf, ticker, mocker) -> None:
     assert '-0.59%' in result['Profit'].all()
     assert 'Value' in result
 
+
 def test_rpc_daily_profit(default_conf, update, ticker, limit_buy_order, limit_sell_order, mocker)\
         -> None:
     """

--- a/freqtrade/tests/rpc/test_rpc.py
+++ b/freqtrade/tests/rpc/test_rpc.py
@@ -66,7 +66,7 @@ def test_rpc_trade_status(default_conf, ticker, mocker) -> None:
         '*Close Rate:* `None`\n'
         '*Current Rate:* `0.00001098`\n'
         '*Close Profit:* `None`\n'
-        '*Stake Value:* `0.000999`\n'        
+        '*Stake Value:* `0.000999`\n'
         '*Current Profit:* `-0.59%`\n'
         '*Open Order:* `(LIMIT_BUY rem=0.00000000)`'
     ]

--- a/freqtrade/tests/rpc/test_rpc.py
+++ b/freqtrade/tests/rpc/test_rpc.py
@@ -104,7 +104,7 @@ def test_rpc_status_table(default_conf, ticker, mocker) -> None:
     assert 'just now' in result['Since'].all()
     assert 'BTC_ETH' in result['Pair'].all()
     assert '-0.59%' in result['Profit'].all()
-
+    assert 'Value' in result
 
 def test_rpc_daily_profit(default_conf, update, ticker, limit_buy_order, limit_sell_order, mocker)\
         -> None:

--- a/freqtrade/tests/rpc/test_rpc.py
+++ b/freqtrade/tests/rpc/test_rpc.py
@@ -66,7 +66,7 @@ def test_rpc_trade_status(default_conf, ticker, mocker) -> None:
         '*Close Rate:* `None`\n'
         '*Current Rate:* `0.00001098`\n'
         '*Close Profit:* `None`\n'
-        '*Stake Value:* `0.00099999`\n'
+        '*Stake Value:* `0.00099909`\n'
         '*Current Profit:* `-0.59%`\n'
         '*Open Order:* `(LIMIT_BUY rem=0.00000000)`'
     ]


### PR DESCRIPTION
## Summary

This includes a simple addition to the status table, basically the stake value of the currency at any given time, since % are not always what is needed.

## What's new?

Improves the status table a bit, to provide me with more needed information

ID  Pair       Since    Profit       Value
----  ---------  -------  --------  --------
  31  BTC_STORJ  5 d      -7.23%    0.006526
  36  BTC_LTC    5 d      -2.79%    0.006839
  45  BTC_GNT    4 d      -6.84%    0.006553
  56  BTC_XRP    3 d      -3.91%    0.006759
  57  BTC_BCC    2 d      -3.27%    0.006805
  61  BTC_QTUM   1 d      -4.01%    0.006753
  74  BTC_BTG    17 h     -1.10%    0.006958
  78  BTC_PART   9 h      -0.39%    0.007007
  80  BTC_IGNIS  6 h      -8.11%    0.006457
  81  BTC_LRC    4 h      -2.99%    0.006824
