### PR TITLE
Fix fiat initialization

### DIFF
--- a/freqtrade/fiat_convert.py
+++ b/freqtrade/fiat_convert.py
@@ -8,6 +8,7 @@ import time
 from typing import Dict
 
 from coinmarketcap import Market
+from requests.exceptions import RequestException
 
 logger = logging.getLogger(__name__)
 
@@ -94,8 +95,8 @@ class CryptoToFiatConverter(object):
             coinlistings = self._coinmarketcap.listings()
             self._cryptomap = dict(map(lambda coin: (coin["symbol"], str(coin["id"])),
                                        coinlistings["data"]))
-        except ValueError:
-            logger.error("Could not load FIAT Cryptocurrency map")
+        except (ValueError, RequestException) as e:
+            logger.error("Could not load FIAT Cryptocurrency map for the following problem: %s", e)
 
     def convert_amount(self, crypto_amount: float, crypto_symbol: str, fiat_symbol: str) -> float:
         """

--- a/freqtrade/tests/test_fiat_convert.py
+++ b/freqtrade/tests/test_fiat_convert.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from requests.exceptions import RequestException
+
 from freqtrade.fiat_convert import CryptoFiat, CryptoToFiatConverter
 from freqtrade.tests.conftest import patch_coinmarketcap
 
@@ -131,6 +133,21 @@ def test_loadcryptomap(mocker):
     assert len(fiat_convert._cryptomap) == 2
 
     assert fiat_convert._cryptomap["BTC"] == "1"
+
+
+def test_fiat_init_network_exception(mocker):
+    # Because CryptoToFiatConverter is a Singleton we reset the listings
+    listmock = MagicMock(side_effect=RequestException)
+    mocker.patch.multiple(
+        'freqtrade.fiat_convert.Market',
+        listings=listmock,
+    )
+    # with pytest.raises(RequestEsxception):
+    fiat_convert = CryptoToFiatConverter()
+    fiat_convert._cryptomap = {}
+    fiat_convert._load_cryptomap()
+
+    assert len(fiat_convert._cryptomap) == 0
 
 
 def test_fiat_convert_without_network():


### PR DESCRIPTION
## Summary
Catch network exceptions when initializing coinmarketcap (Fiat convert should never cause the bot to stop!!)

Solve the issue: #732

## Quick changelog

- Catch base-class of Requests exceptions (based on [this](http://docs.python-requests.org/en/master/_modules/requests/exceptions/)).
- Added test to verify network-exceptions are successfully cought.


