### PR TITLE
Sell filled amount or an open limit buy order in forcesell.

### DIFF
--- a/freqtrade/rpc/rpc.py
+++ b/freqtrade/rpc/rpc.py
@@ -316,8 +316,10 @@ class RPC(object):
                         and order['side'] == 'buy':
                     exchange.cancel_order(trade.open_order_id, trade.pair)
                     trade.close(order.get('price') or trade.open_rate)
-                    # TODO: sell amount which has been bought already
-                    return
+                    # Do the best effort, if we don't know 'filled' amount, don't try selling
+                    if order['filled'] is None:
+                        return
+                    trade.amount = order['filled']
 
                 # Ignore trades with an attached LIMIT_SELL order
                 if order and order['status'] == 'open' \


### PR DESCRIPTION
## Summary
Sell filled amount or an open limit buy order in forcesell.

## What's new?
Currently forcesell only cancels an open limit buy order and doesn't sell the filled amount.

After this change, forcesell will also update trade's amount to filled amount and sell the filled amount.
