### PR TITLE
Fix the in-progress dot that does not show up during a Hyperopt run

### DIFF
--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -455,6 +455,7 @@ class Hyperopt(Backtesting):
 
         if trade_count == 0 or trade_duration > self.max_accepted_trade_duration:
             print('.', end='')
+            sys.stdout.flush()
             return {
                 'status': STATUS_FAIL,
                 'loss': float('inf')


### PR DESCRIPTION
## Summary
This very simple PR fixing the in-progress '.' that is not displayed during a Hyperopt. The fault to my refactoring, when I forgot a `sys.stdout.flush()`.

No behavior change, only provide a better user experience during Hyperopt.

## Quick changelog

- In-progress '.' used during Hyperopt are now displayed all the time.