### PR TITLE
Fix wrong hint '--update-pairs-cached' from Backtesting/Hyperopt

### DIFF
--- a/freqtrade/optimize/__init__.py
+++ b/freqtrade/optimize/__init__.py
@@ -103,7 +103,10 @@ def load_data(datadir: str,
         if pairdata:
             result[pair] = pairdata
         else:
-            logger.warn('No data for pair %s, use --update-pairs-cached to download the data', pair)
+            logger.warning(
+                'No data for pair %s, use --refresh-pairs-cached to download the data',
+                pair
+            )
 
     return result
 

--- a/freqtrade/tests/optimize/test_optimize.py
+++ b/freqtrade/tests/optimize/test_optimize.py
@@ -105,7 +105,7 @@ def test_load_data_with_new_pair_1min(ticker_history, mocker, caplog) -> None:
                        refresh_pairs=False,
                        pairs=['MEME/BTC'])
     assert os.path.isfile(file) is False
-    assert log_has('No data for pair MEME/BTC, use --update-pairs-cached to download the data',
+    assert log_has('No data for pair MEME/BTC, use --refresh-pairs-cached to download the data',
                    caplog.record_tuples)
 
     # download a new pair if refresh_pairs is set


### PR DESCRIPTION
## Summary
When backtesting/hyperopt does not have the pair in cache it asks to use `--update-pairs-cached`, but this param does not exist. The right param is `--refresh-pairs-cached`.

## Quick changelog

- Fix the backtesting/hyperopt hint `No data for pair %s, use --update-pairs-cached to download the data` for `No data for pair %s, use --refresh-pairs-cached to download the data`