### PR TITLE
Add unnecessary files to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,12 @@ Dockerfile
 .dockerignore
 config.json*
 *.sqlite
+.coveragerc
+.eggs
+.github
+.pylintrc
+.travis.yml
+CONTRIBUTING.md
+MANIFEST.in
+README.md
+freqtrade.service


### PR DESCRIPTION
## Summary

these files are not needed to run the bot - therefore should not be
added to the docker container

## Quick changelog

- Exclude files from the Docker image which are not necessary to run the bot (except for `LICENSE`).

## What's new?
Very slight reduction of Docker image - but "declutters" the image.