### PR TITLE
OSX docker start cmd updated

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -132,6 +132,12 @@ You can run a one-off container that is immediately deleted upon exiting with th
 docker run --rm -v /etc/localtime:/etc/localtime:ro -v `pwd`/config.json:/freqtrade/config.json -it freqtrade
 ```
 
+There is known issue in OSX Docker versions after 17.09.1, whereby /etc/localtime cannot be shared causing Docker to not start. A work-around for this is to start with the following cmd. 
+
+```bash
+docker run --rm -e TZ=`ls -la /etc/localtime | cut -d/ -f8-9` -v `pwd`/config.json:/freqtrade/config.json -it freqtrade
+```
+
 In this example, the database will be created inside the docker instance and will be lost when you will refresh your image.
 
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -137,6 +137,7 @@ There is known issue in OSX Docker versions after 17.09.1, whereby /etc/localtim
 ```bash
 docker run --rm -e TZ=`ls -la /etc/localtime | cut -d/ -f8-9` -v `pwd`/config.json:/freqtrade/config.json -it freqtrade
 ```
+More information on this docker issue and work-around can be read here: https://github.com/docker/for-mac/issues/2396
 
 In this example, the database will be created inside the docker instance and will be lost when you will refresh your image.
 


### PR DESCRIPTION
New versions of Docker will not start in OSX using the cmd in these instructions as /etc/localtime cannot be mounted. 
The change provides an alternate command that does work. 
`docker run --rm -e TZ=`ls -la /etc/localtime | cut -d/ -f8-9` -v `pwd`/config.json:/freqtrade/config.json -it freqtrade`

More info is in this thread: 
https://github.com/docker/for-mac/issues/2396

Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/gcarq/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary
Explain in one sentence the goal of this PR

Solve the issue: #___Start Docketr instructions change. 

## Quick changelog

- <change log #1>
- <change log #2>

## What's new? 
*Explain in details what this PR solve or improve. You can include visuals.* 
No code change, only an added sentence and cmd to install instructions. This is as new Docker versions will not allow /etc/localtime to be mounted. The change is to help new users on OSX start freqtrade in docker 
#