### PR TITLE
Fix stake_currency returned by Hyperopt  …

### DIFF
--- a/freqtrade/optimize/__init__.py
+++ b/freqtrade/optimize/__init__.py
@@ -104,8 +104,10 @@ def load_data(datadir: str,
             result[pair] = pairdata
         else:
             logger.warning(
-                'No data for pair %s, use --refresh-pairs-cached to download the data',
-                pair
+                'No data for pair: "%s", Interval: %s. '
+                'Use --refresh-pairs-cached to download the data',
+                pair,
+                ticker_interval
             )
 
     return result

--- a/freqtrade/optimize/hyperopt.py
+++ b/freqtrade/optimize/hyperopt.py
@@ -479,16 +479,16 @@ class Hyperopt(Backtesting):
             'result': result_explanation,
         }
 
-    @staticmethod
-    def format_results(results: DataFrame) -> str:
+    def format_results(self, results: DataFrame) -> str:
         """
         Return the format result in a string
         """
         return ('{:6d} trades. Avg profit {: 5.2f}%. '
-                'Total profit {: 11.8f} BTC ({:.4f}Σ%). Avg duration {:5.1f} mins.').format(
+                'Total profit {: 11.8f} {} ({:.4f}Σ%). Avg duration {:5.1f} mins.').format(
                     len(results.index),
                     results.profit_percent.mean() * 100.0,
                     results.profit_BTC.sum(),
+                    self.config['stake_currency'],
                     results.profit_percent.sum(),
                     results.duration.mean(),
                 )

--- a/freqtrade/tests/optimize/test_hyperopt.py
+++ b/freqtrade/tests/optimize/test_hyperopt.py
@@ -389,10 +389,12 @@ def test_start_uses_mongotrials(mocker, init_hyperopt, default_conf) -> None:
 # test buy_strategy_generator def populate_buy_trend
 # test optimizer if 'ro_t1' in params
 
-def test_format_results():
+def test_format_results(init_hyperopt):
     """
     Test Hyperopt.format_results()
     """
+
+    # Test with BTC as stake_currency
     trades = [
         ('ETH/BTC', 2, 2, 123),
         ('LTC/BTC', 1, 1, 123),
@@ -400,8 +402,21 @@ def test_format_results():
     ]
     labels = ['currency', 'profit_percent', 'profit_BTC', 'duration']
     df = pd.DataFrame.from_records(trades, columns=labels)
-    x = Hyperopt.format_results(df)
-    assert x.find(' 66.67%')
+
+    result = _HYPEROPT.format_results(df)
+    assert result.find(' 66.67%')
+    assert result.find('Total profit 1.00000000 BTC')
+    assert result.find('2.0000Σ %')
+
+    # Test with EUR as stake_currency
+    trades = [
+        ('ETH/EUR', 2, 2, 123),
+        ('LTC/EUR', 1, 1, 123),
+        ('XPR/EUR', -1, -2, -246)
+    ]
+    df = pd.DataFrame.from_records(trades, columns=labels)
+    result = _HYPEROPT.format_results(df)
+    assert result.find('Total profit 1.00000000 EUR')
 
 
 def test_signal_handler(mocker, init_hyperopt):

--- a/freqtrade/tests/optimize/test_optimize.py
+++ b/freqtrade/tests/optimize/test_optimize.py
@@ -105,7 +105,8 @@ def test_load_data_with_new_pair_1min(ticker_history, mocker, caplog) -> None:
                        refresh_pairs=False,
                        pairs=['MEME/BTC'])
     assert os.path.isfile(file) is False
-    assert log_has('No data for pair MEME/BTC, use --refresh-pairs-cached to download the data',
+    assert log_has('No data for pair: "MEME/BTC", Interval: 1m. '
+                   'Use --refresh-pairs-cached to download the data',
                    caplog.record_tuples)
 
     # download a new pair if refresh_pairs is set


### PR DESCRIPTION
## Summary
2 fixes in the PR:
1. Remove the hardcoded BTC stake_currency.
2. Improve the backtesting error message "No data for pair..."

### 1. Remove the hardcoded BTC stake_currency
Hyperopt has "BTC" hardcoded in the result. This PR will fix it and display the real stake_currency used.

If you used `"stake_currency": "USDT",` in your config file.
Before this PR you saw a message like:
`"2 trades. Avg profit  0.13%. Total profit  0.00002651 BTC (0.0027Σ%). Avg duration 142.5 mins."`

Now with the commit, we fix the wrong BTC currency:
`"2 trades. Avg profit  0.13%. Total profit  0.00002651 USDT (0.0027Σ%). Avg duration 142.5 mins."`

###  2. Improve the backtesting error message "No data for pair..."
The Backtesting message `"No data for pair ETH/USDT, use --refresh-pairs-cached to download the data"` is not clear what interval data is missing.

This PR improve the message:
`"No data for pair: "ETH/USDT", Interval: 5m. Use --refresh-pairs-cached to download the data"`

## Quick changelog

- Fix Hyperopt stake_currency displayed
- Complete the unit test `test_format_results` 
- Improve the backtesting "No data for pair" message 
