### PR TITLE
Make plot_dataframe able to show trades stored in database.

### DIFF
--- a/docs/plotting.md
+++ b/docs/plotting.md
@@ -43,6 +43,10 @@ python scripts/plot_dataframe.py -p BTC_ETH --timerange=100-200
 ```
 Timerange doesn't work with live data.
 
+To plot trades stored in a database use `-db-url` argument:
+```
+python scripts/plot_dataframe.py --db-url tradesv3.dry_run.sqlite -p BTC_ETH
+```
 
 ## Plot profit
 

--- a/docs/plotting.md
+++ b/docs/plotting.md
@@ -43,7 +43,7 @@ python scripts/plot_dataframe.py -p BTC_ETH --timerange=100-200
 ```
 Timerange doesn't work with live data.
 
-To plot trades stored in a database use `-db-url` argument:
+To plot trades stored in a database use `--db-url` argument:
 ```
 python scripts/plot_dataframe.py --db-url tradesv3.dry_run.sqlite -p BTC_ETH
 ```

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -260,6 +260,13 @@ class Arguments(object):
             default=None
         )
 
+        self.parser.add_argument(
+            '-db', '--db-url',
+            help='Show trades stored in database.',
+            dest='db_url',
+            default=None
+        )
+
     def testdata_dl_options(self) -> None:
         """
         Parses given arguments for testdata download

--- a/scripts/plot_dataframe.py
+++ b/scripts/plot_dataframe.py
@@ -10,6 +10,7 @@ Optional Cli parameters
 -d / --datadir: path to pair backtest data
 --timerange: specify what timerange of data to use.
 -l / --live: Live, to download the latest ticker for the pair
+-db / --db-url: Show trades stored in database
 """
 import logging
 import sys
@@ -21,14 +22,14 @@ from plotly import tools
 from plotly.offline import plot
 import plotly.graph_objs as go
 
+from typing import Dict, List, Any
+from sqlalchemy import create_engine
+
 from freqtrade.arguments import Arguments
 from freqtrade.analyze import Analyze
 from freqtrade import exchange
 import freqtrade.optimize as optimize
-
-from typing import Dict, List, Any
 from freqtrade import persistence
-from sqlalchemy import create_engine
 from freqtrade.persistence import Trade
 
 logger = logging.getLogger(__name__)
@@ -54,7 +55,7 @@ def plot_analyzed_dataframe(args: Namespace) -> None:
 
     tick_interval = analyze.strategy.ticker_interval
 
-    tickers = {}
+    tickers = []
     if args.live:
         logger.info('Downloading pair.')
         # Init Bittrex to use public API

--- a/scripts/plot_dataframe.py
+++ b/scripts/plot_dataframe.py
@@ -55,7 +55,7 @@ def plot_analyzed_dataframe(args: Namespace) -> None:
 
     tick_interval = analyze.strategy.ticker_interval
 
-    tickers = []
+    tickers = {}
     if args.live:
         logger.info('Downloading pair.')
         # Init Bittrex to use public API
@@ -74,7 +74,7 @@ def plot_analyzed_dataframe(args: Namespace) -> None:
     dataframe = analyze.populate_buy_trend(dataframe)
     dataframe = analyze.populate_sell_trend(dataframe)
 
-    trades = {}
+    trades = []
     if args.db_url:
         engine = create_engine('sqlite:///' + args.db_url)
         persistence.init(_CONF, engine)


### PR DESCRIPTION
## Summary
Make plot_dataframe.py able to show buy and sell trades stored in database.


## Quick changelog

- Introduce '--db-url' argument
- Implement feature in plot_dataframe.py
- Update plotting.md
