### PR TITLE
Add USDT to the list of fiat currencies

### DIFF
--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -40,7 +40,8 @@ CONF_SCHEMA = {
                                                              'KRW', 'MXN', 'MYR', 'NOK',
                                                              'NZD', 'PHP', 'PKR', 'PLN',
                                                              'RUB', 'SEK', 'SGD', 'THB',
-                                                             'TRY', 'TWD', 'ZAR', 'USD']},
+                                                             'TRY', 'TWD', 'ZAR', 'USD',
+                                                             'USDT']},
         'dry_run': {'type': 'boolean'},
         'minimal_roi': {
             'type': 'object',

--- a/freqtrade/optimize/__init__.py
+++ b/freqtrade/optimize/__init__.py
@@ -74,11 +74,10 @@ def load_tickerdata_file(
             pairdata = json.load(tickerdata)
     else:
         return None
-
+    
     if timerange:
         pairdata = trim_tickerlist(pairdata, timerange)
     return pairdata
-
 
 def load_data(datadir: str,
               ticker_interval: str,

--- a/freqtrade/optimize/__init__.py
+++ b/freqtrade/optimize/__init__.py
@@ -49,7 +49,8 @@ def trim_tickerlist(tickerlist: List[Dict], timerange: Tuple[Tuple, int, int]) -
 def load_tickerdata_file(
         datadir: str, pair: str,
         ticker_interval: str,
-        timerange: Optional[Tuple[Tuple, int, int]] = None) -> Optional[List[Dict]]:
+        timerange: Optional[Tuple[Tuple, int, int]] = None,
+        load_count=1 ) -> Optional[List[Dict]]:
     """
     Load a pair from file,
     :return dict OR empty if unsuccesful
@@ -74,7 +75,35 @@ def load_tickerdata_file(
             pairdata = json.load(tickerdata)
     else:
         return None
-    
+    """
+    Check if timerange is in the pairdata loaded
+    Return None is not, which will then download the file.
+    This is to avoid trim_tickerlist throwing
+    "list index out of range" error else.
+    If we've been around the download loop and still missng a start 
+    or end date, return pair data there is without trimming and log 
+    exchange does not have the range requested
+    """
+    if timerange:
+        stype, start, stop = timerange
+        if stype[0] == 'date':
+            if (pairdata[0][0]) > (start * 1000):
+                if load_count > 1:
+                    logger.info('Start timerange unavailable from exchange')
+                    return pairdata
+                else:
+                    logger.info('Start timerange not in cached data')
+                    return None
+        if stype[1] == 'date':
+            if (pairdata[(len(pairdata) - 1)][0]) < (stop * 1000):
+                logger.info('End timerange not in cached data')
+                if load_count > 1:
+                    logger.info('End timerange for unavailable from exchange')
+                    return pairdata
+                else:
+                    logger.info('End timerange for not in cached data')
+                    return None
+
     if timerange:
         pairdata = trim_tickerlist(pairdata, timerange)
     return pairdata
@@ -98,7 +127,7 @@ def load_data(datadir: str,
         download_pairs(datadir, _pairs, ticker_interval, timerange=timerange)
 
     for pair in _pairs:
-        pairdata = load_tickerdata_file(datadir, pair, ticker_interval, timerange=timerange)
+        pairdata = load_tickerdata_file(datadir, pair, ticker_interval, timerange=timerange, load_count=1)
         if not pairdata:
             # download the tickerdata from exchange
             download_backtesting_testdata(datadir,
@@ -106,7 +135,9 @@ def load_data(datadir: str,
                                           tick_interval=ticker_interval,
                                           timerange=timerange)
             # and retry reading the pair
-            pairdata = load_tickerdata_file(datadir, pair, ticker_interval, timerange=timerange)
+            # TODO if load_tickerdata returns None we're doing nothing with it.
+            # Added load_count argument
+            pairdata = load_tickerdata_file(datadir, pair, ticker_interval, timerange=timerange, load_count=2)
         result[pair] = pairdata
     return result
 


### PR DESCRIPTION
USDT is common on many exchanges and treated as a currency. 
It is helpful to allow USDT to be accepted as a fiat currency when testing config.json
 
By way of example of a usecase
A strategy or otherwise report may not query:  config['stake_currency'] and currency = config['fiat_display_currency'] where USDT is set as fiat_display_currency; 
as the config.json with fail test.
We cannot cleanly create a base/pair such as BTC/USDT which is valid as base pair and present in feqtrade historic ticker data. 

Pulling BTC/USDT from config values can be useful to download query ticker file name and data, enumerating base/pair price to whitelist target pairs, performing correlation coefficient statistics etc.

As example: building a dataframe such as here 
           date       BTC/USDT      ETH/BTC          XLM/BTC        LTC/BTC
0    1517443200       10283.00       0.109475       0.000052       0.016031

The transposing to actual USDT ticker value row-wise per pair
               date  BTC/USDT   ETH/USD   XLM/USD     LTC/USD
1517443200  10283.00   1125.731425  0.535950  164.846773

Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/gcarq/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary
Explain in one sentence the goal of this PR

Solve the issue: #___

## Quick changelog

- <change log #1>
- <change log #2>

## What's new?
*Explain in details what this PR solve or improve. You can include visuals.* 
