### PR TITLE
Add __main__.py to improve how to launch the bot

### DIFF
--- a/freqtrade/__main__.py
+++ b/freqtrade/__main__.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""
+__main__.py for Freqtrade
+To launch Freqtrade as a module
+
+> python -m freqtrade (with Python >= 3.6)
+"""
+
+import sys
+from freqtrade import main
+
+
+if __name__ == '__main__':
+    main.set_loggers()
+    main.main(sys.argv[1:])


### PR DESCRIPTION
## Summary
If you have tried to launch the bot from a command like `python3 freqtrade`, you certainly saw the message `can't find '__main__' module in 'freqtrade'`.

This PR fix this issue.
With this PR you can start the bot from `python3 freqtrade`. It behave like an alias to `python3 freqtrade/main.py`.

## Help

|  Command | Alias |
|----------|---------|
| `python3 freqtrade/main.py` | `python3 freqtrade` |
| `python3 freqtrade/main.py --help` | `python3 freqtrade --help` | 
| `python3 freqtrade/main.py backtesting` | `python3 freqtrade backtesting` | 
| `python3 freqtrade/main.py backtesting --help` | `python3 freqtrade backtesting --help` | 
| `python3 freqtrade/main.py hyperopt` | `python3 freqtrade hyperopt` | 
| `python3 freqtrade/main.py hyperopt --help` | `python3 freqtrade hyperopt --help` | 

## Quick changelog

- Add `__main__.py` file that calls `main.py`
