### PR TITLE
Reduce verbosity of get_ticker_history

### DIFF
--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -297,9 +297,10 @@ def get_ticker_history(pair: str, tick_interval: str, since_ms: Optional[int] = 
             if not data_part:
                 break
 
-            logger.info('Downloaded data for time range [%s, %s]',
-                        arrow.get(data_part[0][0] / 1000).format(),
-                        arrow.get(data_part[-1][0] / 1000).format())
+            logger.debug('Downloaded data for %s time range [%s, %s]',
+                         pair,
+                         arrow.get(data_part[0][0] / 1000).format(),
+                         arrow.get(data_part[-1][0] / 1000).format())
 
             data.extend(data_part)
             since_ms = data[-1][0] + 1


### PR DESCRIPTION
## Summary
This sets the log-level for get_ticker_history to debug instead of info and adds the pair.

Having this level of detail at info-loglevel does not make sense - and makes the log pretty unreadable.

it's fine for Debug mode though.

Previously produced the following output:

```
2018-05-12 20:14:53,749 - freqtrade.exchange - INFO - Downloaded data for time range [2018-05-09 06:55:00+00:00, 2018-05-12 18:10:00+00:00]
2018-05-12 20:14:54,418 - freqtrade.exchange - INFO - Downloaded data for time range [2018-05-09 06:55:00+00:00, 2018-05-12 18:10:00+00:00]
2018-05-12 20:14:55,007 - freqtrade.exchange - INFO - Downloaded data for time range [2018-05-09 06:55:00+00:00, 2018-05-12 18:10:00+00:00]
2018-05-12 20:14:56,059 - freqtrade.exchange - INFO - Downloaded data for time range [2018-05-09 06:55:00+00:00, 2018-05-12 18:10:00+00:00]
2018-05-12 20:14:56,578 - freqtrade.exchange - INFO - Downloaded data for time range [2018-05-09 06:55:00+00:00, 2018-05-12 18:10:00+00:00]
2018-05-12 20:14:57,658 - freqtrade.exchange - INFO - Downloaded data for time range [2018-05-09 06:55:00+00:00, 2018-05-12 18:10:00+00:00]
2018-05-12 20:14:58,097 - freqtrade.exchange - INFO - Downloaded data for time range [2018-05-09 06:55:00+00:00, 2018-05-12 18:10:00+00:00]
2018-05-12 20:14:58,678 - freqtrade.exchange - INFO - Downloaded data for time range [2018-05-09 06:55:00+00:00, 2018-05-12 18:10:00+00:00]
2018-05-12 20:14:59,723 - freqtrade.exchange - INFO - Downloaded data for time range [2018-05-09 06:55:00+00:00, 2018-05-12 18:10:00+00:00]
2018-05-12 20:15:00,301 - freqtrade.exchange - INFO - Downloaded data for time range [2018-05-09 06:55:00+00:00, 2018-05-12 18:10:00+00:00]
2018-05-12 20:15:00,993 - freqtrade.exchange - INFO - Downloaded data for time range [2018-05-09 06:55:00+00:00, 2018-05-12 18:10:00+00:00]
2018-05-12 20:15:01,546 - freqtrade.exchange - INFO - Downloaded data for time range [2018-05-09 06:55:00+00:00, 2018-05-12 18:10:00+00:00]
2018-05-12 20:15:02,512 - freqtrade.exchange - INFO - Downloaded data for time range [2018-05-09 07:00:00+00:00, 2018-05-12 18:15:00+00:00]
```