### PR TITLE
Fix fiat convert

### DIFF
--- a/freqtrade/fiat_convert.py
+++ b/freqtrade/fiat_convert.py
@@ -198,5 +198,6 @@ class CryptoToFiatConverter(object):
                     convert=fiat_symbol
                 )[0]['price_' + fiat_symbol.lower()]
             )
-        except BaseException:
+        except BaseException as ex:
+            logger.error("Error in _find_price: %s", ex)
             return 0.0

--- a/freqtrade/fiat_convert.py
+++ b/freqtrade/fiat_convert.py
@@ -92,7 +92,7 @@ class CryptoToFiatConverter(object):
     def _load_cryptomap(self) -> None:
         try:
             coinlistings = self._coinmarketcap.listings()
-            self._cryptomap = dict(map(lambda coin: (coin["symbol"], str(coin["id"]),
+            self._cryptomap = dict(map(lambda coin: (coin["symbol"], str(coin["id"])),
                                        coinlistings["data"]))
         except ValueError:
             logger.error("Could not load FIAT Cryptocurrency map")

--- a/freqtrade/fiat_convert.py
+++ b/freqtrade/fiat_convert.py
@@ -5,6 +5,7 @@ e.g BTC to USD
 
 import logging
 import time
+from typing import Dict
 
 from coinmarketcap import Market
 
@@ -73,12 +74,7 @@ class CryptoToFiatConverter(object):
         "RUB", "SEK", "SGD", "THB", "TRY", "TWD", "ZAR", "USD"
     ]
 
-    CRYPTOMAP = {
-        'BTC': 'bitcoin',
-        'ETH': 'ethereum',
-        'USDT': 'thether',
-        'BNB': 'binance-coin'
-    }
+    _cryptomap: Dict = {}
 
     def __new__(cls):
         if CryptoToFiatConverter.__instance is None:
@@ -91,6 +87,15 @@ class CryptoToFiatConverter(object):
 
     def __init__(self) -> None:
         self._pairs = []
+        self._load_cryptomap()
+
+    def _load_cryptomap(self) -> None:
+        try:
+            coinlistings = self._coinmarketcap.listings()
+            self._cryptomap = dict(map(lambda coin: (coin["symbol"], coin["id"]),
+                                       coinlistings["data"]))
+        except ValueError:
+            logger.error("Could not load FIAT Cryptocurrency map")
 
     def convert_amount(self, crypto_amount: float, crypto_symbol: str, fiat_symbol: str) -> float:
         """
@@ -182,14 +187,14 @@ class CryptoToFiatConverter(object):
         if not self._is_supported_fiat(fiat=fiat_symbol):
             raise ValueError('The fiat {} is not supported.'.format(fiat_symbol))
 
-        if crypto_symbol not in self.CRYPTOMAP:
+        if crypto_symbol not in self._cryptomap:
             # return 0 for unsupported stake currencies (fiat-convert should not break the bot)
             logger.warning("unsupported crypto-symbol %s - returning 0.0", crypto_symbol)
             return 0.0
         try:
             return float(
                 self._coinmarketcap.ticker(
-                    currency=self.CRYPTOMAP[crypto_symbol],
+                    currency=self._cryptomap[crypto_symbol],
                     convert=fiat_symbol
                 )[0]['price_' + fiat_symbol.lower()]
             )

--- a/freqtrade/fiat_convert.py
+++ b/freqtrade/fiat_convert.py
@@ -196,7 +196,7 @@ class CryptoToFiatConverter(object):
                 self._coinmarketcap.ticker(
                     currency=self._cryptomap[crypto_symbol],
                     convert=fiat_symbol
-                )[0]['price_' + fiat_symbol.lower()]
+                )['data']['quotes'][fiat_symbol.upper()]['price']
             )
         except BaseException as ex:
             logger.error("Error in _find_price: %s", ex)

--- a/freqtrade/fiat_convert.py
+++ b/freqtrade/fiat_convert.py
@@ -92,7 +92,7 @@ class CryptoToFiatConverter(object):
     def _load_cryptomap(self) -> None:
         try:
             coinlistings = self._coinmarketcap.listings()
-            self._cryptomap = dict(map(lambda coin: (coin["symbol"], coin["id"]),
+            self._cryptomap = dict(map(lambda coin: (coin["symbol"], str(coin["id"]),
                                        coinlistings["data"]))
         except ValueError:
             logger.error("Could not load FIAT Cryptocurrency map")

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -2,6 +2,7 @@
 import json
 import logging
 from datetime import datetime
+from typing import Dict, Optional
 from functools import reduce
 from unittest.mock import MagicMock
 
@@ -34,7 +35,8 @@ def get_patched_freqtradebot(mocker, config) -> FreqtradeBot:
     :param config: Config to pass to the bot
     :return: None
     """
-    mocker.patch('freqtrade.fiat_convert.Market', {'price_usd': 12345.0})
+    # mocker.patch('freqtrade.fiat_convert.Market', {'price_usd': 12345.0})
+    patch_coinmarketcap(mocker, {'price_usd': 12345.0})
     mocker.patch('freqtrade.freqtradebot.Analyze', MagicMock())
     mocker.patch('freqtrade.freqtradebot.RPCManager', MagicMock())
     mocker.patch('freqtrade.freqtradebot.persistence.init', MagicMock())
@@ -44,6 +46,25 @@ def get_patched_freqtradebot(mocker, config) -> FreqtradeBot:
     mocker.patch('freqtrade.freqtradebot.Analyze.get_signal', MagicMock())
 
     return FreqtradeBot(config, create_engine('sqlite://'))
+
+
+def patch_coinmarketcap(mocker, value: Optional[Dict[str, float]] = None) -> None:
+    """
+    Mocker to coinmarketcap to speed up tests
+    :param mocker: mocker to patch coinmarketcap class
+    :return: None
+    """
+    mock = MagicMock()
+
+    if value:
+        mock.ticker = {'price_usd': 12345.0}
+    mock.listings = {'data': [{'id': 1, 'name': 'Bitcoin', 'symbol': 'BTC',
+                               'website_slug': 'bitcoin'},
+                              {'id': 1027, 'name': 'Ethereum', 'symbol': 'ETH',
+                               'website_slug': 'ethereum'}
+                              ]}
+
+    mocker.patch('freqtrade.fiat_convert.Market', mock)
 
 
 @pytest.fixture(scope="function")

--- a/freqtrade/tests/conftest.py
+++ b/freqtrade/tests/conftest.py
@@ -54,17 +54,19 @@ def patch_coinmarketcap(mocker, value: Optional[Dict[str, float]] = None) -> Non
     :param mocker: mocker to patch coinmarketcap class
     :return: None
     """
-    mock = MagicMock()
 
-    if value:
-        mock.ticker = {'price_usd': 12345.0}
-    mock.listings = {'data': [{'id': 1, 'name': 'Bitcoin', 'symbol': 'BTC',
-                               'website_slug': 'bitcoin'},
-                              {'id': 1027, 'name': 'Ethereum', 'symbol': 'ETH',
-                               'website_slug': 'ethereum'}
-                              ]}
+    tickermock = MagicMock(return_value={'price_usd': 12345.0})
+    listmock = MagicMock(return_value={'data': [{'id': 1, 'name': 'Bitcoin', 'symbol': 'BTC',
+                                                 'website_slug': 'bitcoin'},
+                                                {'id': 1027, 'name': 'Ethereum', 'symbol': 'ETH',
+                                                 'website_slug': 'ethereum'}
+                                                ]})
+    mocker.patch.multiple(
+        'freqtrade.fiat_convert.Market',
+        ticker=tickermock,
+        listings=listmock,
 
-    mocker.patch('freqtrade.fiat_convert.Market', mock)
+    )
 
 
 @pytest.fixture(scope="function")

--- a/freqtrade/tests/test_fiat_convert.py
+++ b/freqtrade/tests/test_fiat_convert.py
@@ -128,7 +128,9 @@ def test_fiat_convert_without_network():
 
     fiat_convert = CryptoToFiatConverter()
 
+    cmc_temp = CryptoToFiatConverter._coinmarketcap
     CryptoToFiatConverter._coinmarketcap = None
 
     assert fiat_convert._coinmarketcap is None
     assert fiat_convert._find_price(crypto_symbol='BTC', fiat_symbol='USD') == 0.0
+    CryptoToFiatConverter._coinmarketcap = cmc_temp

--- a/freqtrade/tests/test_fiat_convert.py
+++ b/freqtrade/tests/test_fiat_convert.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from freqtrade.fiat_convert import CryptoFiat, CryptoToFiatConverter
+from freqtrade.tests.conftest import patch_coinmarketcap
 
 
 def test_pair_convertion_object():
@@ -121,6 +122,15 @@ def test_fiat_convert_get_price(mocker):
     fiat_convert._pairs[0]._expiration = expiration
     assert fiat_convert.get_price(crypto_symbol='BTC', fiat_symbol='USD') == 28000.0
     assert fiat_convert._pairs[0]._expiration is not expiration
+
+
+def test_loadcryptomap(mocker):
+    patch_coinmarketcap(mocker)
+
+    fiat_convert = CryptoToFiatConverter()
+    assert len(fiat_convert._cryptomap) == 2
+
+    assert fiat_convert._cryptomap["BTC"] == "1"
 
 
 def test_fiat_convert_without_network():

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -8,7 +8,6 @@ import logging
 import re
 import time
 from copy import deepcopy
-from typing import Dict, Optional
 from unittest.mock import MagicMock
 
 import arrow
@@ -20,7 +19,7 @@ from freqtrade import DependencyException, OperationalException, TemporaryError
 from freqtrade.freqtradebot import FreqtradeBot
 from freqtrade.persistence import Trade
 from freqtrade.state import State
-from freqtrade.tests.conftest import log_has
+from freqtrade.tests.conftest import log_has, patch_coinmarketcap
 
 
 # Functions for recurrent object patching
@@ -62,20 +61,6 @@ def patch_RPCManager(mocker) -> MagicMock:
     mocker.patch('freqtrade.freqtradebot.RPCManager._init', MagicMock())
     rpc_mock = mocker.patch('freqtrade.freqtradebot.RPCManager.send_msg', MagicMock())
     return rpc_mock
-
-
-def patch_coinmarketcap(mocker, value: Optional[Dict[str, float]] = None) -> None:
-    """
-    Mocker to coinmarketcap to speed up tests
-    :param mocker: mocker to patch coinmarketcap class
-    :return: None
-    """
-    mock = MagicMock()
-
-    if value:
-        mock.ticker = {'price_usd': 12345.0}
-
-    mocker.patch('freqtrade.fiat_convert.Market', mock)
 
 
 # Unit tests


### PR DESCRIPTION
## Summary
This will reenable convert to fiat (which was broken by a combination of updating coinmarketcap to 5.xx and coinmarketcap.com changing the api.

Solve the issue: #661 

## Quick changelog

- dynamically load available coins
- Adapt to new format
- slight refactoring of some tests to support testing the new functionality

For details on the bug refer to  issue #661 

### Additional remarks:
I know we should not test external libraries - however the change to the API was intentional (forced by coinmarketcap.com - but that doesn't really matter), and the test-suite did not catch it correctly (mostly because all external calls are mocked).

