### PR TITLE
trim_tickerlist - fix out of range index, download json data

### DIFF
--- a/freqtrade/optimize/__init__.py
+++ b/freqtrade/optimize/__init__.py
@@ -74,6 +74,25 @@ def load_tickerdata_file(
             pairdata = json.load(tickerdata)
     else:
         return None
+    
+    """
+    Check if timerange is in the pairdata loaded
+    Return None is not, which will then download the file.
+    
+    This is to avoid trim_tickerlist throwing
+    "list index out of range" error else.
+    """
+    if timerange:
+        howmany = (len(pairdata) - 1)
+        first_file_timestamp = (pairdata[0][0])
+        last_file_timestamp =  (pairdata[howmany][0])
+        stype, start, stop = timerange
+        if stype[0] == 'date':
+            if first_file_timestamp > (start * 1000):
+                return None
+        if stype[1] == 'date':
+            if last_file_timestamp < (stop * 1000):
+                return None
 
     if timerange:
         pairdata = trim_tickerlist(pairdata, timerange)


### PR DESCRIPTION
trim_tickerlist will throw an index out of range error when parsing an exiting pair data json file for a timerange outside it contents. 

There exists a test to check the file exits, which returns None is not.  
The file will then to be downloaded with the timerange requested.

This change runs after the test to check if the json file exists checking the required range exists within the file.  If not then also returns None, the file is then downloaded with the timerange requested.

Here is an example of the out or range index being hit. 
```
  File "/Users/creslin/PycharmProjects/freqtrade/freqtrade/optimize/__init__.py", line 107, in load_data
    pairdata = load_tickerdata_file(datadir, pair, ticker_interval, timerange=timerange)
  File "/Users/creslin/PycharmProjects/freqtrade/freqtrade/optimize/__init__.py", line 84, in load_tickerdata_file
    pairdata = trim_tickerlist(pairdata, timerange)
  File "/Users/creslin/PycharmProjects/freqtrade/freqtrade/optimize/__init__.py", line 36, in trim_tickerlist
while tickerlist[start_index][0] < start * 1000:
IndexError: list index out of range
```
Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/gcarq/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary
Explain in one sentence the goal of this PR

Solve the issue: #___

## Quick changelog

- <change log #1>
- <change log #2>

## What's new?
*Explain in details what this PR solve or improve. You can include visuals.* 
