### PR TITLE
Timerange unixtime argument

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -83,6 +83,8 @@ The full timerange specification:
 - Use tickframes till 2018/01/31: `--timerange=-20180131`
 - Use tickframes since 2018/01/31: `--timerange=20180131-`
 - Use tickframes since 2018/01/31 till 2018/03/01 : `--timerange=20180131-20180301`
+- Use tickframes between POSIX timestamps 1527595200 1527618600:
+                                                `--timerange=1527595200-1527618600`
 
 
 **Update testdata directory**

--- a/freqtrade/arguments.py
+++ b/freqtrade/arguments.py
@@ -222,6 +222,9 @@ class Arguments(object):
         syntax = [(r'^-(\d{8})$', (None, 'date')),
                   (r'^(\d{8})-$', ('date', None)),
                   (r'^(\d{8})-(\d{8})$', ('date', 'date')),
+                  (r'^-(\d{10})$', (None, 'timestamp')),
+                  (r'^(\d{10})-$', ('timestamp', None)),
+                  (r'^(\d{10})-(\d{10})$', ('timestamp', 'timestamp')),
                   (r'^(-\d+)$', (None, 'line')),
                   (r'^(\d+)-$', ('line', None)),
                   (r'^(\d+)-(\d+)$', ('index', 'index'))]
@@ -237,6 +240,8 @@ class Arguments(object):
                     start = rvals[index]
                     if stype[0] == 'date':
                         start = arrow.get(start, 'YYYYMMDD').timestamp
+                    elif stype[0] == 'timestamp':
+                        start = arrow.get(start).timestamp
                     else:
                         start = int(start)
                     index += 1
@@ -244,6 +249,8 @@ class Arguments(object):
                     stop = rvals[index]
                     if stype[1] == 'date':
                         stop = arrow.get(stop, 'YYYYMMDD').timestamp
+                    elif stype[1] == 'timestamp':
+                        stop = arrow.get(stop).timestamp
                     else:
                         stop = int(stop)
                 return stype, start, stop


### PR DESCRIPTION
This PR extends arguments.py for --timerrange to accept POSIX timetamps as arguments. 
This allows finer grained time-periods for backtesting or other calls. 

This is useful if wanting to test against a bear/bull period that does not fit well within whole days. 

output from execution below showing yymmdd and timestamp both working.
```

/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/bin/python3.6 /Users/creslin/PycharmProjects/freqtrade/scripts/report_correlation.py --timerange=20180528-20180529
2018-06-02 18:44:58,829 - freqtrade.configuration - INFO - Log level set to INFO
2018-06-02 18:44:58,830 - freqtrade.configuration - INFO - Using max_open_trades: 200 ...
2018-06-02 18:44:58,831 - freqtrade.configuration - INFO - Parameter --timerange detected: 20180528-20180529 ...
2018-06-02 18:44:58,831 - freqtrade.configuration - INFO - Parameter --datadir detected: freqtrade/tests/testdata ...
   BasePair      Pair  Correlation  BTC % Change  Pair % USD Ch  Pair % BTC Ch  Gain % on BTC        Start         Stop  BTC Volume
1  BTC_USDT   ETC_USD        0.965        -2.942         -4.070         -1.163      -1.128585  05-28 00:00  05-29 00:00      335.19
0  BTC_USDT   SNT_USD        0.943        -2.942         -5.857         -3.004      -2.915585  05-28 00:00  05-29 00:00      496.01
3  BTC_USDT  DASH_USD        0.902        -2.942         -9.034         -6.277      -6.092432  05-28 00:00  05-29 00:00      751.41
2  BTC_USDT   MTH_USD        0.954        -2.942         -9.290         -6.541      -6.348708  05-28 00:00  05-29 00:00       23.00
4  BTC_USDT   TRX_USD        0.951        -2.942        -13.647        -11.029     -10.704957  05-28 00:00  05-29 00:00    14544.57

```
```

/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/bin/python3.6 /Users/creslin/PycharmProjects/freqtrade/scripts/report_correlation.py --timerange=1527595200-1527618600
2018-06-02 18:47:40,382 - freqtrade.configuration - INFO - Log level set to INFO
2018-06-02 18:47:40,382 - freqtrade.configuration - INFO - Using max_open_trades: 200 ...
2018-06-02 18:47:40,383 - freqtrade.configuration - INFO - Parameter --timerange detected: 1527595200-1527618600 ...
2018-06-02 18:47:40,383 - freqtrade.configuration - INFO - Parameter --datadir detected: freqtrade/tests/testdata ...
   BasePair      Pair  Correlation  BTC % Change  Pair % USD Ch  Pair % BTC Ch  Gain % on BTC        Start         Stop  BTC Volume
0  BTC_USDT   SNT_USD        0.680           NaN            NaN            NaN            NaN  05-29 12:00  05-29 18:30    68866.30
1  BTC_USDT   ETC_USD        0.857           NaN            NaN            NaN            NaN  05-29 12:00  05-29 18:30   227514.17
2  BTC_USDT   MTH_USD        0.790           NaN            NaN            NaN            NaN  05-29 12:00  05-29 18:30    12103.96
3  BTC_USDT  DASH_USD        0.862           NaN            NaN            NaN            NaN  05-29 12:00  05-29 18:30    72982.78
4  BTC_USDT   TRX_USD        0.178           NaN            NaN            NaN            NaN  05-29 12:00  05-29 18:30  1258316.95


```Process finished with exit code 0

Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/gcarq/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary
Explain in one sentence the goal of this PR

Solve the issue: #___

## Quick changelog

- <change log #1>
- <change log #2>

## What's new?
*Explain in details what this PR solve or improve. You can include visuals.* 
