### PR TITLE
Fixed bot crash while requesting the current balance

### DIFF
--- a/freqtrade/rpc/telegram.py
+++ b/freqtrade/rpc/telegram.py
@@ -264,17 +264,15 @@ class Telegram(RPC):
         (currencys, total, symbol, value) = result
         output = ''
         for currency in currencys:
-            output += """*Currency*: {currency}
-    *Available*: {available}
-    *Balance*: {balance}
-    *Pending*: {pending}
-    *Est. BTC*: {est_btc: .8f}
-    """.format(**currency)
+            output += "*{currency}:*\n" \
+                      "\t`Available: {available: .8f}`\n" \
+                      "\t`Balance: {balance: .8f}`\n" \
+                      "\t`Pending: {pending: .8f}`\n" \
+                      "\t`Est. BTC: {est_btc: .8f}`\n".format(**currency)
 
-        output += """*Estimated Value*:
-    *BTC*: {0: .8f}
-    *{1}*: {2: .2f}
-    """.format(total, symbol, value)
+        output += "\n*Estimated Value*:\n" \
+                  "\t`BTC: {0: .8f}`\n" \
+                  "\t`{1}: {2: .2f}`\n".format(total, symbol, value)
         self.send_msg(output)
 
     @authorized_only

--- a/freqtrade/tests/rpc/test_rpc.py
+++ b/freqtrade/tests/rpc/test_rpc.py
@@ -288,22 +288,18 @@ def test_rpc_balance_handle(default_conf, mocker):
     """
     Test rpc_balance() method
     """
-    mock_balance = [
-        {
-            'Currency': 'BTC',
-            'Balance': 10.0,
-            'Available': 12.0,
-            'Pending': 0.0,
-            'CryptoAddress': 'XXXX',
+    mock_balance = {
+        'BTC': {
+            'free': 10.0,
+            'total': 12.0,
+            'used': 2.0,
         },
-        {
-            'Currency': 'ETH',
-            'Balance': 0.0,
-            'Available': 0.0,
-            'Pending': 0.0,
-            'CryptoAddress': 'XXXX',
+        'ETH': {
+            'free': 0.0,
+            'total': 0.0,
+            'used': 0.0,
         }
-    ]
+    }
 
     patch_get_signal(mocker, (True, False))
     mocker.patch.multiple(
@@ -324,15 +320,15 @@ def test_rpc_balance_handle(default_conf, mocker):
     (error, res) = rpc.rpc_balance(default_conf['fiat_display_currency'])
     assert not error
     (trade, x, y, z) = res
-    assert prec_satoshi(x, 10)
-    assert prec_satoshi(z, 150000)
+    assert prec_satoshi(x, 12)
+    assert prec_satoshi(z, 180000)
     assert 'USD' in y
     assert len(trade) == 1
     assert 'BTC' in trade[0]['currency']
-    assert prec_satoshi(trade[0]['available'], 12)
-    assert prec_satoshi(trade[0]['balance'], 10)
-    assert prec_satoshi(trade[0]['pending'], 0)
-    assert prec_satoshi(trade[0]['est_btc'], 10)
+    assert prec_satoshi(trade[0]['available'], 10)
+    assert prec_satoshi(trade[0]['balance'], 12)
+    assert prec_satoshi(trade[0]['pending'], 2)
+    assert prec_satoshi(trade[0]['est_btc'], 12)
 
 
 def test_rpc_start(mocker, default_conf) -> None:

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -554,36 +554,29 @@ def test_telegram_balance_handle(default_conf, update, mocker) -> None:
     """
     Test _balance() method
     """
-    mock_balance = [
-        {
-            'Currency': 'BTC',
-            'Balance': 10.0,
-            'Available': 12.0,
-            'Pending': 0.0,
-            'CryptoAddress': 'XXXX',
+
+    mock_balance = {
+        'BTC': {
+            'total': 12.0,
+            'free': 12.0,
+            'used': 0.0
         },
-        {
-            'Currency': 'ETH',
-            'Balance': 0.0,
-            'Available': 0.0,
-            'Pending': 0.0,
-            'CryptoAddress': 'XXXX',
+        'ETH': {
+            'total': 0.0,
+            'free': 0.0,
+            'used': 0.0
         },
-        {
-            'Currency': 'USDT',
-            'Balance': 10000.0,
-            'Available': 0.0,
-            'Pending': 0.0,
-            'CryptoAddress': 'XXXX',
+        'USDT': {
+            'total': 10000.0,
+            'free': 10000.0,
+            'used': 0.0
         },
-        {
-            'Currency': 'LTC',
-            'Balance': 10.0,
-            'Available': 10.0,
-            'Pending': 0.0,
-            'CryptoAddress': 'XXXX',
+        'LTC': {
+            'total': 10.0,
+            'free': 10.0,
+            'used': 0.0
         }
-    ]
+    }
 
     def mock_ticker(symbol, refresh):
         """
@@ -626,7 +619,7 @@ def test_telegram_balance_handle(default_conf, update, mocker) -> None:
     assert '*Currency*: USDT' in result
     assert 'Balance' in result
     assert 'Est. BTC' in result
-    assert '*BTC*:  12.00000000' in result
+    assert '*BTC*:  14.00000000' in result
 
 
 def test_zero_balance_handle(default_conf, update, mocker) -> None:
@@ -636,7 +629,7 @@ def test_zero_balance_handle(default_conf, update, mocker) -> None:
     patch_get_signal(mocker, (True, False))
     patch_coinmarketcap(mocker, value={'price_usd': 15000.0})
     mocker.patch('freqtrade.freqtradebot.exchange.init', MagicMock())
-    mocker.patch('freqtrade.freqtradebot.exchange.get_balances', return_value=[])
+    mocker.patch('freqtrade.freqtradebot.exchange.get_balances', return_value={})
 
     msg_mock = MagicMock()
     mocker.patch.multiple(

--- a/freqtrade/tests/rpc/test_rpc_telegram.py
+++ b/freqtrade/tests/rpc/test_rpc_telegram.py
@@ -614,12 +614,12 @@ def test_telegram_balance_handle(default_conf, update, mocker) -> None:
     telegram._balance(bot=MagicMock(), update=update)
     result = msg_mock.call_args_list[0][0][0]
     assert msg_mock.call_count == 1
-    assert '*Currency*: BTC' in result
-    assert '*Currency*: ETH' not in result
-    assert '*Currency*: USDT' in result
-    assert 'Balance' in result
-    assert 'Est. BTC' in result
-    assert '*BTC*:  14.00000000' in result
+    assert '*BTC:*' in result
+    assert '*ETH:*' not in result
+    assert '*USDT:*' in result
+    assert 'Balance:' in result
+    assert 'Est. BTC:' in result
+    assert 'BTC:  14.00000000' in result
 
 
 def test_zero_balance_handle(default_conf, update, mocker) -> None:


### PR DESCRIPTION
## Summary
Fixed `/balance` bot functionality. The functionality was broken after moving to CCXT library.
Also I've redesigned a balance message a little bit. Here is the example of the message:

![screenshot_5_15_18__1_50_pm](https://user-images.githubusercontent.com/1016504/40055818-e7c0ebb4-5851-11e8-9534-c4405009c8c0.png)


Solve the issue: `/balance` crash

## Quick changelog

- fixed `/balance` crash
- balance message redesign