### PR TITLE
Do not download pairs if --refresh-pairs-cached isn't set

### DIFF
--- a/freqtrade/optimize/__init__.py
+++ b/freqtrade/optimize/__init__.py
@@ -104,7 +104,7 @@ def load_data(datadir: str,
             result[pair] = pairdata
         else:
             logger.warn('No data for pair %s, use --update-pairs-cached to download the data', pair)
-        
+
     return result
 
 

--- a/freqtrade/optimize/__init__.py
+++ b/freqtrade/optimize/__init__.py
@@ -29,7 +29,7 @@ def trim_tickerlist(tickerlist: List[Dict], timerange: Tuple[Tuple, int, int]) -
     if stype[0] == 'index':
         start_index = start
     elif stype[0] == 'date':
-        while tickerlist[start_index][0] < start * 1000:
+        while start_index < len(tickerlist) and tickerlist[start_index][0] < start * 1000:
             start_index += 1
 
     if stype[1] == 'line':
@@ -37,7 +37,7 @@ def trim_tickerlist(tickerlist: List[Dict], timerange: Tuple[Tuple, int, int]) -
     if stype[1] == 'index':
         stop_index = stop
     elif stype[1] == 'date':
-        while tickerlist[stop_index-1][0] > stop * 1000:
+        while stop_index > 0 and tickerlist[stop_index-1][0] > stop * 1000:
             stop_index -= 1
 
     if start_index > stop_index:
@@ -100,15 +100,11 @@ def load_data(datadir: str,
 
     for pair in _pairs:
         pairdata = load_tickerdata_file(datadir, pair, ticker_interval, timerange=timerange)
-        if not pairdata:
-            # download the tickerdata from exchange
-            download_backtesting_testdata(datadir,
-                                          pair=pair,
-                                          tick_interval=ticker_interval,
-                                          timerange=timerange)
-            # and retry reading the pair
-            pairdata = load_tickerdata_file(datadir, pair, ticker_interval, timerange=timerange)
-        result[pair] = pairdata
+        if pairdata:
+            result[pair] = pairdata
+        else:
+            logger.warn('No data for pair %s, use --update-pairs-cached to download the data', pair)
+        
     return result
 
 

--- a/freqtrade/tests/optimize/test_optimize.py
+++ b/freqtrade/tests/optimize/test_optimize.py
@@ -99,7 +99,20 @@ def test_load_data_with_new_pair_1min(ticker_history, mocker, caplog) -> None:
     file = os.path.join(os.path.dirname(__file__), '..', 'testdata', 'MEME_BTC-1m.json')
 
     _backup_file(file)
-    optimize.load_data(None, ticker_interval='1m', pairs=['MEME/BTC'])
+    # do not download a new pair if refresh_pairs isn't set
+    optimize.load_data(None,
+                       ticker_interval='1m',
+                       refresh_pairs=False,
+                       pairs=['MEME/BTC'])
+    assert os.path.isfile(file) is False
+    assert log_has('No data for pair MEME/BTC, use --update-pairs-cached to download the data',
+                   caplog.record_tuples)
+
+    # download a new pair if refresh_pairs is set
+    optimize.load_data(None,
+                       ticker_interval='1m',
+                       refresh_pairs=True,
+                       pairs=['MEME/BTC'])
     assert os.path.isfile(file) is True
     assert log_has('Download the pair: "MEME/BTC", Interval: 1m', caplog.record_tuples)
     _clean_test_file(file)


### PR DESCRIPTION
## Summary
The current implementation of freqtrade contains the following issue: if you try to run backtesting for the period when the pair was not listed on the exchange(for example BCN/BTC on Binance on February) the bot re-downloads the data for that pair. It happens because the bot could not find the data on the disk and then re-downloads it form the exchange. It is a pain when you try to do backtesting on all the pairs on an exchange.

This PR makes the bot to download data only if `--refresh-pairs-cached` is set. If the data doesn't exist for the requested period of time the bot will show a notice about it.

## Quick changelog

- download pair data only if `--refresh-pairs-cached` is set
