### PR TITLE
change misleading logging for datadir

### DIFF
--- a/freqtrade/configuration.py
+++ b/freqtrade/configuration.py
@@ -145,7 +145,7 @@ class Configuration(object):
         # If --datadir is used we add it to the configuration
         if 'datadir' in self.args and self.args.datadir:
             config.update({'datadir': self.args.datadir})
-            logger.info('Parameter --datadir detected: %s ...', self.args.datadir)
+            logger.info('Using data folder: %s ...', self.args.datadir)
 
         # If -r/--refresh-pairs-cached is used we add it to the configuration
         if 'refresh_pairs' in self.args and self.args.refresh_pairs:

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -181,7 +181,7 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
     assert 'pair_whitelist' in config['exchange']
     assert 'datadir' in config
     assert log_has(
-        'Parameter --datadir detected: {} ...'.format(config['datadir']),
+        'Using data folder: {} ...'.format(config['datadir']),
         caplog.record_tuples
     )
     assert 'ticker_interval' in config
@@ -229,7 +229,7 @@ def test_setup_configuration_with_arguments(mocker, default_conf, caplog) -> Non
     assert 'pair_whitelist' in config['exchange']
     assert 'datadir' in config
     assert log_has(
-        'Parameter --datadir detected: {} ...'.format(config['datadir']),
+        'Using data folder: {} ...'.format(config['datadir']),
         caplog.record_tuples
     )
     assert 'ticker_interval' in config
@@ -632,7 +632,7 @@ def test_backtest_start_live(default_conf, mocker, caplog):
         'Parameter -l/--live detected ...',
         'Using max_open_trades: 1 ...',
         'Parameter --timerange detected: -100 ..',
-        'Parameter --datadir detected: freqtrade/tests/testdata ...',
+        'Using data folder: freqtrade/tests/testdata ...',
         'Using stake_currency: BTC ...',
         'Using stake_amount: 0.001 ...',
         'Downloading data for all pairs in whitelist ...',

--- a/freqtrade/tests/test_configuration.py
+++ b/freqtrade/tests/test_configuration.py
@@ -235,7 +235,7 @@ def test_setup_configuration_without_arguments(mocker, default_conf, caplog) -> 
     assert 'pair_whitelist' in config['exchange']
     assert 'datadir' in config
     assert log_has(
-        'Parameter --datadir detected: {} ...'.format(config['datadir']),
+        'Using data folder: {} ...'.format(config['datadir']),
         caplog.record_tuples
     )
     assert 'ticker_interval' in config
@@ -286,7 +286,7 @@ def test_setup_configuration_with_arguments(mocker, default_conf, caplog) -> Non
     assert 'pair_whitelist' in config['exchange']
     assert 'datadir' in config
     assert log_has(
-        'Parameter --datadir detected: {} ...'.format(config['datadir']),
+        'Using data folder: {} ...'.format(config['datadir']),
         caplog.record_tuples
     )
     assert 'ticker_interval' in config


### PR DESCRIPTION
Because datadir has a default value, bot will always print:

`Parameter --datadir detected: freqtrade/tests/testdata`

which is misleading. Instead we would now print:

`Using data folder: freqtrade/tests/testdata`