### PR TITLE
Enable Backtesting with GDAX and allow trading with EUR/USD

### DIFF
--- a/freqtrade/constants.py
+++ b/freqtrade/constants.py
@@ -31,7 +31,7 @@ CONF_SCHEMA = {
     'properties': {
         'max_open_trades': {'type': 'integer', 'minimum': 0},
         'ticker_interval': {'type': 'string', 'enum': list(TICKER_INTERVAL_MINUTES.keys())},
-        'stake_currency': {'type': 'string', 'enum': ['BTC', 'ETH', 'USDT']},
+        'stake_currency': {'type': 'string', 'enum': ['BTC', 'ETH', 'USDT', 'EUR', 'USD']},
         'stake_amount': {'type': 'number', 'minimum': 0.0005},
         'fiat_display_currency': {'type': 'string', 'enum': ['AUD', 'BRL', 'CAD', 'CHF',
                                                              'CLP', 'CNY', 'CZK', 'DKK',

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -294,6 +294,11 @@ def get_ticker_history(pair: str, tick_interval: str, since_ms: Optional[int] = 
         while not since_ms or since_ms < till_time_ms:
             data_part = _API.fetch_ohlcv(pair, timeframe=tick_interval, since=since_ms)
 
+            # Because some exchange sort Tickers ASC and other DESC.
+            # Ex: Bittrex returns a list of tickers ASC (oldest first, newest last)
+            # when GDAX returns a list of tickers DESC (newest first, oldest last)
+            data_part = sorted(data_part, key=lambda x: x[0])
+
             if not data_part:
                 break
 

--- a/freqtrade/fiat_convert.py
+++ b/freqtrade/fiat_convert.py
@@ -95,8 +95,11 @@ class CryptoToFiatConverter(object):
             coinlistings = self._coinmarketcap.listings()
             self._cryptomap = dict(map(lambda coin: (coin["symbol"], str(coin["id"])),
                                        coinlistings["data"]))
-        except (ValueError, RequestException) as e:
-            logger.error("Could not load FIAT Cryptocurrency map for the following problem: %s", e)
+        except (ValueError, RequestException) as exception:
+            logger.error(
+                "Could not load FIAT Cryptocurrency map for the following problem: %s",
+                exception
+            )
 
     def convert_amount(self, crypto_amount: float, crypto_symbol: str, fiat_symbol: str) -> float:
         """
@@ -188,6 +191,10 @@ class CryptoToFiatConverter(object):
         if not self._is_supported_fiat(fiat=fiat_symbol):
             raise ValueError('The fiat {} is not supported.'.format(fiat_symbol))
 
+        # No need to convert if both crypto and fiat are the same
+        if crypto_symbol == fiat_symbol:
+            return 1.0
+
         if crypto_symbol not in self._cryptomap:
             # return 0 for unsupported stake currencies (fiat-convert should not break the bot)
             logger.warning("unsupported crypto-symbol %s - returning 0.0", crypto_symbol)
@@ -199,6 +206,6 @@ class CryptoToFiatConverter(object):
                     convert=fiat_symbol
                 )['data']['quotes'][fiat_symbol.upper()]['price']
             )
-        except BaseException as ex:
-            logger.error("Error in _find_price: %s", ex)
+        except BaseException as exception:
+            logger.error("Error in _find_price: %s", exception)
             return 0.0

--- a/freqtrade/tests/test_fiat_convert.py
+++ b/freqtrade/tests/test_fiat_convert.py
@@ -133,6 +133,13 @@ def test_fiat_convert_same_currencies(mocker):
     assert fiat_convert.get_price(crypto_symbol='USD', fiat_symbol='USD') == 1.0
 
 
+def test_fiat_convert_two_FIAT(mocker):
+    patch_coinmarketcap(mocker)
+    fiat_convert = CryptoToFiatConverter()
+
+    assert fiat_convert.get_price(crypto_symbol='USD', fiat_symbol='EUR') == 0.0
+
+
 def test_loadcryptomap(mocker):
     patch_coinmarketcap(mocker)
 

--- a/freqtrade/tests/test_fiat_convert.py
+++ b/freqtrade/tests/test_fiat_convert.py
@@ -126,6 +126,13 @@ def test_fiat_convert_get_price(mocker):
     assert fiat_convert._pairs[0]._expiration is not expiration
 
 
+def test_fiat_convert_same_currencies(mocker):
+    patch_coinmarketcap(mocker)
+    fiat_convert = CryptoToFiatConverter()
+
+    assert fiat_convert.get_price(crypto_symbol='USD', fiat_symbol='USD') == 1.0
+
+
 def test_loadcryptomap(mocker):
     patch_coinmarketcap(mocker)
 


### PR DESCRIPTION
## Summary
This PR fix `get_ticker_history()` that does not work with GDAX/Coinbase. 
The issue is the ticker history received from GDAX is ordered DESC when Bittrex/Binance is ordered ASC. Because of that, the get_ticker_history() fall in a very long loop when the tickers are sorted DESC. Means it downloads more ticker than needed and you could get throttle by GDAX.

In addition, this PR allows the usage of EUR and USD as `stake_currency` Means you can try trading with FIAT on an exchange that supports it

## Quick changelog

- Allow using EUR or USD as `stake_currency`. 
- Fix backtesting with GDAX and certainly more exchanges
- First phase to make the bot compatible with GDAX

## What's new?
Provide the ability to backtest with GDAX and even more testing trading with EUR or USD.

## Disclaimer
I have not tested trading on GDAX yet. Only running Backtesting.
