### PR TITLE
Added support to load strategy directly from a given url

### DIFF
--- a/freqtrade/tests/strategy/test_strategy.py
+++ b/freqtrade/tests/strategy/test_strategy.py
@@ -26,6 +26,15 @@ def test_load_strategy(result):
     assert 'adx' in resolver.strategy.populate_indicators(result)
 
 
+def test_load_strategy_from_url(result):
+    resolver = StrategyResolver()
+    resolver._load_strategy('https://raw.githubusercontent.com/berlinguyinca'
+                            '/freqtrade-trading-strategies'
+                            '/master/user_data/strategies/Simple.py')
+    assert hasattr(resolver.strategy, 'populate_indicators')
+    assert 'adx' in resolver.strategy.populate_indicators(result)
+
+
 def test_load_strategy_custom_directory(result):
     resolver = StrategyResolver()
     extra_dir = os.path.join('some', 'path')

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,3 @@ coinmarketcap==4.2.1
 
 # Required for plotting data
 #plotly==2.3.0
-
-# Required for dynamic strategy loading from urls
-validators

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,6 @@ coinmarketcap==4.2.1
 
 # Required for plotting data
 #plotly==2.3.0
+
+# Required for dynamic strategy loading from urls
+validators

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(name='freqtrade',
           'TA-Lib',
           'tabulate',
           'cachetools',
-          'coinmarketcap',
+          'coinmarketcap'
       ],
       include_package_data=True,
       zip_safe=False,


### PR DESCRIPTION
## Summary

This addition allows to easily allow strategy from remote urls. This is mostly required for the strategy testing tool I'm working on and I think it would be a nice feature to add.

Obviously, it is rather insecure, since it allows to execute any remote python code and you should only specify URL's you trust.

## What's new?

This addition allows to easily allow strategy from remote urls. This is mostly required for the strategy testing tool I'm working on and I think it would be a nice feature to add.

Obviously, it is rather insecure, since it allows to execute any remote python code and you should only specify URL's you trust.

## Usage:

Just provide the url of the strategy in the config or the command line

```
 "strategy" : "https://raw.githubusercontent.com/berlinguyinca/freqtrade-trading-strategies/master/user_data/strategies/ReinforcedQuickie.py"
```

as an example