### PR TITLE
set ccxt loglevel to info

### DIFF
--- a/freqtrade/main.py
+++ b/freqtrade/main.py
@@ -61,6 +61,7 @@ def set_loggers() -> None:
     :return: None
     """
     logging.getLogger('requests.packages.urllib3').setLevel(logging.INFO)
+    logging.getLogger('ccxt.base.exchange').setLevel(logging.INFO)
     logging.getLogger('telegram').setLevel(logging.INFO)
 
 


### PR DESCRIPTION
## Summary
Change loglevel for ccxt to info - otherwise output of running the bot in verbose-mode becomes very cluttered as ccxt logs every request (including headers etc.) to Debug loglevel.

The same is done for telegram and requests in the same place.

``` bash
python freqtrade/main.py -v
```

## Quick changelog

- Change loglevel for ccxt library

## What's new?
* Reduce verbosity of "verbose" mode by removing external logmessages

