### PR TITLE
Make backtesting report markdown shareable (resubmit)

### DIFF
--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -106,7 +106,7 @@ class Backtesting(object):
             len(results[results.profit_BTC > 0]),
             len(results[results.profit_BTC < 0])
         ])
-        return tabulate(tabular_data, headers=headers, floatfmt=floatfmt)
+        return tabulate(tabular_data, headers=headers, floatfmt=floatfmt, tablefmt="pipe")
 
     def _get_sell_trade_entry(
             self, pair: str, buy_row: DataFrame,

--- a/freqtrade/tests/optimize/test_backtesting.py
+++ b/freqtrade/tests/optimize/test_backtesting.py
@@ -374,16 +374,15 @@ def test_generate_text_table(default_conf, mocker):
     )
 
     result_str = (
-        'pair       buy count    avg profit %    '
-        'total profit BTC    avg duration    profit    loss\n'
-        '-------  -----------  --------------  '
-        '------------------  --------------  --------  ------\n'
-        'ETH/BTC            2           15.00          '
-        '0.60000000            20.0         2       0\n'
-        'TOTAL              2           15.00          '
-        '0.60000000            20.0         2       0'
+        '| pair    |   buy count |   avg profit % |   '
+        'total profit BTC |   avg duration |   profit |   loss |\n'
+        '|:--------|------------:|---------------:|'
+        '-------------------:|---------------:|---------:|-------:|\n'
+        '| ETH/BTC |           2 |          15.00 |         '
+        '0.60000000 |           20.0 |        2 |      0 |\n'
+        '| TOTAL   |           2 |          15.00 |         '
+        '0.60000000 |           20.0 |        2 |      0 |'
     )
-
     assert backtesting._generate_text_table(data={'ETH/BTC': {}}, results=results) == result_str
 
 


### PR DESCRIPTION
Fix test of: #706
the initial PR #706 looked good to me - however the source-repo has been deleted so pushing a fix for the Test is not possible anymore.

Full credit for this PR needs to go to @rymdluo.

## Summary
Small options tweak to make the backtesting report markdown ready and much easier to share reports on many markdown publishing tools and editors that already support Markdown Extra with just a copy and paste.

## What's new?
Example:
![Example](https://i.imgur.com/HXlNkfm.png)