### PR TITLE
Fix testfluke in hyperopt

### DIFF
--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -123,7 +123,7 @@ def test_loss_calculation_has_limited_profit(init_hyperopt) -> None:
     assert under > correct
 
 
-def test_log_results_if_loss_improves(capsys) -> None:
+def test_log_results_if_loss_improves(init_hyperopt, capsys) -> None:
     hyperopt = _HYPEROPT
     hyperopt.current_best_loss = 2
     hyperopt.log_results(


### PR DESCRIPTION
## Summary
fix a test-fluke which appeared in hyperopt:
reproduce running `pytest  --random-order-seed=194824`


Will solve the test-failure which appeared in : #658